### PR TITLE
enhance external part of ffi a bit

### DIFF
--- a/jscomp/lib/bench.ml
+++ b/jscomp/lib/bench.ml
@@ -32,8 +32,8 @@ class type suites =
     method run : unit -> unit 
   end
 
-external js_new_suites : unit ->  suites = "" 
-    [@@js.new "Suite"] [@@js.module "benchmark" "Bench"] [@@js.scope "Bench"]
+external js_new_suites : unit ->  suites = "Suite" 
+    [@@js.new ] [@@js.module "benchmark" "Bench"] [@@js.scope "Bench"]
 
 let suite = js_new_suites ()
 

--- a/jscomp/lib/js.ml
+++ b/jscomp/lib/js.ml
@@ -40,7 +40,7 @@ external to_opt : 'a -> 'a opt  = "%identity"
 
 external is_nil : 'a opt -> bool = "js_is_nil"
 
-external nil : 'a opt = "js_null" [@@js.global]
+external nil : 'a opt = "null" [@@js.global]
 
 (* Note [to_opt null] will be [null : 'a opt opt]*)
 
@@ -49,13 +49,13 @@ type + 'a def
 external from_def : 'a def -> 'a option = "js_from_def"
 external to_def : 'a -> 'a def = "%identity"
 external is_undef : 'a def -> bool =  "js_is_undef"
-external undef : 'a def = "js_undefined" [@@js.global]
+external undef : 'a def = "undefined" [@@js.global]
 
 type boolean 
 
 (* let true_ : boolean = unsafe_js_expr "true" *)
-external true_ : boolean = "js_true" [@@js.global]
+external true_ : boolean = "true" [@@js.global]
 
-external false_ : boolean = "js_false" [@@js.global]
+external false_ : boolean = "false" [@@js.global]
 
 external to_bool : boolean -> bool = "js_boolean_to_bool" 

--- a/jscomp/lib/js.mli
+++ b/jscomp/lib/js.mli
@@ -44,14 +44,14 @@ external from_opt : 'a opt -> 'a option = "js_from_nullable"
 
 external to_opt : 'a  -> 'a opt = "%identity"
 
-external nil : 'a opt = "js_null" [@@js.global]
+external nil : 'a opt = "null" [@@js.global]
 
 
 type + 'a def
 external from_def : 'a def -> 'a option = "js_from_def"
 external to_def : 'a -> 'a def = "%identity"
 external is_undef : 'a def -> bool =  "js_is_undef"
-external undef : 'a def = "js_undefined" [@@js.global]
+external undef : 'a def = "undefined" [@@js.global]
 
 
 external unsafe_js_expr : string -> 'a = "js_pure_expr"
@@ -62,6 +62,6 @@ external is_nil : 'a opt -> bool = "js_is_nil"
 
 type boolean 
 
-external true_ : boolean = "js_true" [@@js.global]
-external false_ : boolean = "js_false" [@@js.global]
+external true_ : boolean = "true" [@@js.global]
+external false_ : boolean = "false" [@@js.global]
 external to_bool : boolean -> bool = "js_boolean_to_bool" 

--- a/jscomp/lib/js_date.ml
+++ b/jscomp/lib/js_date.ml
@@ -131,10 +131,10 @@ external parse : string -> number = ""
 external now : unit -> number = ""
   [@@js.call "Date.now"]
 
-external current : unit -> t = ""
-  [@@js.new "Date"] [@@js.nullary]
-external of_string : string -> t = ""
-  [@@js.new "Date"]
+external current : unit -> t = "Date"
+  [@@js.new ] [@@js.nullary]
+external of_string : string -> t = "Date"
+  [@@js.new ]
 
 
 
@@ -176,38 +176,38 @@ external utc_of_y_m_d_h_m_s_m :
   [@@js.call "Date.UTC"]
 
 
-external of_y_m:   year:number -> month:number -> unit -> t = ""
-  [@@js.new "Date"]
+external of_y_m:   year:number -> month:number -> unit -> t = "Date"
+  [@@js.new ]
 
-external of_y_m_d:  year:number -> month:number -> day:number ->   unit -> t = ""
-  [@@js.new "Date"]
+external of_y_m_d:  year:number -> month:number -> day:number ->   unit -> t = "Date"
+  [@@js.new ]
 
 external of_y_m_d_h:  
   year:number -> month:number -> 
   day:number -> hour:number ->
-  unit -> t = ""
-  [@@js.new "Date"]
+  unit -> t = "Date"
+  [@@js.new ]
 
 external of_y_m_d_h_m :
   year:number -> month:number -> 
   day:number -> hour:number ->
   minute:number -> 
-  unit -> t = ""
-  [@@js.new "Date"]
+  unit -> t = "Date"
+  [@@js.new ]
 
 external of_y_m_d_h_m_s :
   year:number -> month:number -> 
   day:number -> hour:number ->
   minute:number -> second:number -> 
-  unit -> t = ""
-  [@@js.new "Date"]
+  unit -> t = "Date"
+  [@@js.new ]
 
 external of_y_m_d_h_m_s_m:
   year:number -> month:number -> 
   day:number -> hour:number  -> 
   minute:number  -> second:number  ->
-  millisecond:number -> unit -> t = ""
-  [@@js.new "Date"]
+  millisecond:number -> unit -> t = "Date"
+  [@@js.new ]
 
 
 

--- a/jscomp/runtime/caml_float.ml
+++ b/jscomp/runtime/caml_float.ml
@@ -36,11 +36,11 @@ function $$caml_int64_float_of_bits (x) {
 }
 |}]
 
-external caml_int64_float_of_bits : Int64.t -> float = ""
-[@@js.call "$$caml_int64_float_of_bits"] [@@js.local]
+external caml_int64_float_of_bits : Int64.t -> float = "$$caml_int64_float_of_bits"
+[@@js.call ] [@@js.local]
 
-external caml_int64_bits_of_float : float -> Int64.t =  ""
-[@@js.call "$$caml_int64_bits_of_float"] [@@js.call]
+external caml_int64_bits_of_float : float -> Int64.t =  "$$caml_int64_bits_of_float"
+[@@js.call ] [@@js.local]
 
 external is_finite : float -> bool = ""
 [@@js.call "isFinite"]
@@ -59,8 +59,8 @@ let caml_classify_float x : fpclass  =
     FP_nan 
   else FP_infinite
 
-external nan : float = " "  
-[@@js.global "NaN" ] 
+external nan : float = "NaN"
+[@@js.global ] 
 
 let caml_modf_float (x : float) : float * float = 
   if is_finite x then 

--- a/jscomp/runtime/caml_io.ml
+++ b/jscomp/runtime/caml_io.ml
@@ -19,7 +19,7 @@
 (* Author: Hongbo Zhang  *)
 
 type 'a def
-external undef : 'a def = "js_undefined" [@@js.global]
+external undef : 'a def = "undefined" [@@js.global]
 
 let stdin = undef
 let stdout = undef 

--- a/jscomp/test/.depend
+++ b/jscomp/test/.depend
@@ -106,6 +106,8 @@ ext_string.cmo : ../stdlib/string.cmi ext_bytes.cmo ../stdlib/bytes.cmi
 ext_string.cmx : ../stdlib/string.cmx ext_bytes.cmx ../stdlib/bytes.cmx
 extensible_variant_test.cmo : mt.cmi
 extensible_variant_test.cmx : mt.cmx
+ffi_test.cmo : ../lib/js.cmi
+ffi_test.cmx : ../lib/js.cmx
 fib.cmo :
 fib.cmx :
 float_of_bits_test.cmo : mt.cmi ../stdlib/int64.cmi
@@ -548,6 +550,8 @@ ext_string.cmo : ../stdlib/string.cmi ext_bytes.cmo ../stdlib/bytes.cmi
 ext_string.cmj : ../stdlib/string.cmj ext_bytes.cmj ../stdlib/bytes.cmj
 extensible_variant_test.cmo : mt.cmi
 extensible_variant_test.cmj : mt.cmj
+ffi_test.cmo : ../lib/js.cmi
+ffi_test.cmj : ../lib/js.cmj
 fib.cmo :
 fib.cmj :
 float_of_bits_test.cmo : mt.cmi ../stdlib/int64.cmi

--- a/jscomp/test/ffi_test.d.ts
+++ b/jscomp/test/ffi_test.d.ts
@@ -1,0 +1,8 @@
+export var u: any ;
+export var v: any ;
+export var a: any ;
+export var b: any ;
+export var c: any ;
+export var d: any ;
+export var Textarea: any ;
+

--- a/jscomp/test/ffi_test.js
+++ b/jscomp/test/ffi_test.js
@@ -1,0 +1,30 @@
+// Generated CODE, PLEASE EDIT WITH CARE
+'use strict';
+
+
+var u = xx(3);
+
+var v = null;
+
+var match_000 = true;
+
+var match_001 = false;
+
+var Textarea = [];
+
+var a = match_000;
+
+var b = match_001;
+
+var c = null;
+
+var d = undefined;
+
+exports.u        = u;
+exports.v        = v;
+exports.a        = a;
+exports.b        = b;
+exports.c        = c;
+exports.d        = d;
+exports.Textarea = Textarea;
+/* u Not a pure module */

--- a/jscomp/test/ffi_test.ml
+++ b/jscomp/test/ffi_test.ml
@@ -1,0 +1,23 @@
+
+
+external f : int -> int = "xx" [@@js.call ]
+
+
+let u = f 3 
+let v = Js.nil
+
+let a, b ,c, d = Js.(true_, false_, nil, undef)
+
+module Textarea = struct
+  type t
+  external create : unit -> t  = "TextArea" [@@ js.new ]
+  (* TODO: *)
+  (* external set_minHeight : t -> int -> unit = "minHeight" [@@js.set ]     *)
+  (* external get_minHeight : t ->  int = "minHeight" [@@js.get] *)
+
+end
+
+(* let v = *)
+(*   let u = Textarea.create () in  *)
+(*    Textarea.set_minHeight u 3 ; *)
+(*    Textarea.get_minHeight u  *)

--- a/jscomp/test/test.mllib
+++ b/jscomp/test/test.mllib
@@ -195,3 +195,4 @@ bigarray_test
 float_of_bits_test
 swap_test
 int64_mul_div_test
+ffi_test

--- a/jscomp/test/test_react.ml
+++ b/jscomp/test/test_react.ml
@@ -7,13 +7,13 @@ class type doc =
   object
     method getElementById : string -> html_element
   end
-external doc :  doc = "doc" [@@js.global "doc"]
+external doc :  doc = "doc" [@@js.global ]
 
 class type console = 
     object 
         method log : 'a -> unit
     end
-external console : console  = "console" [@@js.global "console"]
+external console : console  = "console" [@@js.global ]
 
 let v = console#log "hey";;
 let u = console
@@ -22,8 +22,8 @@ external log : 'a -> unit = "" [@@js.call "console.log"]
 let v = log 32
 type t 
 type element
-external document : unit -> t = "" [@@js.global "document"] [@@js.scope "window"]
-external getElementById : t -> string -> element = "" [@@js.send "getElementById"]        
+external document :  t = "document" [@@js.global ] [@@js.scope "window"]
+external getElementById : t -> string -> element = "getElementById" [@@js.send ]        
 
 
 type config 
@@ -78,7 +78,7 @@ render (
                 h3 [| str "type safe!" |];
               |]
                )
-        ()))) (getElementById (document ()) "hi")
+        ()))) (getElementById document  "hi")
   
     
 


### PR DESCRIPTION
so we can write both
```ocaml
external ff : int -> int = "a" [@@js.call]
external ff : int -> int = "" [@@js.call "a"]
```
Note that names in `js.call` has a higher priority

TODO: finish `js.set` and `js.get`