### PR TITLE
Debugger support

### DIFF
--- a/jscomp/j.ml
+++ b/jscomp/j.ml
@@ -326,7 +326,7 @@ and statement_desc =
   | String_switch of expression * string case_clause list * block option 
   | Throw of expression
   | Try of block * (exception_ident * block) option * block option
-
+  | Debugger
 and return_expression = {
  (* since in ocaml, it's expression oriented langauge, [return] in
     general has no jumps, it only happens when we do 

--- a/jscomp/js_dump.ml
+++ b/jscomp/js_dump.ml
@@ -1285,7 +1285,13 @@ and statement_desc top cxt f (s : J.statement_desc) : Ext_pp_scope.t =
     semi f;
     P.newline f;
     cxt
-
+  | Debugger
+    -> 
+    P.newline f ;
+    P.string f "debugger";
+    semi f ;
+    P.newline f;
+    cxt 
   | Break
     ->
     P.string f "break ";

--- a/jscomp/js_fold.ml
+++ b/jscomp/js_fold.ml
@@ -310,6 +310,7 @@ class virtual fold =
                  let o = o#exception_ident _x in let o = o#block _x_i1 in o)
               _x_i1 in
           let o = o#option (fun o -> o#block) _x_i2 in o
+      | Debugger -> o
     method statement : statement -> 'self_type =
       fun { statement_desc = _x; comment = _x_i1 } ->
         let o = o#statement_desc _x in

--- a/jscomp/js_map.ml
+++ b/jscomp/js_map.ml
@@ -327,6 +327,7 @@ class virtual map =
               _x_i1 in
           let _x_i2 = o#option (fun o -> o#block) _x_i2
           in Try (_x, _x_i1, _x_i2)
+      | Debugger -> Debugger
     method statement : statement -> statement =
       fun { statement_desc = _x; comment = _x_i1 } ->
         let _x = o#statement_desc _x in

--- a/jscomp/js_stmt_make.ml
+++ b/jscomp/js_stmt_make.ml
@@ -350,3 +350,7 @@ let continue  ?comment   ?(label="") unit  : t =
     comment;
   }
 
+let debugger : t = 
+  { statement_desc = J.Debugger ; 
+    comment = None 
+  }

--- a/jscomp/js_stmt_make.mli
+++ b/jscomp/js_stmt_make.mli
@@ -97,3 +97,4 @@ val break : ?comment:string  -> unit -> t
 (** if [label] is not set, it will default to empty *)  
 val continue : ?comment:string  -> ?label:J.label -> unit  -> t
 
+val debugger :  t

--- a/jscomp/lam_compile.ml
+++ b/jscomp/lam_compile.ml
@@ -675,7 +675,8 @@ and
           Js_output.handle_block_return st should_return lam args_code exp
       end
 
- 
+    | Lprim (Pccall{prim_name = "js_debugger"; _}, []) 
+      ->  Js_output.handle_block_return st should_return lam  [S.debugger] E.unit 
     | Lprim (prim, args_lambda)  ->
       begin
         let args_block, args_expr =

--- a/jscomp/lam_compile.ml
+++ b/jscomp/lam_compile.ml
@@ -675,8 +675,13 @@ and
           Js_output.handle_block_return st should_return lam args_code exp
       end
 
-    | Lprim (Pccall{prim_name = "js_debugger"; _}, []) 
-      ->  Js_output.handle_block_return st should_return lam  [S.debugger] E.unit 
+    | Lprim (Pccall{prim_name = "js_debugger"; _}, 
+             _) 
+      -> 
+      (* [%js.debugger] guarantees that the expression does not matter 
+         TODO: make it even safer
+         *)
+      Js_output.handle_block_return st should_return lam  [S.debugger] E.unit 
     | Lprim (prim, args_lambda)  ->
       begin
         let args_block, args_expr =

--- a/jscomp/lam_compile_group.ml
+++ b/jscomp/lam_compile_group.ml
@@ -387,7 +387,7 @@ let lambda_as_module
     (lam : Lambda.lambda) = 
   begin 
     Lam_current_unit.set_file filename ;  
-    Lam_current_unit.set_debug_file "shift_test.ml";
+    Lam_current_unit.iset_debug_file "shift_test.ml";
     Ext_pervasives.with_file_as_chan 
       (Ext_filename.chop_extension ~loc:__LOC__ filename ^  ".js")
       (fun chan -> Js_dump.dump_deps_program (compile ~filename false env sigs lam) chan)

--- a/jscomp/test/.depend
+++ b/jscomp/test/.depend
@@ -80,6 +80,8 @@ cps_test.cmo : mt.cmi ../stdlib/array.cmi
 cps_test.cmx : mt.cmx ../stdlib/array.cmx
 cross_module_inline_test.cmo :
 cross_module_inline_test.cmx :
+debugger_test.cmo : ../lib/js.cmi
+debugger_test.cmx : ../lib/js.cmx
 demo.cmo :
 demo.cmx :
 demo_page.cmo :
@@ -526,6 +528,8 @@ cps_test.cmo : mt.cmi ../stdlib/array.cmi
 cps_test.cmj : mt.cmj ../stdlib/array.cmj
 cross_module_inline_test.cmo :
 cross_module_inline_test.cmj :
+debugger_test.cmo : ../lib/js.cmi
+debugger_test.cmj : ../lib/js.cmj
 demo.cmo :
 demo.cmj :
 demo_page.cmo :

--- a/jscomp/test/debugger_test.d.ts
+++ b/jscomp/test/debugger_test.d.ts
@@ -1,0 +1,3 @@
+export var f: (x : any, y : any) => any ;
+export var g: (param : any) => any ;
+

--- a/jscomp/test/debugger_test.js
+++ b/jscomp/test/debugger_test.js
@@ -1,0 +1,23 @@
+// Generated CODE, PLEASE EDIT WITH CARE
+'use strict';
+
+
+function f(x, y) {
+  console.log(/* tuple */[
+        x,
+        y
+      ]);
+  return x + y;
+}
+
+function g() {
+  f(1, 2);
+  debugger;
+  f(1, 2);
+  debugger;
+  return 3;
+}
+
+exports.f = f;
+exports.g = g;
+/* No side effect */

--- a/jscomp/test/debugger_test.ml
+++ b/jscomp/test/debugger_test.ml
@@ -1,0 +1,10 @@
+
+let f x y =
+  Js.log (x,y);
+  x + y 
+let g () =
+  ignore @@ f 1 2; 
+  let () = [%js.debug ] in 
+  ignore @@ f 1 2; 
+  [%js.debug];
+  3

--- a/jscomp/test/test.mllib
+++ b/jscomp/test/test.mllib
@@ -197,3 +197,4 @@ swap_test
 int64_mul_div_test
 ffi_test
 shift_test
+debugger_test


### PR DESCRIPTION
Example:

```ocaml
let f x y =
  Js.log (x,y);
  x + y
let g () =
  ignore @@ f 1 2;
  let () = [%js.debug ] in
  ignore @@ f 1 2;
  [%js.debug];
  3
```


```js
let f x y =
  Js.log (x,y);
  x + y
let g () =
  ignore @@ f 1 2;
  let () = [%js.debug ] in
  ignore @@ f 1 2;
  [%js.debug];
  3

```