### PR TITLE
Add contribution process guidelines and DCO

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,26 @@
+# How to contribute
+
+If you'd like to help us improve and extend BuckleScript, then we welcome your
+contributions!
+
+Below you will find some basic steps required to be able to contribute to the project. If
+you have any questions about this process or any other aspect of contributing to a Bloomberg open
+source project, feel free to send an email to open-tech@bloomberg.net and we'll get your questions
+answered as quickly as we can.
+
+
+## Contribution Licensing
+
+Since BuckleScript is distributed under the terms of the [LGPL Version 3](LICENSE), contributions that you make
+are licensed under the same terms. In order for us to be able to accept your contributions,
+we will need explicit confirmation from you that you are able and willing to provide them under
+these terms, and the mechanism we use to do this is called a Developer's Certificate of Origin
+[DCO](DCO.md).  This is very similar to the process used by the Linux(R) kernel, Samba, and many
+other major open source projects.
+
+To participate under these terms, all that you must do is include a line like the following as the
+last line of the commit message for each commit in your contribution:
+
+    Signed-Off-By: Random J. Developer <random@developer.example.org>
+
+You must use your real name (sorry, no pseudonyms, and no anonymous contributions).

--- a/DCO.md
+++ b/DCO.md
@@ -1,0 +1,25 @@
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+1. The contribution was created in whole or in part by me and I
+   have the right to submit it under the open source license
+   indicated in the file; or
+
+2. The contribution is based upon previous work that, to the best
+   of my knowledge, is covered under an appropriate open source
+   license and I have the right under that license to submit that
+   work with modifications, whether created in whole or in part
+   by me, under the same open source license (unless I am
+   permitted to submit under a different license), as indicated
+   in the file; or
+
+3. The contribution was provided directly to me by some other
+   person who certified (1), (2) or (3) and I have not modified
+   it.
+
+4. I understand and agree that this project and the contribution
+   are public and that a record of the contribution (including all
+   personal information I submit with it, including my sign-off) is
+   maintained indefinitely and may be redistributed consistent with
+   this project or the open source license(s) involved.


### PR DESCRIPTION
There is a slight inconsistency here as the LICENSE file still contains a copy of GPLv2, but I don't want to change that in this commit. That will get fixed next week when the licensing cleanup is completed.