### PR TITLE
allow more flexible type annotation in `js.raw`

### DIFF
--- a/jscomp/build.sh
+++ b/jscomp/build.sh
@@ -51,6 +51,6 @@ ocamlbuild  -cflags $OCAMLBUILD_CFLAGS -no-links js_generate_require.byte  -- 2>
 
 echo "........" >> ./build.compile
 
-npm run cover&
+# npm run cover&
 
 echo "Done"

--- a/jscomp/test/unsafe_ppx_test.js
+++ b/jscomp/test/unsafe_ppx_test.js
@@ -8,10 +8,6 @@ var x = ("\x01\x02\x03");
 
 var max = (Math.max);
 
-function u(param) {
-  return max(1, param);
-}
-
 
 
 function $$test(x,y){
@@ -19,6 +15,18 @@ function $$test(x,y){
 }
 
 ;
+
+var max2 = (Math.max);
+
+function u(param) {
+  return max2(3, param);
+}
+
+var max3 = (Math.max);
+
+function uu(param) {
+  return max2(3, param);
+}
 
 var empty = ( Object.keys)(3);
 
@@ -80,7 +88,10 @@ Mt.from_pair_suites("unsafe_ppx_test.ml", /* :: */[
 
 exports.x     = x;
 exports.max   = max;
+exports.max2  = max2;
 exports.u     = u;
+exports.max3  = max3;
+exports.uu    = uu;
 exports.empty = empty;
 exports.v     = v;
 /* x Not a pure module */

--- a/jscomp/test/unsafe_ppx_test.ml
+++ b/jscomp/test/unsafe_ppx_test.ml
@@ -14,6 +14,12 @@ function $$test(x,y){
 }
 |}]
 
+let max2 : float -> float -> float = [%js.raw "Math.max"]
+let u = max2 3.
+
+let max3 = ([%js.raw "Math.max"] :  float -> float -> float)
+let uu = max2 3.
+    
 external test : int -> int -> int = "" [@@js.call "$$test"]
 
 let empty = ([%js.raw ({| Object.keys|}  : _ -> string array) ]) 3 


### PR DESCRIPTION

such as 

```ocaml
let f : float -> float -> float = [%js.raw "Math.max" ]
```

the type annotation will be used in arity inference