### PR TITLE
simulate stdout using console.log -- get Printf.printf to work

### DIFF
--- a/jscomp/lib/js.ml
+++ b/jscomp/lib/js.ml
@@ -75,17 +75,19 @@ external string_of_char : char -> string = "js_string_of_char"
 *)
 module String = struct 
   external of_char : char -> string = "String.fromCharCode" 
-    [@@js.call]
+      [@@js.call]
   external toUpperCase : string -> string = "toUpperCase" [@@js.send]
   external of_int : int -> base:int -> string = "toString" [@@js.send]
   external slice : string -> int -> int -> string = "slice" 
-    [@@js.send]
+      [@@js.send]
   external slice_rest : string -> int -> string = "slice" 
-    [@@js.send]
+      [@@js.send]
   external index_of : string -> string -> int = "indexOf"
-    [@@js.send]
+      [@@js.send]
   external append : string -> string -> string = "js_string_append"
   external of_small_int_array : int array -> string = "js_string_of_small_int_array"
+  external lastIndexOf : string -> string -> int = "lastIndexOf"
+      [@@js.send]    
 end
 
 module Array = struct 

--- a/jscomp/runtime/caml_io.js
+++ b/jscomp/runtime/caml_io.js
@@ -2,12 +2,42 @@
 'use strict';
 
 var Caml_builtin_exceptions = require("./caml_builtin_exceptions");
+var Caml_curry              = require("./caml_curry");
 
 var stdin = undefined;
 
-var stdout = undefined;
+var stdout = /* record */[
+  "",
+  function (_, s) {
+    var v = s.length - 1;
+    if (( process && process.stdout && process.stdout.write)) {
+      return ( process.stdout.write )(s);
+    }
+    else if (s[v] === "\n") {
+      console.log(s.slice(0, v));
+      return /* () */0;
+    }
+    else {
+      console.log(s);
+      return /* () */0;
+    }
+  }
+];
 
-var stderr = undefined;
+var stderr = /* record */[
+  "",
+  function (_, s) {
+    var v = s.length - 1;
+    if (s[v] === "\n") {
+      console.log(s.slice(0, v));
+      return /* () */0;
+    }
+    else {
+      console.log(s);
+      return /* () */0;
+    }
+  }
+];
 
 function caml_ml_open_descriptor_in() {
   throw [
@@ -23,18 +53,46 @@ function caml_ml_open_descriptor_out() {
       ];
 }
 
-function caml_ml_output_char(_, _$1) {
-  throw [
-        Caml_builtin_exceptions.failure,
-        "caml_ml_output_char not implemented"
-      ];
+function caml_ml_flush(oc) {
+  if (oc[/* buffer */0] !== "") {
+    Caml_curry.app2(oc[/* output */1], oc, oc[/* buffer */0]);
+    oc[/* buffer */0] = "";
+    return /* () */0;
+  }
+  else {
+    return 0;
+  }
 }
 
-function caml_ml_output(_, _$1, _$2, _$3) {
-  throw [
-        Caml_builtin_exceptions.failure,
-        "caml_ml_output not implemented"
-      ];
+var node_std_output = (function (s){
+   return process && process.stdout && (process.stdout.write(s), true);
+   }
+);
+
+function caml_ml_output(oc, str, offset, len) {
+  var str$1 = offset === 0 && len === str.length ? str : str.slice(offset, len);
+  if ((process && process.stdout && process.stdout.write ) && oc === stdout) {
+    return (process.stdout.write)(str$1);
+  }
+  else {
+    var id = str$1.lastIndexOf("\n");
+    if (id < 0) {
+      oc[/* buffer */0] = oc[/* buffer */0] + str$1;
+      return /* () */0;
+    }
+    else {
+      oc[/* buffer */0] = oc[/* buffer */0] + str$1.slice(0, id + 1);
+      caml_ml_flush(oc);
+      oc[/* buffer */0] = oc[/* buffer */0] + str$1.slice(id + 1);
+      return /* () */0;
+    }
+  }
+}
+
+function caml_ml_output_char(oc, $$char) {
+  return function (param, param$1) {
+    return caml_ml_output(oc, String.fromCharCode($$char), param, param$1);
+  };
 }
 
 function caml_ml_input(_, _$1, _$2, _$3) {
@@ -56,18 +114,7 @@ function caml_ml_out_channels_list() {
         Caml_builtin_exceptions.assert_failure,
         [
           "caml_io.ml",
-          46,
-          2
-        ]
-      ];
-}
-
-function caml_ml_flush() {
-  throw [
-        Caml_builtin_exceptions.assert_failure,
-        [
-          "caml_io.ml",
-          49,
+          108,
           2
         ]
       ];
@@ -78,10 +125,11 @@ exports.stdout                      = stdout;
 exports.stderr                      = stderr;
 exports.caml_ml_open_descriptor_in  = caml_ml_open_descriptor_in;
 exports.caml_ml_open_descriptor_out = caml_ml_open_descriptor_out;
-exports.caml_ml_output_char         = caml_ml_output_char;
+exports.caml_ml_flush               = caml_ml_flush;
+exports.node_std_output             = node_std_output;
 exports.caml_ml_output              = caml_ml_output;
+exports.caml_ml_output_char         = caml_ml_output_char;
 exports.caml_ml_input               = caml_ml_input;
 exports.caml_ml_input_char          = caml_ml_input_char;
 exports.caml_ml_out_channels_list   = caml_ml_out_channels_list;
-exports.caml_ml_flush               = caml_ml_flush;
 /* stdin Not a pure module */

--- a/jscomp/runtime/caml_io.ml
+++ b/jscomp/runtime/caml_io.ml
@@ -22,20 +22,82 @@ type 'a def
 
 
 let stdin = Js.undef
-let stdout = Js.undef 
+
 let stderr = Js.undef 
+
+type out_channel  = {
+  mutable buffer :  string;
+  output :   out_channel  -> string -> unit 
+}
+
+let stdout = {
+  buffer = "";
+  output = (fun _ s ->
+    let v = String.length s - 1 in
+    if [%js.raw{| process && process.stdout && process.stdout.write|}] then
+      ([%js.raw{| process.stdout.write |} ] : string -> unit) s
+    else         
+    if s.[v] = '\n' then
+      Js.log (Js.String.slice s 0 v)
+    else Js.log s)
+}
+
+let stderr = {
+  buffer = "";
+  output = fun _ s ->
+    let v = String.length s - 1 in     
+    if s.[v] = '\n' then
+      Js.log (Js.String.slice s 0 v) (* TODO: change to Js.error*)
+    else Js.log s        
+}
 
 let caml_ml_open_descriptor_in (i : int) : in_channel = 
   raise (Failure "caml_ml_open_descriptor_in not implemented")  
 let caml_ml_open_descriptor_out (i : int)  : out_channel = 
   raise (Failure "caml_ml_open_descriptor_out not implemented")
-let caml_ml_output_char (oc : out_channel)  (char : char) =
-  raise (Failure "caml_ml_output_char not implemented"  )
+
+(*TODO: we need flush all buffers in the end *)
+let caml_ml_flush (oc : out_channel)  : unit = 
+  if oc.buffer  <> "" then
+    begin     
+      oc.output oc oc.buffer;
+      oc.buffer <- ""      
+    end      
+
+let node_std_output  : string -> bool = [%js.raw{|function (s){
+   return process && process.stdout && (process.stdout.write(s), true);
+   }
+|}]
 
 (** note we need provide both [bytes] and [string] version 
 *)
-let caml_ml_output (oc : out_channel) (bytes : bytes) offset len  =
-    raise @@ Failure  "caml_ml_output not implemented"  
+let caml_ml_output (oc : out_channel) (str : string) offset len  =
+  let str =
+    if offset = 0 && len = String.length str then str    
+    else Js.String.slice str offset len in
+  if [%js.raw{|process && process.stdout && process.stdout.write |}] &&
+     oc == stdout then
+    begin     
+
+      ([%js.raw{|process.stdout.write|}] : string -> unit ) str
+    end        
+  else
+    begin     
+
+      let id = Js.String.lastIndexOf str "\n" in
+      if id < 0 then
+        oc.buffer <- oc.buffer ^ str
+      else
+        begin 
+          oc.buffer <- oc.buffer ^ Js.String.slice str 0 (id +1);
+          caml_ml_flush oc;
+          oc.buffer <- oc.buffer ^ Js.String.slice_rest str (id + 1)
+        end
+    end      
+
+let caml_ml_output_char (oc : out_channel)  (char : char) =
+  caml_ml_output oc (Js.String.of_char char)
+
 let caml_ml_input (ic : in_channel) (bytes : bytes) offset len : int = 
   raise @@ Failure  "caml_ml_input ic not implemented"
 
@@ -45,6 +107,4 @@ let caml_ml_input_char (ic : in_channel) : char =
 let caml_ml_out_channels_list () : out_channel list  =
   assert false 
 
-let caml_ml_flush oc  = 
-  assert false 
 

--- a/jscomp/test/.depend
+++ b/jscomp/test/.depend
@@ -238,6 +238,8 @@ of_string_test.cmo : mt.cmi
 of_string_test.cmx : mt.cmx
 primitive_reg_test.cmo :
 primitive_reg_test.cmx :
+printf_sim.cmo : ../stdlib/printf.cmi
+printf_sim.cmx : ../stdlib/printf.cmx
 printf_test.cmo : ../stdlib/printf.cmi mt.cmi ../stdlib/format.cmi
 printf_test.cmx : ../stdlib/printf.cmx mt.cmx ../stdlib/format.cmx
 qcc.cmo : ../stdlib/sys.cmi ../stdlib/string.cmi ../stdlib/printf.cmi \
@@ -718,6 +720,8 @@ of_string_test.cmo : mt.cmi
 of_string_test.cmj : mt.cmj
 primitive_reg_test.cmo :
 primitive_reg_test.cmj :
+printf_sim.cmo : ../stdlib/printf.cmi
+printf_sim.cmj : ../stdlib/printf.cmj
 printf_test.cmo : ../stdlib/printf.cmi mt.cmi ../stdlib/format.cmi
 printf_test.cmj : ../stdlib/printf.cmj mt.cmj ../stdlib/format.cmj
 qcc.cmo : ../stdlib/sys.cmi ../stdlib/string.cmi ../stdlib/printf.cmi \

--- a/jscomp/test/printf_sim.js
+++ b/jscomp/test/printf_sim.js
@@ -1,0 +1,87 @@
+// Generated CODE, PLEASE EDIT WITH CARE
+'use strict';
+
+var Printf     = require("../stdlib/printf");
+var Caml_curry = require("../runtime/caml_curry");
+
+Printf.printf(/* Format */{
+      0: /* String_literal */{
+        0: "heloo!\nhelloxx\n",
+        1: /* End_of_format */0,
+        length: 2,
+        tag: 11
+      },
+      1: "heloo!\nhelloxx\n",
+      length: 2,
+      tag: 0
+    });
+
+Printf.printf(/* Format */{
+      0: /* String_literal */{
+        0: "hello\nhi\n",
+        1: /* End_of_format */0,
+        length: 2,
+        tag: 11
+      },
+      1: "hello\nhi\n",
+      length: 2,
+      tag: 0
+    });
+
+Caml_curry.app2(Printf.printf(/* Format */{
+          0: /* Int */{
+            0: /* Int_d */0,
+            1: /* Arg_padding */{
+              0: /* Right */1,
+              length: 1,
+              tag: 1
+            },
+            2: /* No_precision */0,
+            3: /* String_literal */{
+              0: "\n\n",
+              1: /* End_of_format */0,
+              length: 2,
+              tag: 11
+            },
+            length: 4,
+            tag: 4
+          },
+          1: "%*d\n\n",
+          length: 2,
+          tag: 0
+        }), 32, 3);
+
+Caml_curry.app1(Printf.printf(/* Format */{
+          0: /* String */{
+            0: /* No_padding */0,
+            1: /* End_of_format */0,
+            length: 2,
+            tag: 2
+          },
+          1: "%s",
+          length: 2,
+          tag: 0
+        }), Caml_curry.app2(Printf.sprintf(/* Format */{
+              0: /* Int */{
+                0: /* Int_d */0,
+                1: /* Arg_padding */{
+                  0: /* Right */1,
+                  length: 1,
+                  tag: 1
+                },
+                2: /* No_precision */0,
+                3: /* Char_literal */{
+                  0: /* "\n" */10,
+                  1: /* End_of_format */0,
+                  length: 2,
+                  tag: 12
+                },
+                length: 4,
+                tag: 4
+              },
+              1: "%*d\n",
+              length: 2,
+              tag: 0
+            }), 32, 3));
+
+/*  Not a pure module */

--- a/jscomp/test/printf_sim.ml
+++ b/jscomp/test/printf_sim.ml
@@ -1,0 +1,6 @@
+Printf.printf "heloo!\nhelloxx\n";;
+Printf.printf "hello\nhi\n";;
+Printf.printf "%*d\n\n" 32 3;;
+Printf.printf "%s" (Printf.sprintf "%*d\n" 32 3);;
+
+  

--- a/jscomp/test/test.mllib
+++ b/jscomp/test/test.mllib
@@ -209,4 +209,5 @@ io_test
 random_test
 ffi_js
 stringmatch_test
+printf_sim
 # hamming_test


### PR DESCRIPTION
`Printf.printf` is involved in io, however, since it is widely used, it make senses to get it working, here we made a naive simulation using `console.log` stay tuned