### PR TITLE
avoid allocation when check the arity

### DIFF
--- a/jscomp/ext_string.ml
+++ b/jscomp/ext_string.ml
@@ -149,3 +149,18 @@ let tail_from s x =
   let len = String.length s  in 
   if  x > len then invalid_arg ("Ext_string.tail_from " ^s ^ " : "^ string_of_int x )
   else String.sub s x (len - x)
+
+
+(**
+   {[ 
+     digits_of_str "11_js" 2 == 11     
+   ]}
+*)
+let digits_of_str s ~offset x = 
+  let rec aux i acc s x  = 
+    if i >= x then acc 
+    else aux (i + 1) (10 * acc + Char.code s.[offset + i] - 48 (* Char.code '0' *)) s x in 
+  aux 0 0 s x 
+
+
+

--- a/jscomp/ext_string.mli
+++ b/jscomp/ext_string.mli
@@ -47,3 +47,5 @@ val find : ?start:int -> sub:string -> string -> int
 val rfind : sub:string -> string -> int
 
 val tail_from : string -> int -> string
+
+val digits_of_str : string -> offset:int -> int -> int

--- a/jscomp/lam_compile.ml
+++ b/jscomp/lam_compile.ml
@@ -674,9 +674,22 @@ and
           let exp =  E.or_ l_expr r_expr  in
           Js_output.handle_block_return st should_return lam args_code exp
       end
-    | Lprim (Pccall {prim_name = ("00_js_fn_mk" | "01_js_fn_mk" | "02_js_fn_mk"as name )}, [fn])
+    | Lprim (Pccall {prim_name = 
+                       (
+                         "js_fn_mk_00" 
+                       | "js_fn_mk_01"
+                       | "js_fn_mk_02"
+                       | "js_fn_mk_03"
+                       | "js_fn_mk_04"
+                       | "js_fn_mk_05"
+                       | "js_fn_mk_06"
+                       | "js_fn_mk_07"
+                       | "js_fn_mk_08"
+                       | "js_fn_mk_09"
+                         as name )
+                    }, [fn])
       -> 
-      let arity = int_of_string @@ String.sub name 0 2  in
+      let arity = Ext_string.digits_of_str ~offset:9 (* String.length "js_fn_mk_" *) name 2   in
       begin match fn with
       | Lambda.Lfunction(kind,args, body) 
         ->

--- a/jscomp/lib/js_fn.ml
+++ b/jscomp/lib/js_fn.ml
@@ -34,39 +34,39 @@
 type 'a t
 
 external mk0 : (unit -> 'a0) -> 'a0 t = 
-  "00_js_fn_mk" 
+  "js_fn_mk_00" 
 
 external mk1 : ('a0 -> 'a1) -> ('a0 * 'a1) t  = 
-  "01_js_fn_mk"
+  "js_fn_mk_01"
 
 external mk2 : ('a0 -> 'a1 -> 'a2 ) -> ('a0 *  'a1 * 'a2) t = 
-  "02_js_fn_mk"
+  "js_fn_mk_02"
 
 external mk3 : ('a0 -> 'a1 -> 'a2 -> 'a3 ) -> ('a0 *  'a1 * 'a2 * 'a3)  t = 
-  "03_js_fn_mk"
+  "js_fn_mk_03"
 
 external mk4 : ('a0 -> 'a1 -> 'a2 -> 'a3 -> 'a4 ) -> ('a0 *  'a1 * 'a2 * 'a3 * 'a4) t = 
-  "04_js_fn_mk"
+  "js_fn_mk_04"
 
 external mk5 : ('a0 -> 'a1 -> 'a2 -> 'a3 -> 'a4 -> 'a5 ) -> ('a0 *  'a1 * 'a2 * 'a3 * 'a4 * 'a5) t =
-  "05_js_fn_mk"
+  "js_fn_mk_05"
 
 
 external mk6 : ('a0 -> 'a1 -> 'a2 -> 'a3 -> 'a4 -> 'a5 -> 'a6) -> 
   ('a0 *  'a1 * 'a2 * 'a3 * 'a4 * 'a5 * 'a6) t =
-  "06_js_fn_mk"
+  "js_fn_mk_06"
 
 external mk7 : ('a0 -> 'a1 -> 'a2 -> 'a3 -> 'a4 -> 'a5 -> 'a6 -> 'a7) -> 
   ('a0 *  'a1 * 'a2 * 'a3 * 'a4 * 'a5 * 'a6 * 'a7 ) t =
-  "07_js_fn_mk"
+  "js_fn_mk_07"
 
 
 external mk8 : ('a0 -> 'a1 -> 'a2 -> 'a3 -> 'a4 -> 'a5 -> 'a6 -> 'a7 -> 'a8 ) ->
   ('a0 *  'a1 * 'a2 * 'a3 * 'a4 * 'a5 * 'a6 * 'a7 * 'a8 ) t =
-  "08_js_fn_mk"
+  "js_fn_mk_08"
 
 
 external mk9 : ('a0 -> 'a1 -> 'a2 -> 'a3 -> 'a4 -> 'a5 -> 'a6 -> 'a7 -> 'a8 -> 'a9) ->
   ('a0 *  'a1 * 'a2 * 'a3 * 'a4 * 'a5 * 'a6 * 'a7 * 'a8 * 'a9 ) t =
-  "08_js_fn_mk"
+  "js_fn_mk_09"
 

--- a/jscomp/test/.depend
+++ b/jscomp/test/.depend
@@ -110,8 +110,10 @@ ext_list.cmo : ../stdlib/list.cmi ../stdlib/array.cmi
 ext_list.cmx : ../stdlib/list.cmx ../stdlib/array.cmx
 ext_log.cmo : lam_current_unit.cmo ../stdlib/format.cmi
 ext_log.cmx : lam_current_unit.cmx ../stdlib/format.cmx
-ext_string.cmo : ../stdlib/string.cmi ext_bytes.cmo ../stdlib/bytes.cmi
-ext_string.cmx : ../stdlib/string.cmx ext_bytes.cmx ../stdlib/bytes.cmx
+ext_string.cmo : ../stdlib/string.cmi ext_bytes.cmo ../stdlib/char.cmi \
+    ../stdlib/bytes.cmi
+ext_string.cmx : ../stdlib/string.cmx ext_bytes.cmx ../stdlib/char.cmx \
+    ../stdlib/bytes.cmx
 extensible_variant_test.cmo : mt.cmi
 extensible_variant_test.cmx : mt.cmx
 ffi_arity_test.cmo : mt.cmi ../lib/js_fn.cmo
@@ -610,8 +612,10 @@ ext_list.cmo : ../stdlib/list.cmi ../stdlib/array.cmi
 ext_list.cmj : ../stdlib/list.cmj ../stdlib/array.cmj
 ext_log.cmo : lam_current_unit.cmo ../stdlib/format.cmi
 ext_log.cmj : lam_current_unit.cmj ../stdlib/format.cmj
-ext_string.cmo : ../stdlib/string.cmi ext_bytes.cmo ../stdlib/bytes.cmi
-ext_string.cmj : ../stdlib/string.cmj ext_bytes.cmj ../stdlib/bytes.cmj
+ext_string.cmo : ../stdlib/string.cmi ext_bytes.cmo ../stdlib/char.cmi \
+    ../stdlib/bytes.cmi
+ext_string.cmj : ../stdlib/string.cmj ext_bytes.cmj ../stdlib/char.cmj \
+    ../stdlib/bytes.cmj
 extensible_variant_test.cmo : mt.cmi
 extensible_variant_test.cmj : mt.cmj
 ffi_arity_test.cmo : mt.cmi ../lib/js_fn.cmo

--- a/jscomp/test/ext_string.js
+++ b/jscomp/test/ext_string.js
@@ -281,17 +281,38 @@ function tail_from(s, x) {
   }
 }
 
-exports.split_by    = split_by;
-exports.split       = split;
-exports.starts_with = starts_with;
-exports.ends_with   = ends_with;
-exports.escaped     = escaped;
-exports.for_all     = for_all;
-exports.is_empty    = is_empty;
-exports.repeat      = repeat;
-exports.equal       = equal;
-exports._is_sub     = _is_sub;
-exports.find        = find;
-exports.rfind       = rfind;
-exports.tail_from   = tail_from;
+function digits_of_str(s, offset, x) {
+  var _i = 0;
+  var _acc = 0;
+  var s$1 = s;
+  var x$1 = x;
+  while(true) {
+    var acc = _acc;
+    var i = _i;
+    if (i >= x$1) {
+      return acc;
+    }
+    else {
+      _acc = (Caml_primitive.imul(10, acc) + s$1.charCodeAt(offset + i | 0) | 0) - 48 | 0;
+      _i = i + 1 | 0;
+      continue ;
+      
+    }
+  };
+}
+
+exports.split_by      = split_by;
+exports.split         = split;
+exports.starts_with   = starts_with;
+exports.ends_with     = ends_with;
+exports.escaped       = escaped;
+exports.for_all       = for_all;
+exports.is_empty      = is_empty;
+exports.repeat        = repeat;
+exports.equal         = equal;
+exports._is_sub       = _is_sub;
+exports.find          = find;
+exports.rfind         = rfind;
+exports.tail_from     = tail_from;
+exports.digits_of_str = digits_of_str;
 /* No side effect */


### PR DESCRIPTION
also rename `00_js_fn_mk` to `js_fn_mk_00` to follow the same convention `js_blabla`