### PR TITLE
[feature] provide make big-world -- so that it is stand-alone without…

### DIFF
--- a/jscomp/Makefile
+++ b/jscomp/Makefile
@@ -80,6 +80,23 @@ world:
 	cd stdlib && make all	
 	@echo "Making lib finished"
 
+big-world:bin/big_compiler.ml bin/big_compiler.mli
+	@echo "Making compiler"		
+	ocamlopt.opt -g -inline 100 -linkall  -w -a -I +compiler-libs -I bin ocamlcommon.cmxa ocamlbytecomp.cmxa bin/big_compiler.mli bin/big_compiler.ml -o bin/bsc
+	@echo "Making compiler finished"		
+
+	@echo "Making runtime"
+	cd runtime && OCAMLIB=`ocamlc -where` make all
+	@echo "Making runtime finished"
+
+	@echo "Making stdlib"
+	cd lib && make all
+	@echo "Making stdlib finished"
+
+	@echo "Making lib"
+	cd stdlib && make all	
+	@echo "Making lib finished"
+
 world-test:
 	@echo "Making compiler"		
 	ocamlopt.opt -g -inline 100 -w -a -linkall  -I +compiler-libs -I bin ocamlcommon.cmxa ocamlbytecomp.cmxa bin/compiler.mli bin/compiler.ml -o bin/bsc

--- a/jscomp/Makefile
+++ b/jscomp/Makefile
@@ -82,7 +82,7 @@ world:
 
 big-world:bin/big_compiler.ml bin/big_compiler.mli
 	@echo "Making compiler"		
-	ocamlopt.opt -g -inline 100 -linkall  -w -a -I +compiler-libs -I bin ocamlcommon.cmxa ocamlbytecomp.cmxa bin/big_compiler.mli bin/big_compiler.ml -o bin/bsc
+	ocamlopt.opt -g -inline 100 -linkall  -w -a  -I bin  bin/big_compiler.mli bin/big_compiler.ml -o bin/bsc
 	@echo "Making compiler finished"		
 
 	@echo "Making runtime"

--- a/jscomp/bin/big_compiler.ml
+++ b/jscomp/bin/big_compiler.ml
@@ -4988,7 +4988,7 @@ end = struct
 (* The main OCaml version string has moved to ../VERSION *)
 let version = Sys.ocaml_version
 
-let standard_library_default = "/Users/hongbozhang/git/ocamlscript/ocaml/lib/ocaml"
+let standard_library_default = ""
 
 let standard_library =
   try
@@ -4999,19 +4999,19 @@ let standard_library =
   with Not_found ->
     standard_library_default
 
-let standard_runtime = "/Users/hongbozhang/git/ocamlscript/ocaml/bin/ocamlrun"
-let ccomp_type = "cc"
-let bytecomp_c_compiler = "gcc -O  -Wall -D_FILE_OFFSET_BITS=64 -D_REENTRANT -O "
-let bytecomp_c_libraries = "-lcurses -lpthread"
-let native_c_compiler = "gcc -O  -D_FILE_OFFSET_BITS=64 -D_REENTRANT"
+let standard_runtime = ""
+let ccomp_type = ""
+let bytecomp_c_compiler = ""
+let bytecomp_c_libraries = ""
+let native_c_compiler = ""
 let native_c_libraries = ""
-let native_pack_linker = "ld -r -arch x86_64  -o "
+let native_pack_linker = ""
 let ranlib = "ranlib"
 let ar = "ar"
-let cc_profile = "-pg"
-let mkdll = "gcc -bundle -flat_namespace -undefined suppress -Wl,-no_compact_unwind"
-let mkexe = "gcc -Wl,-no_compact_unwind"
-let mkmaindll = "gcc -bundle -flat_namespace -undefined suppress -Wl,-no_compact_unwind"
+let cc_profile = ""
+let mkdll = ""
+let mkexe = ""
+let mkmaindll = ""
 
 let exec_magic_number = "Caml1999X011"
 and cmi_magic_number = "Caml1999I017"
@@ -5039,9 +5039,9 @@ let stack_threshold = 256 (* see byterun/config.h *)
 
 let architecture = "amd64"
 let model = "default"
-let system = "macosx"
+let system = ""
 
-let asm = "clang -arch x86_64 -c"
+let asm = ""
 let asm_cfi_supported = true
 let with_frame_pointers = false
 
@@ -5050,8 +5050,8 @@ let ext_asm = ".s"
 let ext_lib = ".a"
 let ext_dll = ".so"
 
-let host = "x86_64-apple-darwin15.0.0"
-let target = "x86_64-apple-darwin15.0.0"
+let host = ""
+let target = ""
 
 let default_executable_name =
   match Sys.os_type with

--- a/jscomp/bin/big_compiler.ml
+++ b/jscomp/bin/big_compiler.ml
@@ -4988,7 +4988,7 @@ end = struct
 (* The main OCaml version string has moved to ../VERSION *)
 let version = Sys.ocaml_version
 
-let standard_library_default = "/usr/local/lib/ocaml"
+let standard_library_default = "/Users/hongbozhang/git/ocamlscript/ocaml/lib/ocaml"
 
 let standard_library =
   try
@@ -4999,19 +4999,19 @@ let standard_library =
   with Not_found ->
     standard_library_default
 
-let standard_runtime = "/usr/local/bin/ocamlrun"
+let standard_runtime = "/Users/hongbozhang/git/ocamlscript/ocaml/bin/ocamlrun"
 let ccomp_type = "cc"
-let bytecomp_c_compiler = "gcc -O -fno-defer-pop -Wall -D_FILE_OFFSET_BITS=64 -D_REENTRANT -O -fPIC"
-let bytecomp_c_libraries = "-lm  -ldl -lcurses -lpthread"
-let native_c_compiler = "gcc -O -Wall -D_FILE_OFFSET_BITS=64 -D_REENTRANT"
-let native_c_libraries = "-lm  -ldl"
-let native_pack_linker = "ld -r  -o "
+let bytecomp_c_compiler = "gcc -O  -Wall -D_FILE_OFFSET_BITS=64 -D_REENTRANT -O "
+let bytecomp_c_libraries = "-lcurses -lpthread"
+let native_c_compiler = "gcc -O  -D_FILE_OFFSET_BITS=64 -D_REENTRANT"
+let native_c_libraries = ""
+let native_pack_linker = "ld -r -arch x86_64  -o "
 let ranlib = "ranlib"
 let ar = "ar"
 let cc_profile = "-pg"
-let mkdll = "gcc -shared"
-let mkexe = "gcc"
-let mkmaindll = "gcc -shared"
+let mkdll = "gcc -bundle -flat_namespace -undefined suppress -Wl,-no_compact_unwind"
+let mkexe = "gcc -Wl,-no_compact_unwind"
+let mkmaindll = "gcc -bundle -flat_namespace -undefined suppress -Wl,-no_compact_unwind"
 
 let exec_magic_number = "Caml1999X011"
 and cmi_magic_number = "Caml1999I017"
@@ -5039,9 +5039,9 @@ let stack_threshold = 256 (* see byterun/config.h *)
 
 let architecture = "amd64"
 let model = "default"
-let system = "linux"
+let system = "macosx"
 
-let asm = "as"
+let asm = "clang -arch x86_64 -c"
 let asm_cfi_supported = true
 let with_frame_pointers = false
 
@@ -5050,8 +5050,8 @@ let ext_asm = ".s"
 let ext_lib = ".a"
 let ext_dll = ".so"
 
-let host = "x86_64-unknown-linux-gnu"
-let target = "x86_64-unknown-linux-gnu"
+let host = "x86_64-apple-darwin15.0.0"
+let target = "x86_64-apple-darwin15.0.0"
 
 let default_executable_name =
   match Sys.os_type with

--- a/jscomp/bin/big_compiler.mli
+++ b/jscomp/bin/big_compiler.mli
@@ -1,0 +1,28 @@
+(* Copyright (C) 2015-2016 Bloomberg Finance L.P.
+ * 
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In addition to the permissions granted to you by the LGPL, you may combine
+ * or link a "work that uses the Library" with a publicly distributed version
+ * of this file to produce a combined library or application, then distribute
+ * that combined work under the terms of your choosing, with no requirement
+ * to comply with the obligations normally placed on you by section 4 of the
+ * LGPL version 3 (or the corresponding section of a later version of the LGPL
+ * should you choose to use a later version).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
+
+
+
+
+

--- a/jscomp/bin/big_compiler.mllib
+++ b/jscomp/bin/big_compiler.mllib
@@ -1,0 +1,4 @@
+config
+
+include ../compiler_internal.mllib
+include ../compiler.mllib

--- a/jscomp/bin/config.ml
+++ b/jscomp/bin/config.ml
@@ -1,0 +1,143 @@
+(***********************************************************************)
+(*                                                                     *)
+(*                                OCaml                                *)
+(*                                                                     *)
+(*            Xavier Leroy, projet Cristal, INRIA Rocquencourt         *)
+(*                                                                     *)
+(*  Copyright 1996 Institut National de Recherche en Informatique et   *)
+(*  en Automatique.  All rights reserved.  This file is distributed    *)
+(*  under the terms of the Q Public License version 1.0.               *)
+(*                                                                     *)
+(***********************************************************************)
+
+(***********************************************************************)
+(**                                                                   **)
+(**               WARNING WARNING WARNING                             **)
+(**                                                                   **)
+(** When you change this file, you must make the parallel change      **)
+(** in config.mlbuild                                                 **)
+(**                                                                   **)
+(***********************************************************************)
+
+
+(* The main OCaml version string has moved to ../VERSION *)
+let version = Sys.ocaml_version
+
+let standard_library_default = "/Users/hongbozhang/git/ocamlscript/ocaml/lib/ocaml"
+
+let standard_library =
+  try
+    Sys.getenv "OCAMLLIB"
+  with Not_found ->
+  try
+    Sys.getenv "CAMLLIB"
+  with Not_found ->
+    standard_library_default
+
+let standard_runtime = "/Users/hongbozhang/git/ocamlscript/ocaml/bin/ocamlrun"
+let ccomp_type = "cc"
+let bytecomp_c_compiler = "gcc -O  -Wall -D_FILE_OFFSET_BITS=64 -D_REENTRANT -O "
+let bytecomp_c_libraries = "-lcurses -lpthread"
+let native_c_compiler = "gcc -O  -D_FILE_OFFSET_BITS=64 -D_REENTRANT"
+let native_c_libraries = ""
+let native_pack_linker = "ld -r -arch x86_64  -o "
+let ranlib = "ranlib"
+let ar = "ar"
+let cc_profile = "-pg"
+let mkdll = "gcc -bundle -flat_namespace -undefined suppress -Wl,-no_compact_unwind"
+let mkexe = "gcc -Wl,-no_compact_unwind"
+let mkmaindll = "gcc -bundle -flat_namespace -undefined suppress -Wl,-no_compact_unwind"
+
+let exec_magic_number = "Caml1999X011"
+and cmi_magic_number = "Caml1999I017"
+and cmo_magic_number = "Caml1999O010"
+and cma_magic_number = "Caml1999A011"
+and cmx_magic_number = "Caml1999Y014"
+and cmxa_magic_number = "Caml1999Z013"
+and ast_impl_magic_number = "Caml1999M016"
+and ast_intf_magic_number = "Caml1999N015"
+and cmxs_magic_number = "Caml2007D002"
+and cmt_magic_number = "Caml2012T004"
+
+let load_path = ref ([] : string list)
+
+let interface_suffix = ref ".mli"
+
+let max_tag = 245
+(* This is normally the same as in obj.ml, but we have to define it
+   separately because it can differ when we're in the middle of a
+   bootstrapping phase. *)
+let lazy_tag = 246
+
+let max_young_wosize = 256
+let stack_threshold = 256 (* see byterun/config.h *)
+
+let architecture = "amd64"
+let model = "default"
+let system = "macosx"
+
+let asm = "clang -arch x86_64 -c"
+let asm_cfi_supported = true
+let with_frame_pointers = false
+
+let ext_obj = ".o"
+let ext_asm = ".s"
+let ext_lib = ".a"
+let ext_dll = ".so"
+
+let host = "x86_64-apple-darwin15.0.0"
+let target = "x86_64-apple-darwin15.0.0"
+
+let default_executable_name =
+  match Sys.os_type with
+    "Unix" -> "a.out"
+  | "Win32" | "Cygwin" -> "camlprog.exe"
+  | _ -> "camlprog"
+
+let systhread_supported = true;;
+
+let print_config oc =
+  let p name valu = Printf.fprintf oc "%s: %s\n" name valu in
+  let p_bool name valu = Printf.fprintf oc "%s: %B\n" name valu in
+  p "version" version;
+  p "standard_library_default" standard_library_default;
+  p "standard_library" standard_library;
+  p "standard_runtime" standard_runtime;
+  p "ccomp_type" ccomp_type;
+  p "bytecomp_c_compiler" bytecomp_c_compiler;
+  p "bytecomp_c_libraries" bytecomp_c_libraries;
+  p "native_c_compiler" native_c_compiler;
+  p "native_c_libraries" native_c_libraries;
+  p "native_pack_linker" native_pack_linker;
+  p "ranlib" ranlib;
+  p "cc_profile" cc_profile;
+  p "architecture" architecture;
+  p "model" model;
+  p "system" system;
+  p "asm" asm;
+  p_bool "asm_cfi_supported" asm_cfi_supported;
+  p_bool "with_frame_pointers" with_frame_pointers;
+  p "ext_obj" ext_obj;
+  p "ext_asm" ext_asm;
+  p "ext_lib" ext_lib;
+  p "ext_dll" ext_dll;
+  p "os_type" Sys.os_type;
+  p "default_executable_name" default_executable_name;
+  p_bool "systhread_supported" systhread_supported;
+  p "host" host;
+  p "target" target;
+
+  (* print the magic number *)
+  p "exec_magic_number" exec_magic_number;
+  p "cmi_magic_number" cmi_magic_number;
+  p "cmo_magic_number" cmo_magic_number;
+  p "cma_magic_number" cma_magic_number;
+  p "cmx_magic_number" cmx_magic_number;
+  p "cmxa_magic_number" cmxa_magic_number;
+  p "ast_impl_magic_number" ast_impl_magic_number;
+  p "ast_intf_magic_number" ast_intf_magic_number;
+  p "cmxs_magic_number" cmxs_magic_number;
+  p "cmt_magic_number" cmt_magic_number;
+
+  flush oc;
+;;

--- a/jscomp/bin/config.ml
+++ b/jscomp/bin/config.ml
@@ -23,7 +23,7 @@
 (* The main OCaml version string has moved to ../VERSION *)
 let version = Sys.ocaml_version
 
-let standard_library_default = "/Users/hongbozhang/git/ocamlscript/ocaml/lib/ocaml"
+let standard_library_default = ""
 
 let standard_library =
   try
@@ -34,19 +34,19 @@ let standard_library =
   with Not_found ->
     standard_library_default
 
-let standard_runtime = "/Users/hongbozhang/git/ocamlscript/ocaml/bin/ocamlrun"
-let ccomp_type = "cc"
-let bytecomp_c_compiler = "gcc -O  -Wall -D_FILE_OFFSET_BITS=64 -D_REENTRANT -O "
-let bytecomp_c_libraries = "-lcurses -lpthread"
-let native_c_compiler = "gcc -O  -D_FILE_OFFSET_BITS=64 -D_REENTRANT"
+let standard_runtime = ""
+let ccomp_type = ""
+let bytecomp_c_compiler = ""
+let bytecomp_c_libraries = ""
+let native_c_compiler = ""
 let native_c_libraries = ""
-let native_pack_linker = "ld -r -arch x86_64  -o "
+let native_pack_linker = ""
 let ranlib = "ranlib"
 let ar = "ar"
-let cc_profile = "-pg"
-let mkdll = "gcc -bundle -flat_namespace -undefined suppress -Wl,-no_compact_unwind"
-let mkexe = "gcc -Wl,-no_compact_unwind"
-let mkmaindll = "gcc -bundle -flat_namespace -undefined suppress -Wl,-no_compact_unwind"
+let cc_profile = ""
+let mkdll = ""
+let mkexe = ""
+let mkmaindll = ""
 
 let exec_magic_number = "Caml1999X011"
 and cmi_magic_number = "Caml1999I017"
@@ -74,9 +74,9 @@ let stack_threshold = 256 (* see byterun/config.h *)
 
 let architecture = "amd64"
 let model = "default"
-let system = "macosx"
+let system = ""
 
-let asm = "clang -arch x86_64 -c"
+let asm = ""
 let asm_cfi_supported = true
 let with_frame_pointers = false
 
@@ -85,8 +85,8 @@ let ext_asm = ".s"
 let ext_lib = ".a"
 let ext_dll = ".so"
 
-let host = "x86_64-apple-darwin15.0.0"
-let target = "x86_64-apple-darwin15.0.0"
+let host = ""
+let target = ""
 
 let default_executable_name =
   match Sys.os_type with

--- a/jscomp/bin/config.mli
+++ b/jscomp/bin/config.mli
@@ -1,0 +1,129 @@
+(***********************************************************************)
+(*                                                                     *)
+(*                                OCaml                                *)
+(*                                                                     *)
+(*            Xavier Leroy, projet Cristal, INRIA Rocquencourt         *)
+(*                                                                     *)
+(*  Copyright 1996 Institut National de Recherche en Informatique et   *)
+(*  en Automatique.  All rights reserved.  This file is distributed    *)
+(*  under the terms of the Q Public License version 1.0.               *)
+(*                                                                     *)
+(***********************************************************************)
+
+(* System configuration *)
+
+val version: string
+        (* The current version number of the system *)
+
+val standard_library: string
+        (* The directory containing the standard libraries *)
+val standard_runtime: string
+        (* The full path to the standard bytecode interpreter ocamlrun *)
+val ccomp_type: string
+        (* The "kind" of the C compiler, assembler and linker used: one of
+               "cc" (for Unix-style C compilers)
+               "msvc" (for Microsoft Visual C++ and MASM) *)
+val bytecomp_c_compiler: string
+        (* The C compiler to use for compiling C files
+           with the bytecode compiler *)
+val bytecomp_c_libraries: string
+        (* The C libraries to link with custom runtimes *)
+val native_c_compiler: string
+        (* The C compiler to use for compiling C files
+           with the native-code compiler *)
+val native_c_libraries: string
+        (* The C libraries to link with native-code programs *)
+val native_pack_linker: string
+        (* The linker to use for packaging (ocamlopt -pack) and for partial
+           links (ocamlopt -output-obj). *)
+val mkdll: string
+        (* The linker command line to build dynamic libraries. *)
+val mkexe: string
+        (* The linker command line to build executables. *)
+val mkmaindll: string
+        (* The linker command line to build main programs as dlls. *)
+val ranlib: string
+        (* Command to randomize a library, or "" if not needed *)
+val ar: string
+        (* Name of the ar command, or "" if not needed  (MSVC) *)
+val cc_profile : string
+        (* The command line option to the C compiler to enable profiling. *)
+
+val load_path: string list ref
+        (* Directories in the search path for .cmi and .cmo files *)
+
+val interface_suffix: string ref
+        (* Suffix for interface file names *)
+
+val exec_magic_number: string
+        (* Magic number for bytecode executable files *)
+val cmi_magic_number: string
+        (* Magic number for compiled interface files *)
+val cmo_magic_number: string
+        (* Magic number for object bytecode files *)
+val cma_magic_number: string
+        (* Magic number for archive files *)
+val cmx_magic_number: string
+        (* Magic number for compilation unit descriptions *)
+val cmxa_magic_number: string
+        (* Magic number for libraries of compilation unit descriptions *)
+val ast_intf_magic_number: string
+        (* Magic number for file holding an interface syntax tree *)
+val ast_impl_magic_number: string
+        (* Magic number for file holding an implementation syntax tree *)
+val cmxs_magic_number: string
+        (* Magic number for dynamically-loadable plugins *)
+val cmt_magic_number: string
+        (* Magic number for compiled interface files *)
+
+val max_tag: int
+        (* Biggest tag that can be stored in the header of a regular block. *)
+val lazy_tag : int
+        (* Normally the same as Obj.lazy_tag.  Separate definition because
+           of technical reasons for bootstrapping. *)
+val max_young_wosize: int
+        (* Maximal size of arrays that are directly allocated in the
+           minor heap *)
+val stack_threshold: int
+        (* Size in words of safe area at bottom of VM stack,
+           see byterun/config.h *)
+
+val architecture: string
+        (* Name of processor type for the native-code compiler *)
+val model: string
+        (* Name of processor submodel for the native-code compiler *)
+val system: string
+        (* Name of operating system for the native-code compiler *)
+
+val asm: string
+        (* The assembler (and flags) to use for assembling
+           ocamlopt-generated code. *)
+
+val asm_cfi_supported: bool
+        (* Whether assembler understands CFI directives *)
+val with_frame_pointers : bool
+        (* Whether assembler should maintain frame pointers *)
+
+val ext_obj: string
+        (* Extension for object files, e.g. [.o] under Unix. *)
+val ext_asm: string
+        (* Extension for assembler files, e.g. [.s] under Unix. *)
+val ext_lib: string
+        (* Extension for library files, e.g. [.a] under Unix. *)
+val ext_dll: string
+        (* Extension for dynamically-loaded libraries, e.g. [.so] under Unix.*)
+
+val default_executable_name: string
+        (* Name of executable produced by linking if none is given with -o,
+           e.g. [a.out] under Unix. *)
+
+val systhread_supported : bool
+        (* Whether the system thread library is implemented *)
+
+val host : string
+        (* Whether the compiler is a cross-compiler *)
+
+val target : string
+        (* Whether the compiler is a cross-compiler *)
+
+val print_config : out_channel -> unit;;

--- a/jscomp/compiler_internal.mllib
+++ b/jscomp/compiler_internal.mllib
@@ -6,7 +6,7 @@
 
 ../ocaml/utils/misc
 ../ocaml/utils/tbl
-../ocaml/utils/config
+# ../ocaml/utils/config
 ../ocaml/utils/clflags
 ../ocaml/utils/terminfo
 ../ocaml/utils/ccomp
@@ -84,6 +84,3 @@
 ../ocaml/bytecomp/bytepackager
 ../ocaml/driver/errors
 ../ocaml/driver/compile
-
-
-include compiler.mllib

--- a/jscomp/lib/js.ml
+++ b/jscomp/lib/js.ml
@@ -42,7 +42,7 @@ external log : 'a -> unit = "js_dump"
 
 
 
-type any = Obj.t 
+type any = Obj.t
 
 external erase : 'a -> any = "%identity" 
 external cast : any -> 'a = "%identity" 
@@ -153,17 +153,17 @@ module Float = struct
 end
 
 module Caml_obj = struct 
-  external set_tag : Obj.t -> int -> unit = "caml_obj_set_tag"
-  external set_length : Obj.t -> int -> unit = "js_obj_set_length"
-  external length : Obj.t -> int = "js_obj_length"
-  external tag : Obj.t -> int = "caml_obj_tag"
-  external set_tag : Obj.t -> int -> unit = "caml_obj_set_tag"
-  external uninitialized_object : int -> int -> Obj.t = "js_uninitialized_object"
-  external is_instance_array : Obj.t -> bool = 
+  external set_tag : any -> int -> unit = "caml_obj_set_tag"
+  external set_length : any -> int -> unit = "js_obj_set_length"
+  external length : any -> int = "js_obj_length"
+  external tag : any -> int = "caml_obj_tag"
+  external set_tag : any -> int -> unit = "caml_obj_set_tag"
+  external uninitialized_object : int -> int -> any = "js_uninitialized_object"
+  external is_instance_array : any -> bool = 
     "js_is_instance_array" (* use Array.isArray instead*)
-  external size_of_any : Obj.t -> 'a Def.t =
+  external size_of_any : any -> 'a Def.t =
     "length" [@@bs.get]
-  external tag_of_any : Obj.t -> 'a Def.t =
+  external tag_of_any : any -> 'a Def.t =
     "tag" [@@bs.get]
 end
 

--- a/jscomp/runtime/Makefile
+++ b/jscomp/runtime/Makefile
@@ -7,7 +7,7 @@ SOURCE_LIST := $(shell cat runtime.mllib)
 RUNTIME := $(addsuffix .cmj, $(SOURCE_LIST))
 
 
-COMPFLAGS += $(MODULE_FLAGS) -w -40
+COMPFLAGS += $(MODULE_FLAGS) -w -40 
 
 
 

--- a/jscomp/runtime/caml_array.ml
+++ b/jscomp/runtime/caml_array.ml
@@ -26,13 +26,6 @@
 
 
 
-
-
-
-
-
-
-
 let caml_array_sub (x : 'a array) (offset : int) (len : int) = 
   let result = Js.Array.new_uninitialized len  in
   let j = ref 0 and i = ref offset in

--- a/jscomp/runtime/caml_int64.js
+++ b/jscomp/runtime/caml_int64.js
@@ -79,8 +79,8 @@ function sub(x, y) {
 }
 
 function lsl_(x, numBits) {
-  var lo = x[/* lo */1];
   if (numBits) {
+    var lo = x[/* lo */1];
     if (numBits >= 32) {
       return /* record */[
               /* hi */(lo << (numBits - 32 | 0)),
@@ -101,8 +101,8 @@ function lsl_(x, numBits) {
 }
 
 function lsr_(x, numBits) {
-  var hi = x[/* hi */0];
   if (numBits) {
+    var hi = x[/* hi */0];
     var offset = numBits - 32 | 0;
     if (offset) {
       if (offset > 0) {
@@ -134,8 +134,8 @@ function lsr_(x, numBits) {
 }
 
 function asr_(x, numBits) {
-  var hi = x[/* hi */0];
   if (numBits) {
+    var hi = x[/* hi */0];
     if (numBits < 32) {
       var hi$1 = (hi >> numBits);
       var lo = (hi << (32 - numBits | 0)) | (x[/* lo */1] >>> numBits);

--- a/jscomp/test/ext_string.js
+++ b/jscomp/test/ext_string.js
@@ -54,6 +54,25 @@ function split_by($staropt$star, is_delim, str) {
   };
 }
 
+function trim(s) {
+  var i = 0;
+  var j = s.length;
+  while(function () {
+        var u = s.charCodeAt(i);
+        return +(i < j && (u === /* "\t" */9 || u === /* "\n" */10 || u === /* " " */32));
+      }()) {
+    i = i + 1 | 0;
+  };
+  var k = j - 1 | 0;
+  while(function () {
+        var u = s.charCodeAt(k);
+        return +(k >= i && (u === /* "\t" */9 || u === /* "\n" */10 || u === /* " " */32));
+      }()) {
+    k = k - 1 | 0;
+  };
+  return $$String.sub(s, i, (k - i | 0) + 1 | 0);
+}
+
 function split(keep_empty, str, on) {
   if (str === "") {
     return /* [] */0;
@@ -314,6 +333,7 @@ function starts_with_and_number(s, offset, beg) {
 }
 
 exports.split_by               = split_by;
+exports.trim                   = trim;
 exports.split                  = split;
 exports.starts_with            = starts_with;
 exports.ends_with              = ends_with;


### PR DESCRIPTION
… patching the compiler

```ocaml
make big-world
```
should just works so that user does not need do `opam switch`

Also fixes #339 