### PR TITLE
use extension point for bs.obj instead

### DIFF
--- a/jscomp/test/chain_code_test.ml
+++ b/jscomp/test/chain_code_test.ml
@@ -24,6 +24,6 @@ let f4 h x y =
 (*   ##(draw (x,y)) *)
 (*   ##(draw(x,y)) *)
 let () = 
-  eq __LOC__ 32  (f2 ({ x = {y = {z = 32}}} [@bs.obj]))
+  eq __LOC__ 32  [%bs.obj f2 { x = {y = {z = 32}}} ]
 
 let () = Mt.from_pair_suites __FILE__ !suites

--- a/jscomp/test/config2_test.ml
+++ b/jscomp/test/config2_test.ml
@@ -14,14 +14,14 @@ class type v2 = object
 end 
 
 type vv = 
-  < 
+  [%bs.obj: < 
     hey : int * int -> int 
-  > [@bs.obj] [@uncurry]
+  >  [@uncurry] ]
 
 type vv2 = 
-  < 
+  [%bs.obj: < 
     hey : int * int -> int 
-  > [@bs.obj] 
+  > ] 
 
 
 let hh (x : v) : v2 = x 

--- a/jscomp/test/config2_test.mli
+++ b/jscomp/test/config2_test.mli
@@ -10,14 +10,14 @@ class type v2 = object
 end 
 
 type vv = 
-  < 
+  [%bs.obj: < 
     hey : int * int -> int 
-  > [@bs.obj] [@uncurry]
+  >  [@uncurry]]
 
 type vv2 = 
-  < 
+  [%bs.obj: < 
     hey : int * int -> int 
-  > [@bs.obj] 
+  > ]
 
 
 val test_v : v Js.t -> int

--- a/jscomp/test/demo.ml
+++ b/jscomp/test/demo.ml
@@ -84,11 +84,11 @@ class type grid  =
   object [@uncurry]
     inherit widget
     inherit measure
-    method columns_set : (<width : int; .. > [@bs.obj])  array -> unit 
+    method columns_set : [%bs.obj: <width : int; .. >  ]  array -> unit 
     method titleRows_set : 
-      (<label : <text : string; .. >   ; ..>  [@bs.obj])   array -> unit 
+      [%bs.obj: <label : <text : string; .. >   ; ..> ]   array -> unit 
     method dataSource_set :
-      (<label : <text : string; .. >   ; ..> [@bs.obj])  array array -> unit  
+      [%bs.obj: <label : <text : string; .. >   ; ..>  ]  array array -> unit  
   end
 
 external set_interval : (unit -> unit [@uncurry]) -> float -> unit  =  "setInterval"
@@ -186,11 +186,8 @@ let ui_layout
     stackPanel##addChild grid;
     stackPanel##addChild inputCode;
     stackPanel##addChild button;
-    (* {label =  {text } [@bs.obj] }[@bs.obj] 
-       should also work 
-    *)
-    let mk_titleRow text = {label =  {text }  }[@bs.obj] in
-    let u = {width =  200} [@bs.obj] in
+    let mk_titleRow text = [%bs.obj {label =  {text }  } ] in
+    let u =  [%bs.obj {width =  200} ]  in
     grid##minHeight_set 300;
     grid##titleRows_set
         [| mk_titleRow "Ticker";

--- a/jscomp/test/gpr_459_test.ml
+++ b/jscomp/test/gpr_459_test.ml
@@ -9,16 +9,16 @@ let eq loc x y =
 
 
 
-let uu = {
+let uu = [%bs.obj{
   _'x_ = 3;
 
-} [@bs.obj]
+} ]
 
-let uu2 = {
+let uu2 = [%bs.obj{
   then_ = 1;
   catch = 2;
   _'x_ = 3 
-} [@bs.obj]
+}]
 
 let hh = uu##_'x_
 

--- a/jscomp/test/http_types.ml
+++ b/jscomp/test/http_types.ml
@@ -15,23 +15,23 @@
 type req 
 
 type resp = 
-  <
+  [%bs.obj: <
    statusCode_set : int -> unit  ;
    setHeader : string * string -> unit ;
    end_ : string ->  unit 
-  > [@bs.obj] [@uncurry]
+  >  [@uncurry] ]
 
 type server = 
-  <
+  [%bs.obj: <
     listen : int * string *  (unit -> unit) -> unit 
-  > [@bs.obj] [@uncurry]
+  >  [@uncurry] ]
 
 
 
 type http = 
-  <
+  [%bs.obj: <
    createServer : (req  * resp  -> unit ) ->  server
-  > [@bs.obj] [@uncurry]
+  >  [@uncurry] ]
 
 
 external http : http  = "http"  [@@bs.val_of_module ]

--- a/jscomp/test/method_name_test.ml
+++ b/jscomp/test/method_name_test.ml
@@ -28,9 +28,9 @@ let ff x i v =
 *)
 
 
-let u = { _Content'type = "x" } [@bs.obj]
+let u = [%bs.obj { _Content'type = "x" }]
 
-let h = { open_ = 3 ; end_ = 32 } [@bs.obj]
+let h = [%bs.obj { open_ = 3 ; end_ = 32 } ]
 
 let hg x = 
   x##open_ + x ##end_

--- a/jscomp/test/nested_obj_literal.ml
+++ b/jscomp/test/nested_obj_literal.ml
@@ -1,6 +1,7 @@
 
 
-let structural_obj = { x = { y = { z = 3 }}} [@bs.obj]
+let structural_obj = 
+  [%bs.obj { x = { y = { z = 3 }}} ]
 (* compiler inferred type :
   val structural_obj : < x : < y : < z : int >  >  > [@bs.obj] *)
 

--- a/jscomp/test/nested_obj_test.ml
+++ b/jscomp/test/nested_obj_test.ml
@@ -1,7 +1,7 @@
 
 
-type f_obj = < x : < y : < z : int > > > [@bs.obj]
-let f : f_obj = { x = { y = { z = 3 }}} [@bs.obj]
+type f_obj = [%bs.obj:< x : < y : < z : int > > > ]
+let f : f_obj = [%bs.obj { x = { y = { z = 3 }}}]
 
 type 'a x = {x : 'a }
 type 'a y = {y : 'a}
@@ -9,5 +9,35 @@ type 'a z = { z : 'a}
 let f_record   =  { x = { y = { z = 3 }}} 
 
 
-let f : f_obj = { x = { y = ({ z = 3 }[@bs.obj]) }} [@bs.obj]
 
+
+let f : f_obj = [%bs.obj { x = { y = ({ z = 3 }) }}]
+
+
+let f2 : [%bs.obj: 
+  < x : < y : < z : int > > >  list  * < x : < y : < z : int > > > array
+] = 
+  [%bs.obj 
+    [ 
+      { x = { y = { z = 3 }}} ;
+      { x = { y = { z = 31 }}} ;
+    ] , 
+    [| 
+      { x = { y = { z = 3 }}} ;
+      { x = { y = { z = 31 }}} ;
+    |]
+  ]
+
+let f3 = 
+  [%bs.obj
+    ({x = {y = {z = 3 }}} : < x : < y : < z : int > > >  )
+  ]
+(* how about 
+let f x = [%bs.obj (x : < x : int > ) ] 
+*)
+(* 
+advantage of extension point
+: robust, *control the entry point*, entry point can be more flexible easy to write , 
+disdvantage
+: more intrusive, does not work with ocamldep
+*)

--- a/jscomp/test/obj_literal_ppx.ml
+++ b/jscomp/test/obj_literal_ppx.ml
@@ -1,8 +1,9 @@
 
 
-let a = { x = 3 ; y = [| 1|]} [@bs.obj]
+let a = [%bs.obj { x = 3 ; y = [| 1|]} ]
 
-let b = { x = 3 ; y = [| 1 |]; z = 3; u = fun [@uncurry] (x,y) -> x + y } [@bs.obj]
+let b = 
+  [%bs.obj { x = 3 ; y = [| 1 |]; z = 3; u = fun [@uncurry] (x,y) -> x + y } ]
 
 let f obj = 
   obj ## x + Array.length (obj ## y)

--- a/jscomp/test/promise.ml
+++ b/jscomp/test/promise.ml
@@ -21,14 +21,14 @@ let () =
 
 
 let u = 
-  { then_ = 3 ; 
+  [%bs.obj{ then_ = 3 ; 
     catch  = 32
-  }  [@bs.obj]
+  }]
 
 
-let uu = {
+let uu = [%bs.obj{
   _'x_ = 3
-} [@bs.obj]
+}]
 
 
 let hh = uu##_'x_

--- a/jscomp/test/test_index.ml
+++ b/jscomp/test/test_index.ml
@@ -4,9 +4,9 @@
 
 
 
-let f (x : < case : int ->  'a ; 
+let f (x : [%bs.obj: < case : int ->  'a ; 
             case_set : int * int -> unit ;
-            .. > [@uncurry] [@bs.obj])
+            .. > [@uncurry] ] )
  = 
   x ## case_set (3, 2) ;
   x ## case 3 
@@ -24,16 +24,16 @@ let ff (x : int case  Js.t)
 
 
 let h (x : 
-         < case : (int ->  (int -> 'a ) ); .. >  [@uncurry] [@bs.obj]) = 
+         [%bs.obj:< case : (int ->  (int -> 'a ) ); .. >  [@uncurry] ]) = 
   let a = x##case 3 in 
   a 2 [@uncurry]   
 
 
 type x_obj =  
-  < 
+  [%bs.obj: < 
     case : int ->  int ; 
     case_set : int * int -> unit ;
-  >  [@uncurry] [@bs.obj]
+  >  [@uncurry] ]
 
 let f_ext 
     (x : x_obj)
@@ -42,9 +42,9 @@ let f_ext
   x ## case 3 
 
 type 'a h_obj = 
-  < 
+  [%bs.obj: < 
     case : int ->  (int -> 'a)
-  > [@uncurry] [@bs.obj]
+  > [@uncurry] ]
 
 let h_ext  (x : 'a h_obj) = 
   let  a = x ##case 3 in 

--- a/lib/js/test/nested_obj_test.js
+++ b/lib/js/test/nested_obj_test.js
@@ -10,8 +10,60 @@ var f = {
   }
 };
 
+var f2_000 = /* :: */[
+  {
+    x: {
+      y: {
+        z: 3
+      }
+    }
+  },
+  /* :: */[
+    {
+      x: {
+        y: {
+          z: 31
+        }
+      }
+    },
+    /* [] */0
+  ]
+];
+
+var f2_001 = /* array */[
+  {
+    x: {
+      y: {
+        z: 3
+      }
+    }
+  },
+  {
+    x: {
+      y: {
+        z: 31
+      }
+    }
+  }
+];
+
+var f2 = /* tuple */[
+  f2_000,
+  f2_001
+];
+
+var f3 = {
+  x: {
+    y: {
+      z: 3
+    }
+  }
+};
+
 var f_record = /* record */[/* x : record */[/* y : record */[/* z */3]]];
 
 exports.f_record = f_record;
 exports.f        = f;
+exports.f2       = f2;
+exports.f3       = f3;
 /*  Not a pure module */


### PR DESCRIPTION
TO justify we move from `[@bs.obj]` into `[%bs.obj]`

we want to support such cases

```ocaml
  [%bs.obj                                                                                                                                                                                  
    [                                                                                                                                                                                       
      { x = { y = { z = 3 }}} ;                                                                                                                                                             
      { x = { y = { z = 31 }}} ;                                                                                                                                                            
    ] ,                                                                                                                                                                                     
    [|                                                                                                                                                                                      
      { x = { y = { z = 3 }}} ;                                                                                                                                                             
      { x = { y = { z = 31 }}} ;                                                                                                                                                            
    |]                                                                                                                                                                                      
  ]         
```

advantage of extension (compared with attributes):
1.  flexible entry point, robust
disadvantage
1. intrusive, affect ocamldep

here it's okay for `bs.obj` to be intrusive, since we don't expect such code work on other backend except js backend
