### PR TITLE
better handling of js object methdo, remove Levent to avoid pattern m…

### DIFF
--- a/jscomp/lam.mli
+++ b/jscomp/lam.mli
@@ -129,7 +129,7 @@ type primitive =
   (* Integer to external pointer *)
 
   | Pdebugger
-  | Pjs_unsafe_downgrade
+  | Pjs_unsafe_downgrade of string * Location.t
   | Pinit_mod
   | Pupdate_mod
   | Pjs_fn_make of int 
@@ -179,8 +179,11 @@ and  t =  private
   | Lfor of ident * t * t * Asttypes.direction_flag * t
   | Lassign of ident * t
   | Lsend of Lambda.meth_kind * t * t * t list * Location.t
-  | Levent of t * Lambda.lambda_event
   | Lifused of ident * t
+  (* | Levent of t * Lambda.lambda_event 
+     [Levent] in the branch hurt pattern match, 
+     we should use record for trivial debugger info
+  *)
 
 
 module Prim : sig 

--- a/jscomp/lam_beta_reduce.ml
+++ b/jscomp/lam_beta_reduce.ml
@@ -169,9 +169,6 @@ let rewrite (map :   (Ident.t, _) Hashtbl.t)
       let o = aux o in 
       let ll = List.map aux ll in
       Lam.send u  m  o  ll v
-    | Levent(l, event) ->
-      let l = aux l in
-      Lam.event  l event
     | Lifused(v, l) -> 
       let l = aux l in 
       Lam.ifused v  l

--- a/jscomp/lam_compile_primitive.ml
+++ b/jscomp/lam_compile_primitive.ml
@@ -46,7 +46,7 @@ let translate
     (prim : Lam.primitive)
     (args : J.expression list) : J.expression = 
   match prim with
-  | Pjs_unsafe_downgrade
+  | Pjs_unsafe_downgrade _
   | Pdebugger 
   | Pjs_fn_run _ 
   | Pjs_fn_make _
@@ -649,7 +649,7 @@ let translate
   | Pbigstring_set_32 _
   | Pbigstring_set_64 _
     -> 
-      let comment = "Missing primitve" in       
+      let comment = "Missing primitive" in       
       let s = Lam_util.string_of_primitive prim in
       let warn = Printf.sprintf  "%s: %s\n" comment s in
       Ext_log.warn __LOC__ "%s"  warn;

--- a/jscomp/lam_dispatch_primitive.ml
+++ b/jscomp/lam_dispatch_primitive.ml
@@ -1039,7 +1039,7 @@ let query (prim : Lam_compile_env.primitive_description)
 
     | _ -> 
 
-      let comment = "Missing primitve" in       
+      let comment = "Missing primitive" in       
       Ext_log.warn __LOC__  "%s: %s when compiling %s\n" comment prim_name 
         (Js_config.get_current_file ()) ;
       E.not_implemented prim_name

--- a/jscomp/lam_exit_code.ml
+++ b/jscomp/lam_exit_code.ml
@@ -83,8 +83,6 @@ let rec has_exit_code exits  (lam : Lam.t)  : bool =
     has_exit_code exits obj ||
     has_exit_code exits l ||
     List.exists (has_exit_code exits) ls
-  | Levent (b,_) 
-    -> has_exit_code exits b
   | Lifused (_,b) 
     -> has_exit_code exits b
 

--- a/jscomp/lam_group.ml
+++ b/jscomp/lam_group.ml
@@ -59,7 +59,6 @@ let rec flatten
     (acc :  t list ) 
     (lam : Lam.t) :  Lam.t *  t list = 
   match lam with 
-  | Levent (e,_) -> flatten acc e (* TODO: We stripped event in the beginning*)
   | Llet (str,id,arg,body) -> 
     let (res,l) = flatten acc arg  in
     flatten (Single(str, id, res ) :: l) body
@@ -67,7 +66,6 @@ let rec flatten
   (*   match res with *)
   (*   | Llet _ -> assert false *)
   (*   | Lletrec _-> assert false *)
-  (*   | Levent _ -> assert false *)
   (*   | _ ->  *)
   (*       Format.fprintf  Format.err_formatter "%a@." Printlambda.lambda res ; *)
   (*       Format.pp_print_flush Format.err_formatter (); *)
@@ -119,7 +117,6 @@ let deep_flatten
       (acc :  t list ) 
       (lam : Lam.t) :  Lam.t *  t list = 
     match lam with 
-    | Levent (e,_) -> flatten acc e (* TODO: We stripped event in the beginning*)
     | Llet (str, id, 
             (Lprim {primitive = Pccall 
                       {prim_name = 
@@ -175,7 +172,6 @@ let deep_flatten
 
   and aux  (lam : Lam.t) : Lam.t= 
     match lam with 
-    | Levent (e,_) -> aux  e (* TODO: We stripped event in the beginning*)
     | Llet _ -> 
       let res, groups = flatten [] lam  
       in lambda_of_groups res groups
@@ -359,6 +355,5 @@ let deep_flatten
     | Lsend(u, m, o, ll, v) -> 
       Lam.send u (aux m) (aux o) (List.map aux ll) v
 
-    (* Levent(aux  l, event) *)
     | Lifused(v, l) -> Lam.ifused v (aux  l)
   in aux lam

--- a/jscomp/lam_iter.ml
+++ b/jscomp/lam_iter.ml
@@ -71,8 +71,6 @@ let inner_iter f l =
       f e
   | Lsend (k, met, obj, args, _) ->
       List.iter f (met::obj::args)
-  | Levent (lam, evt) ->
-      f lam
   | Lifused (v, e) ->
       f e
 

--- a/jscomp/lam_pass_alpha_conversion.ml
+++ b/jscomp/lam_pass_alpha_conversion.ml
@@ -124,7 +124,6 @@ let alpha_conversion (meta : Lam_stats.meta) (lam : Lam.t) : Lam.t =
       Lam.assign v (simpl  l)
     | Lsend (u, m, o, ll, v) -> 
       Lam.send u (simpl m) (simpl o) (List.map simpl ll) v
-    | Levent (l, event) -> Lam.event (simpl  l) event
     | Lifused (v, l) -> Lam.ifused v (simpl  l)
   in 
 

--- a/jscomp/lam_pass_collect.ml
+++ b/jscomp/lam_pass_collect.ml
@@ -183,7 +183,6 @@ let collect_helper  (meta : Lam_stats.meta) (lam : Lam.t)  =
            v's refcollect *)
         collect  l
     | Lsend(_, m, o, ll, _) -> List.iter collect  (m::o::ll)
-    | Levent(l, _) -> collect  l
     | Lifused(_, l) -> collect  l in collect lam 
 
 

--- a/jscomp/lam_pass_exits.ml
+++ b/jscomp/lam_pass_exits.ml
@@ -103,7 +103,6 @@ let count_helper  (lam : Lam.t) : (int, int ref) Hashtbl.t  =
     | Lfor(_, l1, l2, dir, l3) -> count l1; count l2; count l3
     | Lassign(_, l) -> count l
     | Lsend(_, m, o, ll, _) -> count m; count o; List.iter count ll
-    | Levent(l, _) -> count l
     | Lifused(_, l) -> count l 
 
   and count_default sw =
@@ -290,8 +289,6 @@ let subst_helper (subst : subst_tbl) query lam =
       Lam.assign v (simplif l)
     | Lsend (k, m, o, ll, loc) ->
       Lam.send k (simplif m) (simplif o) (List.map simplif ll) loc
-    | Levent (l, ev) -> 
-      Lam.event (simplif l) ev
     | Lifused (v, l) -> 
       Lam.ifused v (simplif l)
   in 

--- a/jscomp/lam_pass_lets_dce.ml
+++ b/jscomp/lam_pass_lets_dce.ml
@@ -108,8 +108,6 @@ let rec eliminate_ref id (lam : Lam.t) =
     Lam.send k 
       (eliminate_ref id m) (eliminate_ref id o)
       (List.map (eliminate_ref id) el) loc
-  | Levent(l, ev) ->
-    Lam.event (eliminate_ref id l) ev
   | Lifused(v, e) ->
     Lam.ifused v (eliminate_ref id e)
 
@@ -274,8 +272,6 @@ let lets_helper (count_var : Ident.t -> used_info) lam =
     | Lassign(v, l) -> Lam.assign v (simplif l)
     | Lsend(k, m, o, ll, loc) ->
       Lam.send k (simplif m) (simplif o) (List.map simplif ll) loc
-    | Levent(l, ev) 
-      -> Lam.event (simplif l) ev
   in simplif lam ;;
 
 
@@ -420,7 +416,6 @@ let collect_occurs  lam : occ_tbl =
       count bv l2; 
       count Ident_map.empty l3
     | Lsend(_, m, o, ll, _) -> List.iter (count bv) (m::o::ll)
-    | Levent(l, _) -> count bv l
     | Lifused(v, l) ->
       if used v then count bv l
 

--- a/jscomp/lam_pass_remove_alias.ml
+++ b/jscomp/lam_pass_remove_alias.ml
@@ -273,9 +273,6 @@ let simplify_alias
     | Lsend (u, m, o, ll, v) 
       -> 
       Lam.send u (simpl m) (simpl o) (List.map simpl ll) v
-    | Levent (l, event) 
-      ->
-      Lam.event (simpl  l) event
     | Lifused (v, l) -> Lam.ifused v (simpl  l)
   in 
   simpl lam

--- a/jscomp/lam_print.ml
+++ b/jscomp/lam_print.ml
@@ -104,7 +104,7 @@ let primitive ppf (prim : Lam.primitive) = match prim with
   | Pupdate_mod -> fprintf ppf "update_mod!"
   | Pbytes_to_string -> fprintf ppf "bytes_to_string"
   | Pbytes_of_string -> fprintf ppf "bytes_of_string"
-  | Pjs_unsafe_downgrade -> fprintf ppf "js_unsafe_downgrade"
+  | Pjs_unsafe_downgrade (s,_loc) -> fprintf ppf "##%s" s 
   | Pjs_fn_run i -> fprintf ppf "js_fn_run_%i" i 
   | Pjs_fn_make i -> fprintf ppf "js_fn_make_%i" i
   | Pjs_fn_method i -> fprintf ppf "js_fn_method_%i" i 
@@ -467,20 +467,6 @@ let lambda use_env env ppf v  =
       let kind =
         if k = Self then "self" else if k = Cached then "cache" else "" in
       fprintf ppf "@[<2>(send%s@ %a@ %a%a)@]" kind lam obj lam met args largs
-  | Levent(expr, _ev) ->
-      lam ppf expr
-      (* let kind = *)
-      (*  match ev.lev_kind with *)
-      (*  | Lev_before -> "before" *)
-      (*  | Lev_after _  -> "after" *)
-      (*  | Lev_function -> "funct-body" in *)
-      (* fprintf ppf "@[<2>(%s %s(%i)%s:%i-%i@ %a)@]" kind *)
-      (*         ev.lev_loc.Location.loc_start.Lexing.pos_fname *)
-      (*         ev.lev_loc.Location.loc_start.Lexing.pos_lnum *)
-      (*         (if ev.lev_loc.Location.loc_ghost then "<ghost>" else "") *)
-      (*         ev.lev_loc.Location.loc_start.Lexing.pos_cnum *)
-      (*         ev.lev_loc.Location.loc_end.Lexing.pos_cnum *)
-      (*         lam expr *)
   | Lifused(id, expr) ->
       fprintf ppf "@[<2>(ifused@ %a@ %a)@]" Ident.print id lam expr
 

--- a/jscomp/lam_stats_util.ml
+++ b/jscomp/lam_stats_util.ml
@@ -183,7 +183,6 @@ let rec get_arity
     all_lambdas meta [l2;l3]
   | Lsequence(_, l2) -> get_arity meta l2 
   | Lsend(u, m, o, ll, v) -> NA
-  | Levent(l, event) -> NA
   | Lifused(v, l) -> NA 
   | Lwhile _ 
   | Lfor _  

--- a/jscomp/lam_util.ml
+++ b/jscomp/lam_util.ml
@@ -128,8 +128,6 @@ let subst_lambda (s : Lam.t Ident_map.t) lam =
       Lam.assign id (subst e)
     | Lsend (k, met, obj, args, loc) ->
       Lam.send k (subst met) (subst obj) (List.map subst args) loc
-    | Levent (lam, evt)
-      -> Lam.event (subst lam) evt
     | Lifused (v, e) -> Lam.ifused v (subst e)
   and subst_decl (id, exp) = (id, subst exp)
   and subst_case (key, case) = (key, subst case)
@@ -424,5 +422,5 @@ let free_variables l =
     | Lconst _ | Lapply _
     | Lprim _ | Lswitch _ | Lstringswitch _ | Lstaticraise _
     | Lifthenelse _ | Lsequence _ | Lwhile _
-    | Lsend _ | Levent _ | Lifused _ -> ()
+    | Lsend _  | Lifused _ -> ()
   in free l; !fv

--- a/jscomp/syntax/ast_comb.ml
+++ b/jscomp/syntax/ast_comb.ml
@@ -57,6 +57,35 @@ let create_local_external loc
        pexp_loc = loc
      })
 
+let local_extern_cont loc 
+     ?(pval_attributes=[])
+     ~pval_prim
+     ~pval_type 
+     ?(local_module_name = "J")
+     ?(local_fun_name = "unsafe_expr")
+     (cb : Parsetree.expression -> 'a) 
+  : Parsetree.expression_desc = 
+  Pexp_letmodule
+    ({txt = local_module_name; loc},
+     {pmod_desc =
+        Pmod_structure
+          [{pstr_desc =
+              Pstr_primitive
+                {pval_name = {txt = local_fun_name; loc};
+                 pval_type ;
+                 pval_loc = loc;
+                 pval_prim ;
+                 pval_attributes };
+            pstr_loc = loc;
+           }];
+      pmod_loc = loc;
+      pmod_attributes = []},
+     cb {pexp_desc = Pexp_ident {txt = Ldot (Lident local_module_name, local_fun_name); 
+                                 loc};
+         pexp_attributes = [] ;
+         pexp_loc = loc}
+)
+
 open Ast_helper 
 
 let exp_apply_no_label ?loc ?attrs a b = 

--- a/jscomp/syntax/ast_comb.mli
+++ b/jscomp/syntax/ast_comb.mli
@@ -30,6 +30,15 @@ val create_local_external : Location.t ->
   ?local_fun_name:string ->
   (Asttypes.label * Parsetree.expression) list -> Parsetree.expression_desc
 
+val local_extern_cont : 
+  Location.t ->
+  ?pval_attributes:Parsetree.attributes ->
+  pval_prim:string list ->
+  pval_type:Parsetree.core_type ->
+  ?local_module_name:string ->
+  ?local_fun_name:string ->
+  (Parsetree.expression -> Parsetree.expression) -> Parsetree.expression_desc
+
 val exp_apply_no_label : 
   ?loc:Location.t ->
   ?attrs:Parsetree.attributes ->


### PR DESCRIPTION
…atch disaster

having 
```ocaml
type desc = 
  | Lvar 
  | ..
and t = {desc : desc; event : lambda_event_option}
```
this is better than `Levent`...