### PR TITLE
prepare method ppx support

### DIFF
--- a/jscomp/bin/compiler.ml
+++ b/jscomp/bin/compiler.ml
@@ -1,4 +1,4 @@
-(** Bundled by ocaml_pack 06/29-08:57 *)
+(** Bundled by ocaml_pack 07/04-09:47 *)
 module String_map : sig 
 #1 "string_map.mli"
 (* Copyright (C) 2015-2016 Bloomberg Finance L.P.
@@ -136,6 +136,9 @@ val case : string
 val case_set : string 
 val case_prefix : string
 
+val js_fn_run : string
+val js_method_run : string
+
 end = struct
 #1 "literals.ml"
 (* Copyright (C) 2015-2016 Bloomberg Finance L.P.
@@ -191,13 +194,551 @@ let stdlib = "stdlib"
 
 let imul = "imul" (* signed int32 mul *)
 
-let setter_suffix = "_set"
+let setter_suffix = "#="
 let setter_suffix_len = String.length setter_suffix
 
 let case = "case"
 let case_set = "case_set"
 let case_prefix = "case_"
 
+let js_fn_run = "js_fn_run"
+let js_method_run = "js_method_run"
+
+end
+module Ext_ref : sig 
+#1 "ext_ref.mli"
+(* Copyright (C) 2015-2016 Bloomberg Finance L.P.
+ * 
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In addition to the permissions granted to you by the LGPL, you may combine
+ * or link a "work that uses the Library" with a publicly distributed version
+ * of this file to produce a combined library or application, then distribute
+ * that combined work under the terms of your choosing, with no requirement
+ * to comply with the obligations normally placed on you by section 4 of the
+ * LGPL version 3 (or the corresponding section of a later version of the LGPL
+ * should you choose to use a later version).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
+
+val protect : 'a ref -> 'a -> (unit -> 'b) -> 'b
+
+val protect2 : 'a ref -> 'b ref -> 'a -> 'b -> (unit -> 'c) -> 'c
+
+end = struct
+#1 "ext_ref.ml"
+(* Copyright (C) 2015-2016 Bloomberg Finance L.P.
+ * 
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In addition to the permissions granted to you by the LGPL, you may combine
+ * or link a "work that uses the Library" with a publicly distributed version
+ * of this file to produce a combined library or application, then distribute
+ * that combined work under the terms of your choosing, with no requirement
+ * to comply with the obligations normally placed on you by section 4 of the
+ * LGPL version 3 (or the corresponding section of a later version of the LGPL
+ * should you choose to use a later version).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
+
+let protect r v body =
+  let old = !r in
+  try
+    r := v;
+    let res = body() in
+    r := old;
+    res
+  with x ->
+    r := old;
+    raise x
+
+
+let protect2 r1 r2 v1 v2 body =
+  let old1 = !r1 in
+  let old2 = !r2 in  
+  try
+    r1 := v1;
+    r2 := v2;
+    let res = body() in
+    r1 := old1;
+    r2 := old2;
+    res
+  with x ->
+    r1 := old1;
+    r2 := old2;
+    raise x
+
+end
+module Ext_list : sig 
+#1 "ext_list.mli"
+(* Copyright (C) 2015-2016 Bloomberg Finance L.P.
+ * 
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In addition to the permissions granted to you by the LGPL, you may combine
+ * or link a "work that uses the Library" with a publicly distributed version
+ * of this file to produce a combined library or application, then distribute
+ * that combined work under the terms of your choosing, with no requirement
+ * to comply with the obligations normally placed on you by section 4 of the
+ * LGPL version 3 (or the corresponding section of a later version of the LGPL
+ * should you choose to use a later version).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
+
+
+
+
+
+
+
+
+(** Extension to the standard library [List] module *)
+    
+(** TODO some function are no efficiently implemented. *) 
+
+val filter_map : ('a -> 'b option) -> 'a list -> 'b list 
+
+val excludes : ('a -> bool) -> 'a list -> bool * 'a list
+val exclude_with_fact : ('a -> bool) -> 'a list -> 'a option * 'a list
+val exclude_with_fact2 : 
+  ('a -> bool) -> ('a -> bool) -> 'a list -> 'a option * 'a option * 'a list
+val same_length : 'a list -> 'b list -> bool
+
+val init : int -> (int -> 'a) -> 'a list
+
+val take : int -> 'a list -> 'a list * 'a list
+val try_take : int -> 'a list -> 'a list * int * 'a list 
+
+val exclude_tail : 'a list -> 'a list
+
+val filter_map2 : ('a -> 'b -> 'c option) -> 'a list -> 'b list -> 'c list
+
+val filter_map2i : (int -> 'a -> 'b -> 'c option) -> 'a list -> 'b list -> 'c list
+
+val filter_mapi : (int -> 'a -> 'b option) -> 'a list -> 'b list
+
+val flat_map2 : ('a -> 'b -> 'c list) -> 'a list -> 'b list -> 'c list
+
+val flat_map : ('a -> 'b list) -> 'a list -> 'b list 
+
+val flat_map2_last : (bool -> 'a -> 'b -> 'c list) -> 'a list -> 'b list -> 'c list
+
+val map_last : (bool -> 'a -> 'b) -> 'a list -> 'b list
+
+val stable_group : ('a -> 'a -> bool) -> 'a list -> 'a list list
+
+val drop : int -> 'a list -> 'a list 
+
+val for_all_ret : ('a -> bool) -> 'a list -> 'a option
+
+val for_all_opt : ('a -> 'b option) -> 'a list -> 'b option
+(** [for_all_opt f l] returns [None] if all return [None],  
+    otherwise returns the first one. 
+ *)
+
+val fold : ('a -> 'b -> 'b) -> 'a list -> 'b -> 'b
+(** same as [List.fold_left]. 
+    Provide an api so that list can be easily swapped by other containers  
+ *)
+
+val rev_map_append : ('a -> 'b) -> 'a list -> 'b list -> 'b list
+
+val rev_map_acc : 'a list -> ('b -> 'a) -> 'b list -> 'a list
+
+val rev_iter : ('a -> unit) -> 'a list -> unit
+
+val for_all2_no_exn : ('a -> 'b -> bool) -> 'a list -> 'b list -> bool
+
+val find_opt : ('a -> 'b option) -> 'a list -> 'b option
+
+(** [f] is applied follow the list order *)
+val split_map : ('a -> 'b * 'c) -> 'a list -> 'b list * 'c list       
+
+
+val reduce_from_right : ('a -> 'a -> 'a) -> 'a list -> 'a
+
+(** [fn] is applied from left to right *)
+val reduce_from_left : ('a -> 'a -> 'a) -> 'a list -> 'a
+
+
+type 'a t = 'a list ref
+
+val create_ref_empty : unit -> 'a t
+
+val ref_top : 'a t -> 'a 
+
+val ref_empty : 'a t -> bool
+
+val ref_push : 'a -> 'a t -> unit
+
+val ref_pop : 'a t -> 'a
+
+end = struct
+#1 "ext_list.ml"
+(* Copyright (C) 2015-2016 Bloomberg Finance L.P.
+ * 
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In addition to the permissions granted to you by the LGPL, you may combine
+ * or link a "work that uses the Library" with a publicly distributed version
+ * of this file to produce a combined library or application, then distribute
+ * that combined work under the terms of your choosing, with no requirement
+ * to comply with the obligations normally placed on you by section 4 of the
+ * LGPL version 3 (or the corresponding section of a later version of the LGPL
+ * should you choose to use a later version).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
+
+
+
+
+
+
+
+
+let rec filter_map (f: 'a -> 'b option) xs = 
+  match xs with 
+  | [] -> []
+  | y :: ys -> 
+      begin match f y with 
+      | None -> filter_map f ys
+      | Some z -> z :: filter_map f ys
+      end
+
+let excludes p l =
+  let excluded = ref false in 
+  let rec aux accu = function
+  | [] -> List.rev accu
+  | x :: l -> 
+    if p x then 
+      begin 
+        excluded := true ;
+        aux accu l
+      end
+    else aux (x :: accu) l in
+  let v = aux [] l in 
+  if !excluded then true, v else false,l
+
+let exclude_with_fact p l =
+  let excluded = ref None in 
+  let rec aux accu = function
+  | [] -> List.rev accu
+  | x :: l -> 
+    if p x then 
+      begin 
+        excluded := Some x ;
+        aux accu l
+      end
+    else aux (x :: accu) l in
+  let v = aux [] l in 
+  !excluded , if !excluded <> None then v else l 
+
+
+(** Make sure [p2 x] and [p1 x] will not hold at the same time *)
+let exclude_with_fact2 p1 p2 l =
+  let excluded1 = ref None in 
+  let excluded2 = ref None in 
+  let rec aux accu = function
+  | [] -> List.rev accu
+  | x :: l -> 
+    if p1 x then 
+      begin 
+        excluded1 := Some x ;
+        aux accu l
+      end
+    else if p2 x then 
+      begin 
+        excluded2 := Some x ; 
+        aux accu l 
+      end
+    else aux (x :: accu) l in
+  let v = aux [] l in 
+  !excluded1, !excluded2 , if !excluded1 <> None && !excluded2 <> None then v else l 
+
+
+
+let rec same_length xs ys = 
+  match xs, ys with 
+  | [], [] -> true
+  | _::xs, _::ys -> same_length xs ys 
+  | _, _ -> false 
+
+let  filter_mapi (f: int -> 'a -> 'b option) xs = 
+  let rec aux i xs = 
+    match xs with 
+    | [] -> []
+    | y :: ys -> 
+        begin match f i y with 
+        | None -> aux (i + 1) ys
+        | Some z -> z :: aux (i + 1) ys
+        end in
+  aux 0 xs 
+
+let rec filter_map2 (f: 'a -> 'b -> 'c option) xs ys = 
+  match xs,ys with 
+  | [],[] -> []
+  | u::us, v :: vs -> 
+      begin match f u v with 
+      | None -> filter_map2 f us vs (* idea: rec f us vs instead? *)
+      | Some z -> z :: filter_map2 f us vs
+      end
+  | _ -> invalid_arg "Ext_list.filter_map2"
+
+let filter_map2i (f: int ->  'a -> 'b -> 'c option) xs ys = 
+  let rec aux i xs ys = 
+  match xs,ys with 
+  | [],[] -> []
+  | u::us, v :: vs -> 
+      begin match f i u v with 
+      | None -> aux (i + 1) us vs (* idea: rec f us vs instead? *)
+      | Some z -> z :: aux (i + 1) us vs
+      end
+  | _ -> invalid_arg "Ext_list.filter_map2i" in
+  aux 0 xs ys
+
+let rec rev_map_append  f l1 l2 =
+  match l1 with
+  | [] -> l2
+  | a :: l -> rev_map_append f l (f a :: l2)
+
+let flat_map2 f lx ly = 
+  let rec aux acc lx ly = 
+    match lx, ly with 
+    | [], [] 
+      -> List.rev acc
+    | x::xs, y::ys 
+      ->  aux (List.rev_append (f x y) acc) xs ys
+    | _, _ -> invalid_arg "Ext_list.flat_map2" in
+  aux [] lx ly
+        
+let flat_map f lx =
+  let rec aux acc lx =
+    match lx with
+    | [] -> List.rev acc
+    | y::ys -> aux (List.rev_append ( f y)  acc ) ys in
+  aux [] lx
+
+let rec map2_last f l1 l2 =
+  match (l1, l2) with
+  | ([], []) -> []
+  | [u], [v] -> [f true u v ]
+  | (a1::l1, a2::l2) -> let r = f false  a1 a2 in r :: map2_last f l1 l2
+  | (_, _) -> invalid_arg "List.map2_last"
+
+let rec map_last f l1 =
+  match l1 with
+  | [] -> []
+  | [u]-> [f true u ]
+  | a1::l1 -> let r = f false  a1 in r :: map_last f l1
+
+
+let flat_map2_last f lx ly = List.concat @@ map2_last f lx ly
+
+let init n f = 
+  Array.to_list (Array.init n f)
+
+let take n l = 
+  let arr = Array.of_list l in 
+  let arr_length =  Array.length arr in
+  if arr_length  < n then invalid_arg "Ext_list.take"
+  else (Array.to_list (Array.sub arr 0 n ), 
+        Array.to_list (Array.sub arr n (arr_length - n)))
+
+let try_take n l = 
+  let arr = Array.of_list l in 
+  let arr_length =  Array.length arr in
+  if arr_length  <= n then 
+    l,  arr_length, []
+  else Array.to_list (Array.sub arr 0 n ), n, (Array.to_list (Array.sub arr n (arr_length - n)))
+
+let exclude_tail (x : 'a list) : 'a list = 
+  let rec aux acc x = 
+    match x with 
+    | [] -> invalid_arg "Ext_list.exclude_tail"
+    | [ _ ] ->  List.rev acc
+    | y0::ys -> aux (y0::acc) ys in
+  aux [] x
+
+(* For small list, only need partial equality 
+   {[
+   group (=) [1;2;3;4;3]
+   ;;
+   - : int list list = [[3; 3]; [4]; [2]; [1]]
+   # group (=) [];;
+   - : 'a list list = []
+   ]}
+ *)
+let rec group (cmp : 'a -> 'a -> bool) (lst : 'a list) : 'a list list =
+  match lst with 
+  | [] -> []
+  | x::xs -> 
+      aux cmp x (group cmp xs )
+
+and aux cmp (x : 'a)  (xss : 'a list list) : 'a list list = 
+  match xss with 
+  | [] -> [[x]]
+  | y::ys -> 
+      if cmp x (List.hd y) (* cannot be null*) then
+        (x::y) :: ys 
+      else
+        y :: aux cmp x ys                                 
+  
+let stable_group cmp lst =  group cmp lst |> List.rev 
+
+let rec drop n h = 
+  if n < 0 then invalid_arg "Ext_list.drop"
+  else if n = 0 then h 
+  else if h = [] then invalid_arg "Ext_list.drop"
+  else 
+    drop (n - 1) (List.tl h)
+
+let rec for_all_ret  p = function
+  | [] -> None
+  | a::l -> 
+      if p a 
+      then for_all_ret p l
+      else Some a 
+
+let rec for_all_opt  p = function
+  | [] -> None
+  | a::l -> 
+      match p a with
+      | None -> for_all_opt p l
+      | v -> v 
+
+let fold f l init = 
+  List.fold_left (fun acc i -> f  i init) init l 
+
+let rev_map_acc  acc f l = 
+  let rec rmap_f accu = function
+    | [] -> accu
+    | a::l -> rmap_f (f a :: accu) l
+  in
+  rmap_f acc l
+
+let rec rev_iter f xs =
+    match xs with    
+    | [] -> ()
+    | y :: ys -> 
+      rev_iter f ys ;
+      f y      
+      
+let rec for_all2_no_exn p l1 l2 = 
+  match (l1, l2) with
+  | ([], []) -> true
+  | (a1::l1, a2::l2) -> p a1 a2 && for_all2_no_exn p l1 l2
+  | (_, _) -> false
+
+
+let rec find_no_exn p = function
+  | [] -> None
+  | x :: l -> if p x then Some x else find_no_exn p l
+
+
+let rec find_opt p = function
+  | [] -> None
+  | x :: l -> 
+    match  p x with 
+    | Some _ as v  ->  v
+    | None -> find_opt p l
+
+
+let split_map 
+    ( f : 'a -> ('b * 'c)) (xs : 'a list ) : 'b list  * 'c list = 
+  let rec aux bs cs xs =
+    match xs with 
+    | [] -> List.rev bs, List.rev cs 
+    | u::us -> 
+      let b,c =  f u in aux (b::bs) (c ::cs) us in 
+
+  aux [] [] xs 
+
+
+(*
+   {[
+     reduce_from_right (-) [1;2;3];;
+     - : int = 2
+               # reduce_from_right (-) [1;2;3; 4];;
+     - : int = -2
+                # reduce_from_right (-) [1];;
+     - : int = 1
+               # reduce_from_right (-) [1;2;3; 4; 5];;
+     - : int = 3
+   ]} 
+*)
+let reduce_from_right fn lst = 
+  begin match List.rev lst with
+    | last :: rest -> 
+      List.fold_left  (fun x y -> fn y x) last rest 
+    | _ -> invalid_arg "Ext_list.reduce" 
+  end
+let reduce_from_left fn lst = 
+  match lst with 
+  | first :: rest ->  List.fold_left fn first rest 
+  | _ -> invalid_arg "Ext_list.reduce_from_left"
+
+
+type 'a t = 'a list ref
+
+let create_ref_empty () = ref []
+
+let ref_top x = 
+  match !x with 
+  | y::_ -> y 
+  | _ -> invalid_arg "Ext_list.ref_top"
+
+let ref_empty x = 
+  match !x with [] -> true | _ -> false 
+
+let ref_push x refs = 
+  refs := x :: !refs
+
+let ref_pop refs = 
+  match !refs with 
+  | [] -> invalid_arg "Ext_list.ref_pop"
+  | x::rest -> 
+    refs := rest ; 
+    x     
 
 end
 module String_set : sig 
@@ -724,6 +1265,11 @@ val invalid_argf : ('a, unit, string, 'b) format4 -> 'a
 
 val bad_argf : ('a, unit, string, 'b) format4 -> 'a
 
+
+
+val dump : 'a -> string 
+[@@ocaml.deprecated "only for debugging purpose"]
+
 end = struct
 #1 "ext_pervasives.ml"
 (* Copyright (C) 2015-2016 Bloomberg Finance L.P.
@@ -795,6 +1341,88 @@ let failwithf ~loc fmt = Format.ksprintf (fun s -> failwith (loc ^ s))
 let invalid_argf fmt = Format.ksprintf invalid_arg fmt
 
 let bad_argf fmt = Format.ksprintf (fun x -> raise (Arg.Bad x ) ) fmt
+
+
+let rec dump r =
+  if Obj.is_int r then
+    string_of_int (Obj.magic r : int)
+  else (* Block. *)
+    let rec get_fields acc = function
+      | 0 -> acc
+      | n -> let n = n-1 in get_fields (Obj.field r n :: acc) n
+    in
+    let rec is_list r =
+      if Obj.is_int r then
+        r = Obj.repr 0 (* [] *)
+      else
+        let s = Obj.size r and t = Obj.tag r in
+        t = 0 && s = 2 && is_list (Obj.field r 1) (* h :: t *)
+    in
+    let rec get_list r =
+      if Obj.is_int r then
+        []
+      else
+        let h = Obj.field r 0 and t = get_list (Obj.field r 1) in
+        h :: t
+    in
+    let opaque name =
+      (* XXX In future, print the address of value 'r'.  Not possible
+       * in pure OCaml at the moment.  *)
+      "<" ^ name ^ ">"
+    in
+    let s = Obj.size r and t = Obj.tag r in
+    (* From the tag, determine the type of block. *)
+    match t with
+    | _ when is_list r ->
+      let fields = get_list r in
+      "[" ^ String.concat "; " (List.map dump fields) ^ "]"
+    | 0 ->
+      let fields = get_fields [] s in
+      "(" ^ String.concat ", " (List.map dump fields) ^ ")"
+    | x when x = Obj.lazy_tag ->
+      (* Note that [lazy_tag .. forward_tag] are < no_scan_tag.  Not
+         * clear if very large constructed values could have the same
+         * tag. XXX *)
+      opaque "lazy"
+    | x when x = Obj.closure_tag ->
+      opaque "closure"
+    | x when x = Obj.object_tag ->
+      let fields = get_fields [] s in
+      let _clasz, id, slots =
+        match fields with
+        | h::h'::t -> h, h', t
+        | _ -> assert false
+      in
+      (* No information on decoding the class (first field).  So just print
+         * out the ID and the slots. *)
+      "Object #" ^ dump id ^ " (" ^ String.concat ", " (List.map dump slots) ^ ")"
+    | x when x = Obj.infix_tag ->
+      opaque "infix"
+    | x when x = Obj.forward_tag ->
+      opaque "forward"
+    | x when x < Obj.no_scan_tag ->
+      let fields = get_fields [] s in
+      "Tag" ^ string_of_int t ^
+      " (" ^ String.concat ", " (List.map dump fields) ^ ")"
+    | x when x = Obj.string_tag ->
+      "\"" ^ String.escaped (Obj.magic r : string) ^ "\""
+    | x when x = Obj.double_tag ->
+      string_of_float (Obj.magic r : float)
+    | x when x = Obj.abstract_tag ->
+      opaque "abstract"
+    | x when x = Obj.custom_tag ->
+      opaque "custom"
+    | x when x = Obj.custom_tag ->
+      opaque "final"
+    | x when x = Obj.double_array_tag ->
+      "[|"^
+      String.concat ";"
+        (Array.to_list (Array.map string_of_float (Obj.magic r : float array))) ^
+      "|]"
+    | _ ->
+      opaque (Printf.sprintf "unknown: tag %d size %d" t s)
+
+let dump v = dump (Obj.repr v)
 
 
 end
@@ -1253,6 +1881,15 @@ val check_div_by_zero : bool ref
 
 val get_check_div_by_zero : unit -> bool 
 
+(* It will imply [-noassert] be set too, note from the implmentation point of view, 
+   in the lambda layer, it is impossible to tell whehther it is [assert (3 <> 2)] or 
+   [if (3<>2) then assert false]
+ *)
+val no_any_assert : bool ref 
+
+val set_no_any_assert : unit -> unit
+val get_no_any_assert : unit -> bool 
+
 end = struct
 #1 "js_config.ml"
 (* Copyright (C) 2015-2016 Bloomberg Finance L.P.
@@ -1519,539 +2156,15 @@ let is_same_file () =
   !debug_file <> "" &&  !debug_file = !current_file
 
 let tool_name = "BuckleScript"
-let check_div_by_zero = ref true
 
+let check_div_by_zero = ref true
 let get_check_div_by_zero () = !check_div_by_zero 
 
+let no_any_assert = ref false 
 
+let set_no_any_assert () = no_any_assert := true
+let get_no_any_assert () = !no_any_assert
 
-end
-module Ext_ref : sig 
-#1 "ext_ref.mli"
-(* Copyright (C) 2015-2016 Bloomberg Finance L.P.
- * 
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * In addition to the permissions granted to you by the LGPL, you may combine
- * or link a "work that uses the Library" with a publicly distributed version
- * of this file to produce a combined library or application, then distribute
- * that combined work under the terms of your choosing, with no requirement
- * to comply with the obligations normally placed on you by section 4 of the
- * LGPL version 3 (or the corresponding section of a later version of the LGPL
- * should you choose to use a later version).
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
- * 
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
-
-val protect : 'a ref -> 'a -> (unit -> 'b) -> 'b
-
-val protect2 : 'a ref -> 'b ref -> 'a -> 'b -> (unit -> 'c) -> 'c
-
-end = struct
-#1 "ext_ref.ml"
-(* Copyright (C) 2015-2016 Bloomberg Finance L.P.
- * 
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * In addition to the permissions granted to you by the LGPL, you may combine
- * or link a "work that uses the Library" with a publicly distributed version
- * of this file to produce a combined library or application, then distribute
- * that combined work under the terms of your choosing, with no requirement
- * to comply with the obligations normally placed on you by section 4 of the
- * LGPL version 3 (or the corresponding section of a later version of the LGPL
- * should you choose to use a later version).
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
- * 
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
-
-let protect r v body =
-  let old = !r in
-  try
-    r := v;
-    let res = body() in
-    r := old;
-    res
-  with x ->
-    r := old;
-    raise x
-
-
-let protect2 r1 r2 v1 v2 body =
-  let old1 = !r1 in
-  let old2 = !r2 in  
-  try
-    r1 := v1;
-    r2 := v2;
-    let res = body() in
-    r1 := old1;
-    r2 := old2;
-    res
-  with x ->
-    r1 := old1;
-    r2 := old2;
-    raise x
-
-end
-module Ext_list : sig 
-#1 "ext_list.mli"
-(* Copyright (C) 2015-2016 Bloomberg Finance L.P.
- * 
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * In addition to the permissions granted to you by the LGPL, you may combine
- * or link a "work that uses the Library" with a publicly distributed version
- * of this file to produce a combined library or application, then distribute
- * that combined work under the terms of your choosing, with no requirement
- * to comply with the obligations normally placed on you by section 4 of the
- * LGPL version 3 (or the corresponding section of a later version of the LGPL
- * should you choose to use a later version).
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
- * 
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
-
-
-
-
-
-
-
-
-(** Extension to the standard library [List] module *)
-    
-(** TODO some function are no efficiently implemented. *) 
-
-val filter_map : ('a -> 'b option) -> 'a list -> 'b list 
-
-val excludes : ('a -> bool) -> 'a list -> bool * 'a list
-val exclude_with_fact : ('a -> bool) -> 'a list -> 'a option * 'a list
-val exclude_with_fact2 : 
-  ('a -> bool) -> ('a -> bool) -> 'a list -> 'a option * 'a option * 'a list
-val same_length : 'a list -> 'b list -> bool
-
-val init : int -> (int -> 'a) -> 'a list
-
-val take : int -> 'a list -> 'a list * 'a list
-val try_take : int -> 'a list -> 'a list * int * 'a list 
-
-val exclude_tail : 'a list -> 'a list
-
-val filter_map2 : ('a -> 'b -> 'c option) -> 'a list -> 'b list -> 'c list
-
-val filter_map2i : (int -> 'a -> 'b -> 'c option) -> 'a list -> 'b list -> 'c list
-
-val filter_mapi : (int -> 'a -> 'b option) -> 'a list -> 'b list
-
-val flat_map2 : ('a -> 'b -> 'c list) -> 'a list -> 'b list -> 'c list
-
-val flat_map : ('a -> 'b list) -> 'a list -> 'b list 
-
-val flat_map2_last : (bool -> 'a -> 'b -> 'c list) -> 'a list -> 'b list -> 'c list
-
-val map_last : (bool -> 'a -> 'b) -> 'a list -> 'b list
-
-val stable_group : ('a -> 'a -> bool) -> 'a list -> 'a list list
-
-val drop : int -> 'a list -> 'a list 
-
-val for_all_ret : ('a -> bool) -> 'a list -> 'a option
-
-val for_all_opt : ('a -> 'b option) -> 'a list -> 'b option
-(** [for_all_opt f l] returns [None] if all return [None],  
-    otherwise returns the first one. 
- *)
-
-val fold : ('a -> 'b -> 'b) -> 'a list -> 'b -> 'b
-(** same as [List.fold_left]. 
-    Provide an api so that list can be easily swapped by other containers  
- *)
-
-val rev_map_append : ('a -> 'b) -> 'a list -> 'b list -> 'b list
-
-val rev_map_acc : 'a list -> ('b -> 'a) -> 'b list -> 'a list
-
-val rev_iter : ('a -> unit) -> 'a list -> unit
-
-val for_all2_no_exn : ('a -> 'b -> bool) -> 'a list -> 'b list -> bool
-
-val find_opt : ('a -> 'b option) -> 'a list -> 'b option
-
-(** [f] is applied follow the list order *)
-val split_map : ('a -> 'b * 'c) -> 'a list -> 'b list * 'c list       
-
-
-val reduce_from_right : ('a -> 'a -> 'a) -> 'a list -> 'a
-
-
-type 'a t = 'a list ref
-
-val create_ref_empty : unit -> 'a t
-
-val ref_top : 'a t -> 'a 
-
-val ref_empty : 'a t -> bool
-
-val ref_push : 'a -> 'a t -> unit
-
-val ref_pop : 'a t -> 'a
-
-end = struct
-#1 "ext_list.ml"
-(* Copyright (C) 2015-2016 Bloomberg Finance L.P.
- * 
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * In addition to the permissions granted to you by the LGPL, you may combine
- * or link a "work that uses the Library" with a publicly distributed version
- * of this file to produce a combined library or application, then distribute
- * that combined work under the terms of your choosing, with no requirement
- * to comply with the obligations normally placed on you by section 4 of the
- * LGPL version 3 (or the corresponding section of a later version of the LGPL
- * should you choose to use a later version).
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
- * 
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
-
-
-
-
-
-
-
-
-let rec filter_map (f: 'a -> 'b option) xs = 
-  match xs with 
-  | [] -> []
-  | y :: ys -> 
-      begin match f y with 
-      | None -> filter_map f ys
-      | Some z -> z :: filter_map f ys
-      end
-
-let excludes p l =
-  let excluded = ref false in 
-  let rec aux accu = function
-  | [] -> List.rev accu
-  | x :: l -> 
-    if p x then 
-      begin 
-        excluded := true ;
-        aux accu l
-      end
-    else aux (x :: accu) l in
-  let v = aux [] l in 
-  if !excluded then true, v else false,l
-
-let exclude_with_fact p l =
-  let excluded = ref None in 
-  let rec aux accu = function
-  | [] -> List.rev accu
-  | x :: l -> 
-    if p x then 
-      begin 
-        excluded := Some x ;
-        aux accu l
-      end
-    else aux (x :: accu) l in
-  let v = aux [] l in 
-  !excluded , if !excluded <> None then v else l 
-
-
-(** Make sure [p2 x] and [p1 x] will not hold at the same time *)
-let exclude_with_fact2 p1 p2 l =
-  let excluded1 = ref None in 
-  let excluded2 = ref None in 
-  let rec aux accu = function
-  | [] -> List.rev accu
-  | x :: l -> 
-    if p1 x then 
-      begin 
-        excluded1 := Some x ;
-        aux accu l
-      end
-    else if p2 x then 
-      begin 
-        excluded2 := Some x ; 
-        aux accu l 
-      end
-    else aux (x :: accu) l in
-  let v = aux [] l in 
-  !excluded1, !excluded2 , if !excluded1 <> None && !excluded2 <> None then v else l 
-
-
-
-let rec same_length xs ys = 
-  match xs, ys with 
-  | [], [] -> true
-  | _::xs, _::ys -> same_length xs ys 
-  | _, _ -> false 
-
-let  filter_mapi (f: int -> 'a -> 'b option) xs = 
-  let rec aux i xs = 
-    match xs with 
-    | [] -> []
-    | y :: ys -> 
-        begin match f i y with 
-        | None -> aux (i + 1) ys
-        | Some z -> z :: aux (i + 1) ys
-        end in
-  aux 0 xs 
-
-let rec filter_map2 (f: 'a -> 'b -> 'c option) xs ys = 
-  match xs,ys with 
-  | [],[] -> []
-  | u::us, v :: vs -> 
-      begin match f u v with 
-      | None -> filter_map2 f us vs (* idea: rec f us vs instead? *)
-      | Some z -> z :: filter_map2 f us vs
-      end
-  | _ -> invalid_arg "Ext_list.filter_map2"
-
-let filter_map2i (f: int ->  'a -> 'b -> 'c option) xs ys = 
-  let rec aux i xs ys = 
-  match xs,ys with 
-  | [],[] -> []
-  | u::us, v :: vs -> 
-      begin match f i u v with 
-      | None -> aux (i + 1) us vs (* idea: rec f us vs instead? *)
-      | Some z -> z :: aux (i + 1) us vs
-      end
-  | _ -> invalid_arg "Ext_list.filter_map2i" in
-  aux 0 xs ys
-
-let rec rev_map_append  f l1 l2 =
-  match l1 with
-  | [] -> l2
-  | a :: l -> rev_map_append f l (f a :: l2)
-
-let flat_map2 f lx ly = 
-  let rec aux acc lx ly = 
-    match lx, ly with 
-    | [], [] 
-      -> List.rev acc
-    | x::xs, y::ys 
-      ->  aux (List.rev_append (f x y) acc) xs ys
-    | _, _ -> invalid_arg "Ext_list.flat_map2" in
-  aux [] lx ly
-        
-let flat_map f lx =
-  let rec aux acc lx =
-    match lx with
-    | [] -> List.rev acc
-    | y::ys -> aux (List.rev_append ( f y)  acc ) ys in
-  aux [] lx
-
-let rec map2_last f l1 l2 =
-  match (l1, l2) with
-  | ([], []) -> []
-  | [u], [v] -> [f true u v ]
-  | (a1::l1, a2::l2) -> let r = f false  a1 a2 in r :: map2_last f l1 l2
-  | (_, _) -> invalid_arg "List.map2_last"
-
-let rec map_last f l1 =
-  match l1 with
-  | [] -> []
-  | [u]-> [f true u ]
-  | a1::l1 -> let r = f false  a1 in r :: map_last f l1
-
-
-let flat_map2_last f lx ly = List.concat @@ map2_last f lx ly
-
-let init n f = 
-  Array.to_list (Array.init n f)
-
-let take n l = 
-  let arr = Array.of_list l in 
-  let arr_length =  Array.length arr in
-  if arr_length  < n then invalid_arg "Ext_list.take"
-  else (Array.to_list (Array.sub arr 0 n ), 
-        Array.to_list (Array.sub arr n (arr_length - n)))
-
-let try_take n l = 
-  let arr = Array.of_list l in 
-  let arr_length =  Array.length arr in
-  if arr_length  <= n then 
-    l,  arr_length, []
-  else Array.to_list (Array.sub arr 0 n ), n, (Array.to_list (Array.sub arr n (arr_length - n)))
-
-let exclude_tail (x : 'a list) : 'a list = 
-  let rec aux acc x = 
-    match x with 
-    | [] -> invalid_arg "Ext_list.exclude_tail"
-    | [ _ ] ->  List.rev acc
-    | y0::ys -> aux (y0::acc) ys in
-  aux [] x
-
-(* For small list, only need partial equality 
-   {[
-   group (=) [1;2;3;4;3]
-   ;;
-   - : int list list = [[3; 3]; [4]; [2]; [1]]
-   # group (=) [];;
-   - : 'a list list = []
-   ]}
- *)
-let rec group (cmp : 'a -> 'a -> bool) (lst : 'a list) : 'a list list =
-  match lst with 
-  | [] -> []
-  | x::xs -> 
-      aux cmp x (group cmp xs )
-
-and aux cmp (x : 'a)  (xss : 'a list list) : 'a list list = 
-  match xss with 
-  | [] -> [[x]]
-  | y::ys -> 
-      if cmp x (List.hd y) (* cannot be null*) then
-        (x::y) :: ys 
-      else
-        y :: aux cmp x ys                                 
-  
-let stable_group cmp lst =  group cmp lst |> List.rev 
-
-let rec drop n h = 
-  if n < 0 then invalid_arg "Ext_list.drop"
-  else if n = 0 then h 
-  else if h = [] then invalid_arg "Ext_list.drop"
-  else 
-    drop (n - 1) (List.tl h)
-
-let rec for_all_ret  p = function
-  | [] -> None
-  | a::l -> 
-      if p a 
-      then for_all_ret p l
-      else Some a 
-
-let rec for_all_opt  p = function
-  | [] -> None
-  | a::l -> 
-      match p a with
-      | None -> for_all_opt p l
-      | v -> v 
-
-let fold f l init = 
-  List.fold_left (fun acc i -> f  i init) init l 
-
-let rev_map_acc  acc f l = 
-  let rec rmap_f accu = function
-    | [] -> accu
-    | a::l -> rmap_f (f a :: accu) l
-  in
-  rmap_f acc l
-
-let rec rev_iter f xs =
-    match xs with    
-    | [] -> ()
-    | y :: ys -> 
-      rev_iter f ys ;
-      f y      
-      
-let rec for_all2_no_exn p l1 l2 = 
-  match (l1, l2) with
-  | ([], []) -> true
-  | (a1::l1, a2::l2) -> p a1 a2 && for_all2_no_exn p l1 l2
-  | (_, _) -> false
-
-
-let rec find_no_exn p = function
-  | [] -> None
-  | x :: l -> if p x then Some x else find_no_exn p l
-
-
-let rec find_opt p = function
-  | [] -> None
-  | x :: l -> 
-    match  p x with 
-    | Some _ as v  ->  v
-    | None -> find_opt p l
-
-
-let split_map 
-    ( f : 'a -> ('b * 'c)) (xs : 'a list ) : 'b list  * 'c list = 
-  let rec aux bs cs xs =
-    match xs with 
-    | [] -> List.rev bs, List.rev cs 
-    | u::us -> 
-      let b,c =  f u in aux (b::bs) (c ::cs) us in 
-
-  aux [] [] xs 
-
-
-(*
-   {[
-     reduce_from_right (-) [1;2;3];;
-     - : int = 2
-               # reduce_from_right (-) [1;2;3; 4];;
-     - : int = -2
-                # reduce_from_right (-) [1];;
-     - : int = 1
-               # reduce_from_right (-) [1;2;3; 4; 5];;
-     - : int = 3
-   ]} 
-*)
-let reduce_from_right fn lst = 
-  begin match List.rev lst with
-    | last :: rest -> 
-      List.fold_left  (fun x y -> fn y x) last rest 
-    | _ -> invalid_arg "Ext_list.reduce" 
-  end
-
-type 'a t = 'a list ref
-
-let create_ref_empty () = ref []
-
-let ref_top x = 
-  match !x with 
-  | y::_ -> y 
-  | _ -> invalid_arg "Ext_list.ref_top"
-
-let ref_empty x = 
-  match !x with [] -> true | _ -> false 
-
-let ref_push x refs = 
-  refs := x :: !refs
-
-let ref_pop refs = 
-  match !refs with 
-  | [] -> invalid_arg "Ext_list.ref_pop"
-  | x::rest -> 
-    refs := rest ; 
-    x     
 
 end
 module Ast_payload : sig 
@@ -2158,7 +2271,8 @@ let as_empty_structure (x : t ) =
 
 let as_record_and_process 
     loc
-    ( x : t ) (action : Longident.t Asttypes.loc * Parsetree.expression -> unit ): unit= 
+    ( x : t )
+    (action : Longident.t Asttypes.loc * Parsetree.expression -> unit ): unit= 
   match  x with 
   | PStr [ {pstr_desc = Pstr_eval
                 ({pexp_desc = Pexp_record (label_exprs, with_obj) ; pexp_loc = loc}, _); 
@@ -2248,11 +2362,17 @@ module Lid : sig
   val val_unit : t 
   val type_unit : t 
   val pervasives_js_obj : t 
-  val pervasives_uncurry : t 
-  val pervasives_meth : t
-  val js_meth : t 
-  val js_obj : t 
+
   val js_fn : t 
+  val pervasives_fn : t 
+
+  val js_meth : t 
+  val pervasives_meth : t 
+
+  val pervasives_meth_callback : t
+  val js_meth_callback : t 
+  val js_obj : t 
+
   val ignore_id : t 
 end
 
@@ -2306,11 +2426,18 @@ module Lid = struct
   (* TODO should be renamed in to {!Js.fn} *)
   (* TODO should be moved into {!Js.t} Later *)
   let pervasives_js_obj = Longident.Ldot (Lident "Pervasives", "js_obj") 
-  let pervasives_uncurry = Longident.Ldot (Lident "Pervasives", "uncurry")
-  let pervasives_meth = Longident.Ldot (Lident "Pervasives", "meth")
-  let js_obj = Longident.Ldot (Lident "Js", "t") 
+
+
   let js_fn = Longident.Ldot (Lident "Js", "fn")
+  let pervasives_fn = Longident.Ldot (Lident "Pervasives", "fn")
+
   let js_meth = Longident.Ldot (Lident "Js", "meth")
+  let pervasives_meth = Longident.Ldot (Lident "Pervasives", "meth")
+
+  let pervasives_meth_callback = Longident.Ldot (Lident "Pervasives", "meth_callback")
+  let js_obj = Longident.Ldot (Lident "Js", "t") 
+
+  let js_meth_callback = Longident.Ldot (Lident "Js", "meth_callback")
   let ignore_id = Longident.Ldot (Lident "Pervasives", "ignore")
 end
 
@@ -2435,9 +2562,8 @@ val discard_exp_as_unit :
 
 val tuple_type_pair : 
   ?loc:Ast_helper.loc ->
-  [`Make | `Run ] -> 
-  int  ->
-  Parsetree.core_type * Parsetree.core_type
+  [< `Make | `Run ] ->
+  int -> Parsetree.core_type * Parsetree.core_type list * Parsetree.core_type
 
 
 val obj_type_pair : 
@@ -2557,18 +2683,23 @@ let tuple_type_pair ?loc kind arity =
   if arity = 0 then 
     let ty = Typ.var ?loc ( prefix ^ "0") in 
     match kind with 
-    | `Run -> ty, ty 
+    | `Run -> ty,  [], ty 
     | `Make -> 
       (Typ.arrow "" ?loc
          (Ast_literal.type_unit ?loc ())
          ty ,
-       ty)
+       [], ty)
   else
-    let tys = Ext_list.init (arity + 1) (fun i -> 
-        Typ.var ?loc (prefix ^ string_of_int i)
+    let number = arity + 1 in
+    let tys = Ext_list.init number (fun i -> 
+        Typ.var ?loc (prefix ^ string_of_int (number - i - 1))
       )  in
-    (Ext_list.reduce_from_right (fun x y -> Typ.arrow "" ?loc x y) tys,
-     Typ.tuple ?loc  tys)
+    match tys with 
+    | result :: rest -> 
+      Ext_list.reduce_from_left (fun r arg -> Typ.arrow "" ?loc arg r) tys, 
+      List.rev rest , result
+    | [] -> assert false
+    
     
 
 
@@ -2591,6 +2722,611 @@ let obj_type_pair ?loc arity =
     
 
 
+
+end
+module Ast_util : sig 
+#1 "ast_util.mli"
+(* Copyright (C) 2015-2016 Bloomberg Finance L.P.
+ * 
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In addition to the permissions granted to you by the LGPL, you may combine
+ * or link a "work that uses the Library" with a publicly distributed version
+ * of this file to produce a combined library or application, then distribute
+ * that combined work under the terms of your choosing, with no requirement
+ * to comply with the obligations normally placed on you by section 4 of the
+ * LGPL version 3 (or the corresponding section of a later version of the LGPL
+ * should you choose to use a later version).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
+
+
+
+val fn_run : 
+  Ast_helper.loc ->
+  Parsetree.expression ->
+  (string * Parsetree.expression) list ->
+  Ast_mapper.mapper ->
+  Parsetree.expression -> Parsetree.attributes -> Parsetree.expression
+
+val method_run : 
+  Ast_helper.loc ->
+  Parsetree.expression ->
+  string ->
+  (string * Parsetree.expression) list ->
+  Parsetree.expression -> Ast_mapper.mapper -> Parsetree.expression
+
+val property_run : 
+  Ast_helper.loc ->
+  Parsetree.expression ->
+  string ->
+  (string * Parsetree.expression) list ->
+  Parsetree.expression -> Ast_mapper.mapper -> Parsetree.expression
+
+
+val process_attributes_rev : 
+  Parsetree.attributes ->
+  Parsetree.attributes * [ `Meth | `Nothing | `Uncurry ]
+
+type ('a,'b) st = 
+  { get : 'a option ; 
+    set : 'b option }
+
+val process_method_attributes_rev : 
+  Parsetree.attributes ->
+  Parsetree.attribute list * (Parsetree.payload, Parsetree.payload) st
+
+(** turn {[ fun [@bs] x y -> x]} into an uncurried function 
+    TODO: Future 
+    {[ fun%bs this (a,b,c) -> 
+    ]}
+
+    [function] can only take one argument, that is the reason we did not adopt it
+*)
+val destruct_arrow_as_fn : 
+  Ast_helper.loc ->
+  Parsetree.pattern ->
+  Parsetree.expression ->
+  Ast_mapper.mapper ->
+  Parsetree.expression -> Parsetree.attributes -> Parsetree.expression
+
+val destruct_arrow_as_meth_callbak : 
+  Ast_helper.loc ->
+  Parsetree.pattern ->
+  Parsetree.expression ->
+  Ast_mapper.mapper ->
+  Parsetree.expression -> Parsetree.attributes -> Parsetree.expression
+
+val destruct_arrow : 
+  Ast_helper.loc ->
+  Parsetree.core_type ->
+  Parsetree.core_type -> Ast_mapper.mapper -> Parsetree.core_type
+
+val destruct_arrow_as_meth_type : 
+  Ast_helper.loc ->
+  Parsetree.core_type ->
+  Parsetree.core_type -> Ast_mapper.mapper -> Parsetree.core_type
+
+val destruct_arrow_as_meth_callback_type : 
+  Ast_helper.loc ->
+  Parsetree.core_type ->
+  Parsetree.core_type -> Ast_mapper.mapper -> Parsetree.core_type
+
+val bs_object_attribute : Parsetree.attribute
+val bs_uncurry_attribute :  Parsetree.attribute
+val bs_meth_attribute : Parsetree.attribute 
+
+
+
+
+val lift_js_type : 
+  loc:Ast_helper.loc -> Parsetree.core_type -> Parsetree.core_type
+
+
+val from_labels : loc:Ast_helper.loc -> Asttypes.label list -> Parsetree.core_type
+
+val down_with_name : 
+  loc:Ast_helper.loc ->
+  Parsetree.expression -> string -> Parsetree.expression_desc
+
+val handle_debugger : 
+  Location.t -> Ast_payload.t -> Parsetree.expression_desc
+
+val handle_raw : 
+  Location.t -> Ast_payload.t -> Parsetree.expression
+val handle_raw_structure : 
+  Location.t -> Ast_payload.t -> Parsetree.structure_item
+
+end = struct
+#1 "ast_util.ml"
+(* Copyright (C) 2015-2016 Bloomberg Finance L.P.
+ * 
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In addition to the permissions granted to you by the LGPL, you may combine
+ * or link a "work that uses the Library" with a publicly distributed version
+ * of this file to produce a combined library or application, then distribute
+ * that combined work under the terms of your choosing, with no requirement
+ * to comply with the obligations normally placed on you by section 4 of the
+ * LGPL version 3 (or the corresponding section of a later version of the LGPL
+ * should you choose to use a later version).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
+
+open Ast_helper 
+
+let js_obj_type_id () = 
+  if Js_config.get_env () = Browser then
+    Ast_literal.Lid.pervasives_js_obj
+  else Ast_literal.Lid.js_obj 
+    
+let curry_type_id () = 
+  if Js_config.get_env () = Browser then 
+     Ast_literal.Lid.pervasives_fn
+  else 
+    Ast_literal.Lid.js_fn
+
+let method_id () = 
+  if Js_config.get_env () = Browser then 
+     Ast_literal.Lid.pervasives_meth
+  else 
+    Ast_literal.Lid.js_meth
+
+let meth_call_back_id () = 
+  if Js_config.get_env () = Browser then 
+    Ast_literal.Lid.pervasives_meth_callback
+  else 
+    Ast_literal.Lid.js_meth_callback
+
+let mk_args ~loc n tys = 
+  Typ.variant ~loc 
+    [ Rtag ("Args_" ^ string_of_int n, [], (tys = []),  tys)] Closed None
+
+let lift_curry_type  ~loc args result  = 
+  let xs =
+    match args with 
+    | [ ] -> [mk_args 0  ~loc [] ; result ]
+    | [ x ] -> [ mk_args ~loc 1 [x] ; result ] 
+    | _ -> 
+      [mk_args ~loc (List.length args ) [Typ.tuple ~loc args] ; result ]
+  in 
+  Typ.constr ~loc {txt = curry_type_id (); loc} xs
+
+let lift_method_type  ~loc args result  = 
+  let xs =
+    match args with 
+    | [ ] -> [mk_args 0  ~loc [] ; result ]
+    | [ x ] -> [ mk_args ~loc 1 [x] ; result ] 
+    | _ -> 
+      [mk_args ~loc (List.length args ) [Typ.tuple ~loc args] ; result ]
+  in 
+  Typ.constr ~loc {txt = method_id (); loc} xs
+
+let lift_js_type ~loc  x  = 
+  Typ.constr ~loc {txt = js_obj_type_id (); loc} [x]
+
+
+
+let arrow = Typ.arrow
+
+
+
+let lift_js_meth_callback ~loc (obj,meth) 
+  = Typ.constr ~loc {txt = meth_call_back_id () ; loc} [obj; meth]
+
+let down_with_name ~loc obj name =
+  let downgrade ~loc () = 
+    let var = Typ.var ~loc "a" in 
+    Ast_comb.arrow_no_label ~loc
+      (lift_js_type ~loc var) var
+  in
+  Ast_comb.local_extern_cont loc  
+    ~pval_prim:["js_unsafe_downgrade"] 
+    ~pval_type:(downgrade ~loc ())
+    ~local_fun_name:"cast" 
+    (fun down -> Exp.send ~loc (Exp.apply ~loc down ["", obj]) name  )
+
+let gen_fn_run loc arity fn args  : Parsetree.expression_desc = 
+  let pval_prim = [Literals.js_fn_run ; string_of_int arity]  in
+  let fn_type, args_type, result_type = Ast_comb.tuple_type_pair ~loc `Run arity  in 
+  let pval_type =
+    arrow ~loc "" (lift_curry_type ~loc args_type result_type) fn_type in 
+  Ast_comb.create_local_external loc ~pval_prim ~pval_type 
+    (("", fn) :: List.map (fun x -> "",x) args )
+
+let gen_method_run loc arity fn args  : Parsetree.expression_desc = 
+  let pval_prim = [Literals.js_method_run ; string_of_int arity]  in
+  let fn_type, args_type, result_type = Ast_comb.tuple_type_pair ~loc `Run arity  in 
+  let pval_type =
+    arrow ~loc "" (lift_method_type ~loc args_type result_type) fn_type in 
+  Ast_comb.create_local_external loc ~pval_prim ~pval_type 
+    (("", fn) :: List.map (fun x -> "",x) args )
+
+
+let fn_run loc fn args 
+    (mapper : Ast_mapper.mapper) 
+    (e : Parsetree.expression) pexp_attributes = 
+  let fn = mapper.expr mapper fn in 
+  let args = 
+    List.map 
+      (fun (label, e) -> 
+         if label <> "" then 
+           Location.raise_errorf ~loc "label is not allowed here";
+         mapper.expr mapper e
+      ) args in 
+  let len = List.length args in 
+  match args with 
+  | [ {pexp_desc = Pexp_construct ({txt = Lident "()"}, None)}]
+    -> {e with pexp_desc = gen_fn_run loc 0 fn []}
+  | _ -> 
+    {e with
+     pexp_desc = gen_fn_run loc len fn args; 
+     pexp_attributes 
+    }
+
+let property_run loc (obj : Parsetree.expression) 
+    name (args : (string * Parsetree.expression) list ) e 
+    (mapper : Ast_mapper.mapper) : Parsetree.expression = 
+  let obj = mapper.expr mapper obj in
+  let args =
+    List.map (fun (label,e) ->
+        if label <> "" then
+          Location.raise_errorf ~loc "label is not allowed here"        ;
+        mapper.expr mapper e
+      ) args in
+  let len = List.length args in 
+  (* TODO: have a final checking for property arities 
+     [case], [case_set] and other setter       
+  *)
+  match args with 
+  | [ {pexp_desc = Pexp_construct ({txt = Lident "()"}, None)}]
+    -> 
+    {e with pexp_desc = 
+              gen_fn_run loc 0
+                (Exp.mk ~loc @@ down_with_name ~loc obj name)
+                []
+    }
+  | _ -> 
+    {e with pexp_desc = 
+              gen_fn_run loc len 
+                (Exp.mk ~loc @@ down_with_name ~loc obj name)
+                args
+    }
+
+let method_run loc (obj : Parsetree.expression) 
+    name (args : (string * Parsetree.expression) list ) e 
+    (mapper : Ast_mapper.mapper) : Parsetree.expression = 
+  let obj = mapper.expr mapper obj in
+  let args =
+    List.map (fun (label,e) ->
+        if label <> "" then
+          Location.raise_errorf ~loc "label is not allowed here"        ;
+        mapper.expr mapper e
+      ) args in
+  let len = List.length args in
+  let method_kind = 
+    if name = Literals.case_set then `Case_setter
+    else if Ext_string.ends_with name Literals.setter_suffix then `Setter
+    else `Normal name in 
+  let () = 
+     if method_kind = `Setter && len <> 1 then 
+        Location.raise_errorf ~loc "setter expect single argument"
+     else if method_kind = `Case_setter && len <> 2 then 
+       Location.raise_errorf ~loc "case_set would expect arity of 2 "
+  in
+  match args with 
+  | [ {pexp_desc = Pexp_construct ({txt = Lident "()"}, None)}]
+    -> 
+    {e with pexp_desc = 
+              gen_method_run loc 0
+                (Exp.mk ~loc @@ down_with_name ~loc obj name)
+                []
+    }
+  | _ -> 
+    {e with pexp_desc = 
+              gen_method_run loc len 
+                (Exp.mk ~loc @@ down_with_name ~loc obj name)
+                args
+    }
+
+
+
+let gen_fn_mk loc arity arg  : Parsetree.expression_desc = 
+  let pval_prim = [ "js_fn_mk"; string_of_int arity]  in
+  let fn_type , args_type, result_type  = Ast_comb.tuple_type_pair ~loc `Make arity  in 
+  let pval_type = arrow ~loc "" fn_type (lift_curry_type ~loc args_type result_type) in
+  Ast_comb.create_local_external loc ~pval_prim ~pval_type [("", arg)]
+
+let gen_method_mk loc arity arg  : Parsetree.expression_desc = 
+  let pval_prim = [ "js_fn_method"; string_of_int arity]  in
+  let fn_type , (obj_type, tuple_type) = Ast_comb.obj_type_pair ~loc  arity  in 
+  let pval_type = 
+    arrow ~loc "" fn_type (lift_js_meth_callback ~loc (obj_type, tuple_type))
+  in
+  Ast_comb.create_local_external loc ~pval_prim ~pval_type [("", arg)]
+
+
+
+
+let empty_payload = Parsetree.PStr []
+
+let bs_object_attribute  : Parsetree.attribute
+  = {txt = "bs.obj" ; loc = Location.none}, empty_payload
+
+let bs_uncurry_attribute : Parsetree.attribute        
+  =  {txt = "bs" ; loc = Location.none}, empty_payload
+let bs_meth_attribute : Parsetree.attribute        
+  =  {txt = "bs.this" ; loc = Location.none}, empty_payload
+
+
+
+let process_attributes_rev (attrs : Parsetree.attributes) = 
+  List.fold_left (fun (acc, st) attr -> 
+      let tag = fst attr in
+      match tag.Location.txt, st  with 
+      | "bs", (`Nothing | `Uncurry) 
+        -> 
+        (acc, `Uncurry)
+      | "bs.this", (`Nothing | `Meth)
+        -> (acc, `Meth)
+      | "bs", `Meth 
+      | "bs.this", `Uncurry
+        -> Location.raise_errorf 
+             ~loc:tag.Location.loc 
+             "[@bs.this] and [@bs] can not be applied at the same time"
+      | _ , _ -> 
+        (attr::acc , st)
+    ) ([], `Nothing) attrs
+
+type ('a,'b) st = 
+  { get : 'a option ; 
+    set : 'b option }
+
+
+let process_method_attributes_rev (attrs : Parsetree.attributes) = 
+  List.fold_left (fun (acc, st) ((tag, payload) as attr) -> 
+
+      match tag.Location.txt  with 
+      | "bs.get" (* [@@bs.get{null; undefined}]*)
+        -> 
+        (acc, {st with get = Some payload} )
+
+      | "bs.set"
+        -> (* properties -- void 
+              [@@bs.set{only}]
+           *)
+          acc, {st with set = Some payload }
+      | _ -> 
+        (attr::acc , st)
+    ) ([], {get = None ; set = None}) attrs
+
+
+(** TODO: how to handle attributes *)
+let destruct_arrow loc (first_arg : Parsetree.core_type) 
+    (typ : Parsetree.core_type) (mapper : Ast_mapper.mapper) = 
+  let rec aux acc (typ : Parsetree.core_type) = 
+    (* in general, 
+       we should collect [typ] in [int -> typ] before transformation, 
+       however: when attributes [bs] and [bs.this] found in typ, 
+       we should stop 
+    *)
+    match process_attributes_rev typ.ptyp_attributes with 
+    | _ , `Nothing -> 
+      begin match typ.ptyp_desc with 
+      | Ptyp_arrow (label, arg, body)
+        -> 
+        if label <> "" then
+          Location.raise_errorf ~loc:typ.ptyp_loc "label is not allowed";
+        aux (mapper.typ mapper arg :: acc) body 
+      | _ -> mapper.typ mapper typ, acc 
+      end
+    | _, _ -> mapper.typ mapper typ, acc  
+  in 
+  let first_arg = mapper.typ mapper first_arg in
+  let result, rev_extra_args = 
+    aux  [first_arg] typ in 
+
+  match rev_extra_args with 
+  | [{ptyp_desc = Ptyp_constr ({txt = Lident "unit"}, [])}]
+    ->
+    lift_curry_type ~loc [] result 
+  | _
+    -> 
+    lift_curry_type ~loc (List.rev rev_extra_args) result 
+
+
+let destruct_arrow_as_meth_type loc (first_arg : Parsetree.core_type) 
+    (typ : Parsetree.core_type) (mapper : Ast_mapper.mapper) = 
+  let rec aux acc (typ : Parsetree.core_type) = 
+    (* in general, 
+       we should collect [typ] in [int -> typ] before transformation, 
+       however: when attributes [bs] and [bs.this] found in typ, 
+       we should stop 
+    *)
+    match process_attributes_rev typ.ptyp_attributes with 
+    | _ , `Nothing -> 
+      begin match typ.ptyp_desc with 
+      | Ptyp_arrow (label, arg, body)
+        -> 
+        if label <> "" then
+          Location.raise_errorf ~loc:typ.ptyp_loc "label is not allowed";
+        aux (mapper.typ mapper arg :: acc) body 
+      | _ -> mapper.typ mapper typ, acc 
+      end
+    | _, _ -> mapper.typ mapper typ, acc  
+  in 
+  let first_arg = mapper.typ mapper first_arg in
+  let result, rev_extra_args = 
+    aux  [first_arg] typ in 
+
+  match rev_extra_args with 
+  | [{ptyp_desc = Ptyp_constr ({txt = Lident "unit"}, [])}]
+    ->
+    lift_method_type ~loc [] result 
+  | _
+    -> 
+    lift_method_type ~loc (List.rev rev_extra_args) result 
+
+  
+let destruct_arrow_as_meth_callback_type loc (first_arg : Parsetree.core_type) 
+    (typ : Parsetree.core_type) (mapper : Ast_mapper.mapper) = 
+  let rec aux acc (typ : Parsetree.core_type) = 
+    match process_attributes_rev typ.ptyp_attributes with 
+    | _ , `Nothing -> 
+      begin match typ.ptyp_desc with 
+        | Ptyp_arrow (label, arg, body)
+          -> 
+          if label <> "" then
+            Location.raise_errorf ~loc:typ.ptyp_loc "label is not allowed";
+          aux (mapper.typ mapper arg :: acc) body 
+        | _ -> mapper.typ mapper typ, acc 
+      end 
+    | _, _ -> mapper.typ mapper typ, acc  
+  in 
+  let first_arg = mapper.typ mapper first_arg in 
+  let result, rev_extra_args = aux  [] typ in 
+  lift_js_meth_callback ~loc 
+    (first_arg, 
+     if rev_extra_args = [] then result 
+     else Typ.tuple ~loc  (List.rev_append rev_extra_args [result])
+    )
+
+
+
+let destruct_arrow_as_fn loc pat body (mapper : Ast_mapper.mapper) 
+    (e : Parsetree.expression) pexp_attributes = 
+  let rec aux acc (body : Parsetree.expression) = 
+    match process_attributes_rev body.pexp_attributes with 
+    | _ , `Nothing -> 
+      begin match body.pexp_desc with 
+        | Pexp_fun (label,_, arg, body)
+          -> 
+          if label <> "" then
+            Location.raise_errorf ~loc "label is not allowed";
+          aux (mapper.pat mapper arg :: acc) body 
+        | _ -> mapper.expr mapper body, acc 
+      end 
+    | _, _ -> mapper.expr mapper body, acc  
+  in 
+  let first_arg = mapper.pat mapper pat in  
+  let result, rev_extra_args = aux [first_arg] body in 
+  match rev_extra_args with 
+  | [ {ppat_desc = Ppat_construct ({txt = Lident "()"}, None)}]
+    -> { e with pexp_desc =         
+                  gen_fn_mk loc 0 
+                    (Ast_comb.fun_no_label ~loc (Ast_literal.pat_unit ~loc () ) result);
+                pexp_attributes}
+  | _ -> {e with 
+          pexp_desc = 
+            gen_fn_mk loc (List.length rev_extra_args) 
+              (List.fold_left (fun e p -> Ast_comb.fun_no_label ~loc p e )
+                 result rev_extra_args );
+          pexp_attributes 
+         }
+
+let destruct_arrow_as_meth_callbak loc pat body (mapper : Ast_mapper.mapper) 
+    (e : Parsetree.expression) pexp_attributes = 
+  let rec aux acc (body : Parsetree.expression) = 
+    match process_attributes_rev body.pexp_attributes with 
+    | _ , `Nothing -> 
+      begin match body.pexp_desc with 
+        | Pexp_fun (label,_, arg, body)
+          -> 
+          if label <> "" then
+            Location.raise_errorf ~loc "label is not allowed";
+          aux (mapper.pat mapper arg :: acc) body 
+        | _ -> mapper.expr mapper body, acc 
+      end 
+    | _, _ -> mapper.expr mapper body, acc  
+  in 
+  let first_arg = mapper.pat mapper pat in  
+  let result, rev_extra_args = aux [first_arg] body in 
+  let len = List.length rev_extra_args - 1 in 
+  {e with pexp_desc = 
+            gen_method_mk loc len 
+              (List.fold_left 
+                 (fun e p -> Ast_comb.fun_no_label ~loc p e) result rev_extra_args );
+          pexp_attributes 
+  }
+
+
+
+let from_labels ~loc (labels : Asttypes.label list) : Parsetree.core_type = 
+  let arity = List.length labels in 
+  let tyvars = (Ext_list.init arity (fun i ->      
+      Typ.var ~loc ("a" ^ string_of_int i))) in 
+
+  let result_type =
+    lift_js_type ~loc  
+    @@ Typ.object_ ~loc (List.map2 (fun x y -> x ,[], y) labels tyvars) Closed
+
+  in 
+  List.fold_right2 
+    (fun label tyvar acc -> arrow ~loc label tyvar acc) labels tyvars  result_type
+
+let handle_debugger loc payload = 
+  if Ast_payload.as_empty_structure payload then
+    let predef_unit_type = Ast_literal.type_unit ~loc () in
+    let pval_prim = ["js_debugger"] in
+    Ast_comb.create_local_external loc 
+      ~pval_prim
+      ~pval_type:(arrow "" predef_unit_type predef_unit_type)
+      [("",  Ast_literal.val_unit ~loc ())]
+  else Location.raise_errorf ~loc "bs.raw can only be applied to a string"
+
+
+let handle_raw loc payload = 
+  begin match Ast_payload.as_string_exp payload with 
+    | None -> 
+      Location.raise_errorf ~loc "bs.raw can only be applied to a string"
+    | Some exp -> 
+      let pval_prim = ["js_pure_expr"] in
+      { exp with pexp_desc = Ast_comb.create_local_external loc 
+                     ~pval_prim
+                     ~pval_type:(arrow "" 
+                                   (Ast_literal.type_string ~loc ()) 
+                                   (Ast_literal.type_any ~loc ()) )
+
+                     ["",exp]}
+  end
+
+let handle_raw_structure loc payload = 
+  begin match Ast_payload.as_string_exp payload with 
+    | Some exp 
+      -> 
+      let pval_prim = ["js_pure_stmt"] in 
+      Ast_helper.Str.eval 
+        { exp with pexp_desc =
+                     Ast_comb.create_local_external loc 
+                       ~pval_prim
+                       ~pval_type:(arrow ""
+                                     (Ast_literal.type_string ~loc ())
+                                     (Ast_literal.type_any ~loc ()))
+                       ["",exp]}
+    | None
+      -> 
+      Location.raise_errorf ~loc "bs.raw can only be applied to a string"
+  end
 
 end
 module Ppx_entry : sig 
@@ -2625,6 +3361,42 @@ module Ppx_entry : sig
 val rewrite_signature :   (Parsetree.signature -> Parsetree.signature) ref
 
 val rewrite_implementation : (Parsetree.structure -> Parsetree.structure) ref
+
+
+
+
+
+(* object 
+    for setter : we can push more into [Lsend] and enclose it with a unit type
+
+    for getter :
+
+    (* Invariant: we expect the typechecker & lambda emitter  
+       will not do agressive inlining
+       Worst things could happen
+    {[
+      let x = y## case 3  in 
+      x 2
+    ]}
+       in normal case, it should be compiled into Lambda
+    {[
+      let x = Lsend(y,case, [3]) in 
+      Lapp(x,2)
+    ]}
+
+       worst:
+    {[ Lsend(y, case, [3,2])
+    ]}               
+       for setter(include case setter), this could 
+       be prevented by type system, for getter.
+
+       solution: we can prevent this by rewrite into 
+    {[
+      Fn.run1  (!x# case) v 
+      ]}
+       *)
+
+      *)
 
 end = struct
 #1 "ppx_entry.ml"
@@ -2663,7 +3435,7 @@ end = struct
 (**
 1. extension point 
    {[ 
-     [%unsafe{| blabla |}]
+     [%bs.raw{| blabla |}]
    ]}
    will be desugared into 
    {[ 
@@ -2684,161 +3456,30 @@ end = struct
 
 
 
+open Ast_helper
 
 
 
-
-
-let js_obj_type_id () = 
-  if Js_config.get_env () = Browser then
-    Ast_literal.Lid.pervasives_js_obj
-  else Ast_literal.Lid.js_obj 
-    
-let curry_type_id () = 
-  if Js_config.get_env () = Browser then 
-    Ast_literal.Lid.pervasives_uncurry
-  else 
-    Ast_literal.Lid.js_fn 
-
-let meth_type_id () = 
-  if Js_config.get_env () = Browser then 
-    Ast_literal.Lid.pervasives_meth
-  else 
-    Ast_literal.Lid.js_meth
-
-open Ast_helper 
-let arrow = Ast_helper.Typ.arrow
 
 let record_as_js_object = ref None (* otherwise has an attribute *)
 
-let as_js_object_attribute  : Parsetree.attribute
-  = {txt = "bs.obj" ; loc = Location.none}, PStr []
 
 let obj_type_as_js_obj_type = ref false
 let uncurry_type = ref false 
 let obj_type_auto_uncurry =  ref false
 let non_export = ref false 
+let bs_class_type = ref false 
 
 let reset () = 
   record_as_js_object := None ;
   obj_type_as_js_obj_type := false ;
   uncurry_type := false ;
   obj_type_auto_uncurry := false ;
+  bs_class_type := false;
   non_export  :=  false
 
 
-let lift_js_type ~loc  x  = Typ.constr ~loc {txt = js_obj_type_id (); loc} [x]
-let lift_curry_type ~loc x  = Typ.constr ~loc {txt = curry_type_id (); loc} [x]
-
-let lift_js_meth ~loc (obj,meth) 
-  = Typ.constr ~loc {txt = meth_type_id () ; loc} [obj; meth]
-
-let downgrade ~loc () = 
-  let var = Typ.var ~loc "a" in 
-  Ast_comb.arrow_no_label ~loc
-    (lift_js_type ~loc var) var
-
-let down_with_name ~loc obj name =
-  Ast_comb.local_extern_cont loc  
-    ~pval_prim:["js_unsafe_downgrade"] 
-    ~pval_type:(downgrade ~loc ())
-    ~local_fun_name:"cast" 
-    (fun down -> Exp.send ~loc (Exp.apply ~loc down ["", obj]) name  )
-       
-
-
-let gen_fn_run loc arity fn args  : Parsetree.expression_desc = 
-  let pval_prim = ["js_fn_run" ; string_of_int arity]  in
-  let fn_type, tuple_type = Ast_comb.tuple_type_pair ~loc `Run arity  in 
-  let pval_type =
-    arrow ~loc "" (lift_curry_type ~loc tuple_type) fn_type in 
-  Ast_comb.create_local_external loc ~pval_prim ~pval_type 
-    (("", fn) :: List.map (fun x -> "",x) args )
-
-(** The first argument is object itself which is only 
-    for typing checking*)
-let gen_method_run loc arity fn args : Parsetree.expression_desc = 
-  let pval_prim = ["js_fn_runmethod" ; string_of_int arity]  in
-  let fn_type, (obj_type, tuple_type) = Ast_comb.obj_type_pair ~loc  arity  in 
-  let pval_type =
-    arrow ~loc "" (lift_js_meth ~loc (obj_type, tuple_type)) fn_type in 
-  Ast_comb.create_local_external loc ~pval_prim ~pval_type 
-    (("", fn) :: List.map (fun x -> "",x) args )
-
-
-let gen_fn_mk loc arity arg  : Parsetree.expression_desc = 
-  let pval_prim = [ "js_fn_mk"; string_of_int arity]  in
-  let fn_type , tuple_type = Ast_comb.tuple_type_pair ~loc `Make arity  in 
-  let pval_type = arrow ~loc "" fn_type (lift_curry_type ~loc tuple_type)in
-  Ast_comb.create_local_external loc ~pval_prim ~pval_type [("", arg)]
-
-let gen_method_mk loc arity arg  : Parsetree.expression_desc = 
-  let pval_prim = [ "js_fn_method"; string_of_int arity]  in
-  let fn_type , (obj_type, tuple_type) = Ast_comb.obj_type_pair ~loc  arity  in 
-  let pval_type = 
-    arrow ~loc "" fn_type (lift_js_meth ~loc (obj_type, tuple_type))
-  in
-  Ast_comb.create_local_external loc ~pval_prim ~pval_type [("", arg)]
-        
-
-let find_uncurry_attrs_and_remove (attrs : Parsetree.attributes ) = 
-  Ext_list.exclude_with_fact (function 
-    | ({Location.txt  = "uncurry"}, _) -> true 
-    | _ -> false ) attrs 
-
-let destruct_tuple_exp (exp : Parsetree.expression) : Parsetree.expression list = 
-    match exp with 
-    | {pexp_desc = 
-         Pexp_tuple [arg ; {pexp_desc = Pexp_ident{txt = Lident "__"; _}} ]
-      ; _} -> 
-      [arg]
-    | {pexp_desc = Pexp_tuple args; _} -> args
-    | {pexp_desc = Pexp_construct ({txt = Lident "()"}, None); _} -> []
-    | v -> [v]
-let destruct_tuple_pat (pat : Parsetree.pattern) : Parsetree.pattern list = 
-    match pat with 
-    | {ppat_desc = Ppat_tuple [arg ; {ppat_desc = Ppat_var{txt = "__"}} ]; _} -> 
-      [arg]
-    | {ppat_desc = Ppat_tuple args; _} -> args
-    | {ppat_desc = Ppat_construct ({txt = Lident "()"}, None); _} -> []
-    | v -> [v]
-
-let destruct_tuple_typ (args : Parsetree.core_type)  = 
-    match args with
-    | {ptyp_desc = 
-         Ptyp_tuple 
-           [arg ; {ptyp_desc = Ptyp_constr ({txt = Lident "__"}, [])} ]; 
-       _} 
-      -> [ arg]
-    | {ptyp_desc = Ptyp_tuple args; _} -> args 
-      
-    | {ptyp_desc = Ptyp_constr ({txt = Lident "unit"}, []); _} -> []
-    | v -> [v]
-
-(** 
-   Turn {[ int -> int -> int ]} 
-   into {[ (int *  int * int) fn ]}
-*)
-let uncurry_fn_type loc ty attrs
-    (args : Parsetree.core_type ) body  : Parsetree.core_type = 
-  let tyvars = destruct_tuple_typ args in 
-  let arity = List.length tyvars in 
-  if arity = 0 then lift_curry_type ~loc body 
-  else lift_curry_type ~loc (Typ.tuple ~loc ~attrs (tyvars @ [body]))
-
-
-let from_labels ~loc (labels : Asttypes.label list) : Parsetree.core_type = 
-  let arity = List.length labels in 
-  let tyvars = (Ext_list.init arity (fun i ->      
-      Typ.var ~loc ("a" ^ string_of_int i))) in 
-
-  let result_type =
-    lift_js_type ~loc  
-    @@ Typ.object_ ~loc (List.map2 (fun x y -> x ,[], y) labels tyvars) Closed
-
-  in 
-  List.fold_right2 
-    (fun label tyvar acc -> arrow ~loc label tyvar acc) labels tyvars  result_type
+let arrow = Ast_helper.Typ.arrow
 
 let handle_record_as_js_object 
     loc 
@@ -2854,14 +3495,87 @@ let handle_record_as_js_object
   ) label_exprs in 
   let pval_prim = [ "" ] in 
   let pval_attributes = [attr] in 
-  let pval_type = from_labels ~loc labels in 
+  let pval_type = Ast_util.from_labels ~loc labels in 
   Ast_comb.create_local_external loc 
     ~pval_prim
     ~pval_type ~pval_attributes 
     args 
 
 
-
+let handle_class_type_field  acc =
+  (fun self ({pctf_loc = loc } as ctf : Parsetree.class_type_field) -> 
+     match ctf.Parsetree.pctf_desc with 
+     | Pctf_method 
+         (name, private_flag, virtual_flag, ty) 
+       -> 
+       let (pctf_attributes, st) = 
+         Ast_util.process_method_attributes_rev ctf.pctf_attributes 
+       in 
+       begin match ty.ptyp_desc with 
+         | Ptyp_arrow ("", args, body) 
+           -> 
+           { ctf with 
+             pctf_desc = 
+               Pctf_method (name, 
+                            private_flag,
+                            virtual_flag, 
+                            Ast_util.destruct_arrow_as_meth_type 
+                              ty.ptyp_loc args body self );
+             pctf_attributes 
+           } :: acc 
+         | Ptyp_poly (strs, {ptyp_desc = Ptyp_arrow ("", args, body); ptyp_loc})
+           -> 
+           {ctf with 
+            pctf_desc = 
+              Pctf_method 
+                (name,
+                 private_flag, 
+                 virtual_flag, 
+                 {ty with ptyp_desc = 
+                            Ptyp_poly(strs,             
+                                      Ast_util.destruct_arrow_as_meth_type
+                                        ptyp_loc args body self  )});
+            pctf_attributes
+           }  :: acc 
+         | _ -> 
+           match st with 
+           | {set = Some _ } 
+             -> 
+               {ctf with 
+                pctf_desc =
+                  Pctf_method (name ^ Literals.setter_suffix, 
+                               private_flag,
+                               virtual_flag,
+                               Ast_util.destruct_arrow_as_meth_type 
+                                 loc 
+                                 ty 
+                                 (Ast_literal.type_unit ~loc ())
+                                 self 
+                              );
+                pctf_attributes}
+             :: {ctf with 
+                pctf_desc =  
+                  Pctf_method (name , 
+                               private_flag, 
+                               virtual_flag, 
+                               self.typ self ty
+                              );
+                pctf_attributes}
+             :: acc 
+           (*TODO: test on poly type *)
+           | _ -> 
+             {ctf with 
+              pctf_desc =  Pctf_method (name , private_flag, virtual_flag, self.typ self ty);
+              pctf_attributes}
+             :: acc 
+       end
+     | Pctf_inherit _ 
+     | Pctf_val _ 
+     | Pctf_constraint _
+     | Pctf_attribute _ 
+     | Pctf_extension _  -> 
+       Ast_mapper.default_mapper.class_type_field self ctf :: acc 
+  )
 (*
   Attributes are very hard to attribute
   (since ptyp_attributes could happen in so many places), 
@@ -2881,473 +3595,249 @@ let handle_typ
      ptyp_desc = Ptyp_arrow ("", args, body);
      ptyp_loc = loc
    } ->
-    begin match  find_uncurry_attrs_and_remove ptyp_attributes with 
-    | Some _, ptyp_attributes ->
-        let args = self.typ self args in
-        let body = self.typ self body in
-        uncurry_fn_type loc ty ptyp_attributes args body 
-    | None, _ -> 
-        let args = self.typ self args in
-        let body = self.typ self body in
+    begin match  Ast_util.process_attributes_rev ptyp_attributes with 
+      | ptyp_attributes, `Uncurry ->
+        Ast_util.destruct_arrow loc args body self 
+      | ptyp_attributes, `Meth -> 
+        Ast_util.destruct_arrow_as_meth_callback_type loc args body self         
+      | _, `Nothing -> 
         if !uncurry_type then 
-          uncurry_fn_type loc ty ptyp_attributes args body 
-        else {ty with ptyp_desc = Ptyp_arrow("", args, body)}
+          Ast_util.destruct_arrow loc args body self 
+        else 
+          Ast_mapper.default_mapper.typ self ty
     end
   | {
     ptyp_desc =  Ptyp_object ( methods, closed_flag) ;
     ptyp_attributes ;
     ptyp_loc = loc 
     } -> 
-    let inner_type =
+
+    let check_auto_uncurry core_type = 
+      if  !obj_type_auto_uncurry then
+        Ext_ref.protect uncurry_type true (fun _ -> self.typ self core_type  )          
+      else self.typ self core_type in 
+    let methods, ptyp_attributes  =
       begin match Ext_list.exclude_with_fact
                     (function 
-                      | {Location.txt = "uncurry"; _}, _ -> true
+                      | {Location.txt = "bs"; _}, _ -> true
                       | _ -> false)
                     ptyp_attributes with 
-      |   None, _  ->
-        let check_auto_uncurry core_type = 
-          if  !obj_type_auto_uncurry then
-            Ext_ref.protect uncurry_type true (fun _ -> self.typ self core_type  )          
-          else self.typ self core_type in 
-
-        let methods = 
+      | None, _  ->
+        List.map (fun (label, ptyp_attrs, core_type ) -> 
+            match Ast_util.process_attributes_rev ptyp_attrs with 
+            | _, `Nothing -> 
+              label, ptyp_attrs , check_auto_uncurry  core_type
+            | ptyp_attrs, `Uncurry  -> 
+              label , ptyp_attrs, 
+              check_auto_uncurry
+                { core_type with 
+                  ptyp_attributes = 
+                    Ast_util.bs_uncurry_attribute :: core_type.ptyp_attributes}
+            | ptyp_attrs, `Meth 
+              ->  
+              label , ptyp_attrs, 
+              check_auto_uncurry
+                { core_type with 
+                  ptyp_attributes = 
+                    Ast_util.bs_meth_attribute :: core_type.ptyp_attributes}
+          ) methods , ptyp_attributes
+      |  Some _ ,  ptyp_attributes -> 
+        Ext_ref.protect uncurry_type true begin fun _ -> 
           List.map (fun (label, ptyp_attrs, core_type ) -> 
-              match find_uncurry_attrs_and_remove ptyp_attrs with 
-              | None, _ -> 
-                label, ptyp_attrs , check_auto_uncurry  core_type
-              | Some v, ptyp_attrs -> 
-                label , ptyp_attrs, 
-                check_auto_uncurry
-                  { core_type with ptyp_attributes = v :: core_type.ptyp_attributes}
+              match Ast_util.process_attributes_rev ptyp_attrs with 
+              |  _, `Nothing -> label, ptyp_attrs , self.typ self core_type
+              | ptyp_attrs, `Uncurry -> 
+                label , ptyp_attrs, self.typ self 
+                  { core_type with 
+                    ptyp_attributes = 
+                      Ast_util.bs_uncurry_attribute :: core_type.ptyp_attributes}
+              | ptyp_attrs, `Meth -> 
+                label , ptyp_attrs, self.typ self 
+                  { core_type with 
+                    ptyp_attributes = 
+                      Ast_util.bs_meth_attribute :: core_type.ptyp_attributes}
             ) methods 
-        in   
-        { ty with ptyp_desc = Ptyp_object(methods, closed_flag);
-                  ptyp_attributes } 
-
-      |  fact2,  ptyp_attributes -> 
-
-        let uncurry_type_cxt  = fact2 <> None || !uncurry_type || !obj_type_auto_uncurry in 
-        let methods = 
-          Ext_ref.protect uncurry_type uncurry_type_cxt begin fun _ -> 
-            List.map (fun (label, ptyp_attrs, core_type ) -> 
-                match find_uncurry_attrs_and_remove ptyp_attrs with 
-                | None, _ -> label, ptyp_attrs , self.typ self core_type
-                | Some v, ptyp_attrs -> 
-                  label , ptyp_attrs, self.typ self 
-                    { core_type with ptyp_attributes = v :: core_type.ptyp_attributes}
-              ) methods 
-          end
-        in           
-        { ty with ptyp_desc = Ptyp_object(methods, closed_flag);
-                  ptyp_attributes } 
+        end, ptyp_attributes 
       end
     in          
+    let inner_type =
+      { ty
+        with ptyp_desc = Ptyp_object(methods, closed_flag);
+             ptyp_attributes } in 
     if !obj_type_as_js_obj_type then 
-      lift_js_type ~loc  inner_type
+      Ast_util.lift_js_type ~loc inner_type          
     else inner_type
   | _ -> super.typ self ty
 
-let handle_class_obj_typ 
-    (super : Ast_mapper.mapper) 
-    (self : Ast_mapper.mapper)
-    (ty : Parsetree.class_type) = 
-  match ty with
-  | {pcty_attributes ;
-     pcty_desc ; (* we won't have [ class type v = u -> object[@uncurry] ]*)
-     pcty_loc = loc
-   } ->
-    begin match  find_uncurry_attrs_and_remove pcty_attributes with 
-    | Some _, pcty_attributes' ->
-      Ext_ref.protect uncurry_type true begin fun () -> 
-        self.class_type self  {ty with pcty_attributes = pcty_attributes'} 
-      end
-    | None, _ -> 
-      if !obj_type_auto_uncurry then 
-        Ext_ref.protect uncurry_type true begin fun () -> 
-          super.class_type self ty
-        end
-      else 
-        super.class_type self ty
-    end
-
-
-let handle_debugger loc payload = 
-  if Ast_payload.as_empty_structure payload then
-    let predef_unit_type = Ast_literal.type_unit ~loc () in
-    let pval_prim = ["js_debugger"] in
-    Ast_comb.create_local_external loc 
-      ~pval_prim
-      ~pval_type:(arrow "" predef_unit_type predef_unit_type)
-      [("",  Ast_literal.val_unit ~loc ())]
-  else Location.raise_errorf ~loc "bs.raw can only be applied to a string"
-
-
-(** TODO: Future 
-    {[ fun%bs this (a,b,c) -> 
-    ]}
-
-    [function] can only take one argument, that is the reason we did not adopt it
-*)
-let handle_uncurry_fn_generation  loc 
-    (pat : Parsetree.pattern)
-    (body : Parsetree.expression) 
-    (e : Parsetree.expression) (mapper : Ast_mapper.mapper) = 
-  let args = destruct_tuple_pat pat in 
-  let len = List.length args in 
-  let body = mapper.expr mapper body in 
-  let fun_ = 
-    if len = 0 then 
-      Ast_comb.fun_no_label ~loc (Ast_literal.pat_unit ~loc () ) body
-    else 
-      List.fold_right (fun arg body -> 
-          let arg = mapper.pat mapper arg in 
-          Ast_comb.fun_no_label ~loc arg body 
-          ) args body in
-  {e with pexp_desc = gen_fn_mk loc len fun_}
-
-
-let handle_uncurry_method_generation  loc 
-    (pat : Parsetree.pattern)
-    (body : Parsetree.expression) 
-    (e : Parsetree.expression) (mapper : Ast_mapper.mapper) = 
-  let args = destruct_tuple_pat pat in 
-  let len = List.length args in 
-  let body = mapper.expr mapper body in 
-  let fun_ = 
-    if len = 0 then 
-      Location.raise_errorf ~loc "method expect at least one argument"
-    else 
-      List.fold_right (fun arg body -> 
-          let arg = mapper.pat mapper arg in 
-          Ast_comb.fun_no_label ~loc arg body 
-          ) args body in
-  {e with pexp_desc = gen_method_mk loc (len - 1) fun_}
-
-let handle_uncurry_application 
-    loc fn (exp : Parsetree.expression) (e : Parsetree.expression)
-    (self : Ast_mapper.mapper) 
-  : Parsetree.expression = 
-  let args = destruct_tuple_exp exp in
-  let fn = self.expr self fn in 
-  let args = List.map (self.expr self) args in 
-  let len = List.length args in 
-  { e with pexp_desc = gen_fn_run loc len fn args}
-
-
-type method_kind = 
-  | Case_setter
-  | Setter
-  | Normal of string 
-
-(* ./dumpast -e ' (Js.Unsafe.(!) obj) # property ' *)
 let handle_obj_property loc obj name e 
     (mapper : Ast_mapper.mapper) : Parsetree.expression = 
   let obj = mapper.expr mapper obj in 
-  { e with pexp_desc = down_with_name ~loc obj name
-
-  }
+  { e with pexp_desc = Ast_util.down_with_name ~loc obj name  }
 
 
-
-let handle_obj_fn loc (obj : Parsetree.expression) 
-    name (value : Parsetree.expression) e 
-    (mapper : Ast_mapper.mapper) : Parsetree.expression = 
-  let method_kind = 
-    if name = Literals.case_set then Case_setter
-    else if Ext_string.ends_with name Literals.setter_suffix then Setter
-    else Normal name in 
-  let len, args = 
-    match method_kind with 
-    | Setter -> 
-      1, [value]
-    | (Case_setter | Normal _) -> 
-      let args = destruct_tuple_exp value in 
-      let arity = List.length args in  
-      if method_kind = Case_setter && arity <> 2 then 
-        Location.raise_errorf "case_set would expect arity of 2 "
-      else  arity, args 
-  in
-  let obj = mapper.expr mapper obj in 
-  let args = List.map (mapper.expr mapper ) args in 
-
-
-  {e with pexp_desc = 
-            gen_fn_run loc len (Exp.mk ~loc @@ down_with_name ~loc obj name)
-              args
-    }
-        (** TODO: 
-            More syntax sanity check for [case_set] 
-            case_set: arity 2
-            _set : arity 1            
-            case:
-        *)
-
-let handle_obj_method loc (obj : Parsetree.expression) 
-    name (value : Parsetree.expression) e 
-    (mapper : Ast_mapper.mapper) : Parsetree.expression = 
-  let args = destruct_tuple_exp value in 
-  let len = List.length args in 
-  let obj = mapper.expr mapper obj in 
-  let args = List.map (mapper.expr mapper ) args in 
-  {e with pexp_desc =
-            gen_method_run loc len 
-              (Exp.mk ~loc (down_with_name ~loc obj name )) (obj::args)
-  }
-
-(** object 
-    for setter : we can push more into [Lsend] and enclose it with a unit type
-
-    for getter :
-
-    (* Invariant: we expect the typechecker & lambda emitter  
-       will not do agressive inlining
-       Worst things could happen
-    {[
-      let x = y## case 3  in 
-      x 2
-    ]}
-       in normal case, it should be compiled into Lambda
-    {[
-      let x = Lsend(y,case, [3]) in 
-      Lapp(x,2)
-    ]}
-
-       worst:
-    {[ Lsend(y, case, [3,2])
-    ]}               
-       for setter(include case setter), this could 
-       be prevented by type system, for getter.
-
-       solution: we can prevent this by rewrite into 
-    {[
-      Fn.run1  (!x# case) v 
-      ]}
-       *)
-
-      *)
 
 
 let rec unsafe_mapper : Ast_mapper.mapper =   
   { Ast_mapper.default_mapper with 
-    expr = (fun mapper e -> 
+    expr = (fun self ({ pexp_loc = loc } as e) -> 
         match e.pexp_desc with 
-        (** Begin rewriting [bs.raw], its output should not be rewritten anymore
-        *)        
+        (** Its output should not be rewritten anymore *)        
         | Pexp_extension (
             {txt = "bs.raw"; loc} , payload)
           -> 
-          begin match Ast_payload.as_string_exp payload with 
-            | None -> 
-              Location.raise_errorf ~loc "bs.raw can only be applied to a string"
-            | Some exp -> 
-              let pval_prim = ["js_pure_expr"] in
-              { exp with pexp_desc = Ast_comb.create_local_external loc 
-                           ~pval_prim
-                           ~pval_type:(arrow "" 
-                                         (Ast_literal.type_string ~loc ()) 
-                                         (Ast_literal.type_any ~loc ()) )
-
-                           ["",exp]}
-          end
-
-        (** End rewriting [bs.raw] *)
-
-        (** Begin rewriting [bs.debugger], its output should not be rewritten any more*)
+          Ast_util.handle_raw loc payload
+        (** [bs.debugger], its output should not be rewritten any more*)
         | Pexp_extension ({txt = "bs.debugger"; loc} , payload)
-          -> {e with pexp_desc = handle_debugger loc payload}
+          -> {e with pexp_desc = Ast_util.handle_debugger loc payload}
         | Pexp_extension ({txt = "bs.obj"; loc},  payload)
           -> 
             begin match payload with 
             | PStr [{pstr_desc = Pstr_eval (e,_)}]
               -> 
               Ext_ref.protect2 record_as_js_object  obj_type_as_js_obj_type
-                (Some as_js_object_attribute ) true
-                (fun ()-> mapper.expr mapper e ) 
+                (Some Ast_util.bs_object_attribute ) true
+                (fun ()-> self.expr self e ) 
             | _ -> Location.raise_errorf ~loc "Expect an expression here"
             end
-        | Pexp_extension ({txt = "meth"; loc}, payload) 
-          -> 
-          begin match payload with 
-            | PStr [{pstr_desc = 
-                       Pstr_eval ({pexp_desc = Pexp_fun("", None, pat, body)} as e, _)
-                    }]
-              -> handle_uncurry_method_generation loc pat body e mapper 
-            | _ -> Location.raise_errorf ~loc "Expect an fun expression here"
-          end
         (** End rewriting *)
         | Pexp_fun ("", None, pat , body)
           ->
-          let loc = e.pexp_loc in 
-          begin match Ext_list.exclude_with_fact (function 
-              | {Location.txt = "uncurry"; _}, _ -> true 
-              | _ -> false) e.pexp_attributes with 
-          | None, _ -> Ast_mapper.default_mapper.expr mapper e 
-          | Some _, attrs 
+          begin match Ast_util.process_attributes_rev e.pexp_attributes with 
+          | _, `Nothing 
+            -> Ast_mapper.default_mapper.expr self e 
+          |  attrs , `Uncurry
             -> 
-            begin match body.pexp_desc with 
-              | Pexp_fun _ -> 
-                Location.raise_errorf ~loc 
-                  {| `fun [@uncurry] (param0, param1) -> `
-                     instead of `fun [@uncurry] param0 param1 ->` |}
-              | _ -> 
-                handle_uncurry_fn_generation loc pat body 
-                  {e with pexp_attributes = attrs } mapper
-            end
+            Ast_util.destruct_arrow_as_fn loc pat body self e attrs
+          | pexp_attributes, `Meth 
+            -> 
+            Ast_util.destruct_arrow_as_meth_callbak loc pat body self e pexp_attributes
           end
+        | Pexp_apply (fn, args  ) ->
+          begin match fn with 
+            | {pexp_desc = 
+                 Pexp_apply (
+                   {pexp_desc = 
+                      Pexp_ident  {txt = Lident "##"  ; loc} ; _},
+                   [("", obj) ;
+                    ("", {pexp_desc = Pexp_ident {txt = Lident name;_ } ; _} )
+                   ]);
+               _} ->  (* f##paint 1 2 *)
+              Ast_util.method_run loc obj name args e self
+            | {pexp_desc = 
+                 Pexp_apply (
+                   {pexp_desc = 
+                      Pexp_ident  {txt = Lident "#@"  ; loc} ; _},
+                   [("", obj) ;
+                    ("", {pexp_desc = Pexp_ident {txt = Lident name;_ } ; _} )
+                   ]);
+               _} ->  (* f##paint 1 2 *)
+              Ast_util.property_run loc obj name args e self
 
-        | Pexp_apply ({pexp_desc = Pexp_ident {txt = Lident "#@"; loc}},
-                      [("", fn);
-                       ("", pat)])
-          -> 
-          handle_uncurry_application loc fn pat e mapper
+            | {pexp_desc = 
+                 Pexp_ident  {txt = Lident "##" ; loc} ; _} 
+              -> 
+              begin match args with 
+                | [("", obj) ;
+                   ("", {pexp_desc = Pexp_apply(
+                        {pexp_desc = Pexp_ident {txt = Lident name;_ } ; _},
+                        args
+                      ) })
+                  ] -> (* f##(paint 1 2 ) *)
+                  Ast_util.method_run loc obj name args e self
+                | [("", obj) ;
+                   ("", 
+                    {pexp_desc = Pexp_ident {txt = Lident name;_ } ; _}
+                   )  (* f##paint  *)
+                  ] -> handle_obj_property loc obj name e self
+                | _ -> 
+                  Location.raise_errorf ~loc
+                    "Js object ## expect syntax like obj##(paint (a,b)) "
+              end
+            (* we can not use [:=] for precedece cases 
+               like {[i @@ x##length := 3 ]} 
+               is parsed as {[ (i @@ x##length) := 3]}
+            *)
+            | {pexp_desc = 
+                 Pexp_ident {txt = Lident  "#="}
+              } -> 
+              begin match args with 
+              | ["", 
+                  {pexp_desc = 
+                     Pexp_apply ({pexp_desc = Pexp_ident {txt = Lident "##"}}, 
+                                 ["", obj; 
+                                  "", {pexp_desc = Pexp_ident {txt = Lident name}}
+                                 ]                                 
+                                )}; 
+                 "", arg
+                ] -> 
+                Ast_util.method_run loc obj (name ^ Literals.setter_suffix) ["", arg ] e self
+              | _ -> Ast_mapper.default_mapper.expr self e 
+              end
+            | _ -> 
 
-        | Pexp_apply
-            ({pexp_desc = 
-               Pexp_apply (
-                 {pexp_desc = 
-                    Pexp_ident  {txt = Lident "##" ; loc} ; _},
-                 [("", obj) ;
-                  ("", {pexp_desc = Pexp_ident {txt = Lident name;_ } ; _} )
-                 ]);
-              _
-             }, args  )
-          -> (** f ## xx a b -->  (f ## x a ) b -- we just pick the first one 
-                 f ## xx (a,b)
-                 f #.(xx (a,b))
-             *)
-          begin match args with 
-          | [ "", value] -> 
-              handle_obj_fn loc obj name value e mapper
-          | _ -> 
-            Location.raise_errorf 
-              "Js object ## expect only one argument when it is a method "
+              begin match Ext_list.exclude_with_fact (function 
+                  | {Location.txt = "bs"; _}, _ -> true 
+                  | _ -> false) e.pexp_attributes with 
+              | None, _ -> Ast_mapper.default_mapper.expr self e 
+              | Some _, attrs -> 
+                Ast_util.fn_run loc fn args self e attrs 
+              end
           end
-        (* TODO: design: shall we allow 
-                               {[ x #.Capital ]}
-        *)
-        | Pexp_apply (
-            {pexp_desc = 
-               Pexp_ident  {txt = Lident "##" ; loc} ; _}, args
-          )
-          -> (* f##(paint (1,2)) or f##paint *)
-          begin match args with 
-          | [("", obj) ;
-             ("", {pexp_desc = Pexp_apply(
-                  {pexp_desc = Pexp_ident {txt = Lident name;_ } ; _},
-                  ["", value]
-                ) })
-            ] -> 
-            handle_obj_fn loc obj name value e mapper
-          | [("", obj) ;
-                       ("", 
-                       {pexp_desc = Pexp_ident {txt = Lident name;_ } ; _}
-                         )
-                      ] -> handle_obj_property loc obj name e mapper
-          | _ -> 
-            Location.raise_errorf 
-              "Js object ## expect syntax like obj##(paint (a,b)) "
-
-          end
-
-        | Pexp_apply
-            ({pexp_desc = 
-               Pexp_apply (
-                 {pexp_desc = 
-                    Pexp_ident  {txt = Lident "#." ; loc} ; _},
-                 [("", obj) ;
-                  ("", {pexp_desc = Pexp_ident {txt = Lident name;_ } ; _} )
-                 ]);
-              _
-             }, args  )
-          -> (** f ## xx a b -->  (f ## x a ) b -- we just pick the first one 
-                 f #.xx (a,b)
-             *)
-          begin match args with 
-          | [ "", value] -> 
-              handle_obj_method loc obj name value e mapper
-          | _ -> 
-            Location.raise_errorf 
-              "Js object ## expect only one argument when it is a method "
-          end
-        | Pexp_apply (
-            {pexp_desc =
-               Pexp_ident  {txt = Lident "#." ; loc} ; _}, args
-          )
-          -> (* f##(paint (1,2)) or f##paint *)
-          begin match args with
-          | [("", obj) ;
-             ("", {pexp_desc = Pexp_apply(
-                  {pexp_desc = Pexp_ident {txt = Lident name;_ } ; _},
-                  ["", value]
-                ) })
-            ] ->
-            handle_obj_method loc obj name value e mapper
-          | _ ->
-            Location.raise_errorf
-              "Js object #. expect syntax like obj#.(paint (a,b)) "
-
-          end
-
-
-        | Pexp_apply (fn,
-                      [("", pat)]) -> 
-          let loc = e.pexp_loc in 
-          begin match Ext_list.exclude_with_fact (function 
-              | {Location.txt = "uncurry"; _}, _ -> true 
-              | _ -> false) e.pexp_attributes with 
-          | None, _ -> Ast_mapper.default_mapper.expr mapper e 
-          | Some _, attrs -> 
-            handle_uncurry_application loc fn pat 
-              {e with pexp_attributes = attrs} mapper
-          end
-
         | Pexp_record (label_exprs, None)  -> 
             begin match !record_as_js_object with 
             | Some attr 
               (* TODO better error message when [with] detected in [%bs.obj] *)
               -> 
               { e with
-                pexp_desc =  handle_record_as_js_object e.pexp_loc attr label_exprs mapper;
+                pexp_desc =  handle_record_as_js_object e.pexp_loc attr label_exprs self;
               }
             | None -> 
-              Ast_mapper.default_mapper.expr  mapper e
+              Ast_mapper.default_mapper.expr  self e
             end
 
-        | _ ->  Ast_mapper.default_mapper.expr  mapper e
+        | _ ->  Ast_mapper.default_mapper.expr self e
       );
     typ = (fun self typ -> handle_typ Ast_mapper.default_mapper self typ);
-    class_type = (fun self ctyp -> handle_class_obj_typ Ast_mapper.default_mapper self ctyp);
-    structure_item = (fun mapper (str : Parsetree.structure_item) -> 
+    class_signature = 
+      (fun self ({pcsig_self; pcsig_fields } as csg) -> 
+         if !bs_class_type then 
+           let pcsig_self = self.typ self pcsig_self in 
+           {
+             pcsig_self ;
+             pcsig_fields = List.fold_right (fun  f  acc ->
+               handle_class_type_field  acc self f 
+             )  pcsig_fields []
+           }
+         else 
+           Ast_mapper.default_mapper.class_signature self csg 
+      );
+    structure_item = (fun self (str : Parsetree.structure_item) -> 
         begin match str.pstr_desc with 
         | Pstr_extension ( ({txt = "bs.raw"; loc}, payload), _attrs) 
           -> 
-            begin match Ast_payload.as_string_exp payload with 
-              | Some exp 
-                -> 
-                let pval_prim = ["js_pure_stmt"] in 
-                Ast_helper.Str.eval 
-                  { exp with pexp_desc =
-                             Ast_comb.create_local_external loc 
-                               ~pval_prim
-                               ~pval_type:(arrow ""
-                                             (Ast_literal.type_string ~loc ())
-                                             (Ast_literal.type_any ~loc ()))
-                               ["",exp]}
-              | None
-                -> 
-                Location.raise_errorf ~loc "bs.raw can only be applied to a string"
-            end
-        | _ -> Ast_mapper.default_mapper.structure_item mapper str 
+          Ast_util.handle_raw_structure loc payload
+        | _ -> Ast_mapper.default_mapper.structure_item self str 
         end
       )
   }
 
 
+
+
+(** global configurations below *)
 let common_actions_table : 
-  (string *  (Parsetree.expression -> unit)) list = 
+  (string *  (Parsetree.expression option -> unit)) list = 
   [ "obj_type_auto_uncurry", 
     (fun e -> 
-       obj_type_auto_uncurry := Ast_payload.assert_bool_lit e
+       obj_type_auto_uncurry := 
+         (match e with Some e -> Ast_payload.assert_bool_lit e
+         | None -> true)
+    ); 
+    "bs_class_type", 
+    (fun e -> 
+       bs_class_type := 
+         (match e with Some e -> Ast_payload.assert_bool_lit e 
+         | None -> true)
     )
   ]
 
@@ -3355,24 +3845,39 @@ let common_actions_table :
 let structural_config_table  = 
   String_map.of_list 
     (( "non_export" , 
-      (fun e -> non_export := Ast_payload.assert_bool_lit e ))
+      (fun x -> 
+         non_export := (
+           match x with 
+           |Some e -> Ast_payload.assert_bool_lit e 
+           | None -> true)
+      ))
       :: common_actions_table)
 
-let signature_config_table = 
+let signature_config_table : 
+  (Parsetree.expression option -> unit) String_map.t= 
   String_map.of_list common_actions_table
 
 
-let make_call_back table ((x : Longident.t Asttypes.loc) , y) = 
+let make_call_back table 
+    ((x : Longident.t Asttypes.loc) , 
+     (y :Parsetree.expression)) = 
   match x with 
   | {txt = Lident name; loc  } -> 
     begin match String_map.find name table with 
-    | fn -> fn y
-    | exception _ -> Location.raise_errorf ~loc "%s is not supported" name
+      | fn -> 
+        let y = 
+          match y with 
+          | {pexp_desc = Pexp_ident {txt = Lident name2} } when name2 = name -> 
+            None 
+          | _ -> Some y in
+        fn y
+      | exception _ -> Location.raise_errorf ~loc "%s is not supported" name
     end
-  | {loc} -> 
-    Location.raise_errorf ~loc "invalid label for config"
+  | _ -> 
+    Location.raise_errorf ~loc:x.loc "invalid label for config"
 
-let rewrite_signature : (Parsetree.signature -> Parsetree.signature) ref = 
+let rewrite_signature : 
+  (Parsetree.signature  -> Parsetree.signature) ref = 
   ref (fun  x -> 
       let result = 
         match (x : Parsetree.signature) with 
@@ -5149,7 +5654,7 @@ val unit : t
 
 val sequor : binop
 val sequand : binop
-val not : unop
+val not_ : unop
 val seq : binop
 val while_ : binop
 val event : t -> Lambda.lambda_event -> t  
@@ -5484,6 +5989,8 @@ let false_ : t =
 let unit : t = 
   Lconst (Const_pointer( 0, Pt_constructor "()"))
 
+let assert_false_unit : t = 
+  Lconst (Const_pointer( 0, Pt_constructor "impossible branch"))
 
 (** [l || r ] *)
 let sequor l r = if_ l true_ r 
@@ -5696,7 +6203,7 @@ let prim ~primitive:(prim : Prim.t) ~args:(ll : t list)  : t =
   | _ -> default ()
 
 
-let not x : t = 
+let not_ x : t = 
   prim Pnot [x] 
 
 let lam_prim ~primitive:(p : Lambda.primitive) ~args  : t = 
@@ -5751,25 +6258,33 @@ let lam_prim ~primitive:(p : Lambda.primitive) ~args  : t =
 
   | Pccall a -> 
     let prim_name = a.prim_name in
-    begin match prim_name with 
-    |  "js_debugger"
-      -> prim ~primitive:Pdebugger ~args 
-    | "js_fn_run" 
-      -> 
-      prim ~primitive:(Pjs_fn_run (int_of_string a.prim_native_name)) ~args 
-    |  "js_fn_mk"  
-      -> 
-      prim ~primitive:(Pjs_fn_make (int_of_string a.prim_native_name)) ~args           
-    | "js_fn_method"
-      ->
-      prim ~primitive:(Pjs_fn_method (int_of_string a.prim_native_name)) ~args           
-    | "js_fn_runmethod"
-      ->
-      prim ~primitive:(Pjs_fn_runmethod (int_of_string a.prim_native_name)) ~args           
-    | _ -> 
+    if Pervasives.not @@ Ext_string.starts_with prim_name "js_" then 
+      prim ~primitive:(Pccall a ) ~args else 
+    if prim_name =  "js_debugger" then 
+      prim ~primitive:Pdebugger ~args else 
+    if prim_name =  Literals.js_fn_run || prim_name = Literals.js_method_run then
+      prim ~primitive:(Pjs_fn_run (int_of_string a.prim_native_name)) ~args else 
+    if prim_name = "js_fn_mk" then 
+      prim ~primitive:(Pjs_fn_make (int_of_string a.prim_native_name)) ~args else                
+    if prim_name = "js_fn_method" then 
+      prim ~primitive:(Pjs_fn_method (int_of_string a.prim_native_name)) ~args else
+    if prim_name = "js_fn_runmethod" then 
+      prim ~primitive:(Pjs_fn_runmethod (int_of_string a.prim_native_name)) ~args 
+    else
       prim ~primitive:(Pccall a) ~args
-    end
-  | Praise _ -> prim ~primitive:Praise ~args
+  | Praise _ ->
+    if Js_config.get_no_any_assert () then 
+      begin match args with 
+        | [Lprim {primitive = Pmakeblock (0, _, _) ; 
+                  args = [ 
+                    Lprim {primitive = Pgetglobal ({name = "Assert_failure"} as id); args =  []}; 
+                    _
+                  ]
+                 } ] when Ident.global id
+          -> assert_false_unit
+        | _ -> prim ~primitive:Praise ~args
+      end
+    else prim ~primitive:Praise ~args
   | Psequand -> prim ~primitive:Psequand ~args 
   | Psequor -> prim ~primitive:Psequor ~args
   | Pnot -> prim ~primitive:Pnot ~args
@@ -17201,9 +17716,9 @@ end = struct
   what is the behavior for 
   {[
     { case : 
-        (fun [@uncurry] i -> 3);
+        (fun [@fn] i -> 3);
       case_set: 
-        (fun [@uncurry] (i,v) -> ..)
+        (fun [@fn] (i,v) -> ..)
     }
   ]}
 *)
@@ -23010,6 +23525,7 @@ and
                   cont  block0 block1 (Some obj_code) (E.access (E.var obj) value)
               else if  Ext_string.ends_with method_name Literals.setter_suffix then 
                 let property =
+                  Lam_methname.translate ~loc @@ 
                   String.sub method_name 0 
                     (String.length method_name - Literals.setter_suffix_len) in 
                 match Js_ast_util.named_expression  obj with
@@ -24645,13 +25161,13 @@ let simplify_alias
         let l1 = 
           match x with 
           | Null 
-            -> Lam.not ( Lam.prim ~primitive:Lam.Prim.js_is_nil ~args:[l]) 
+            -> Lam.not_ ( Lam.prim ~primitive:Lam.Prim.js_is_nil ~args:[l]) 
           | Undefined 
             -> 
-            Lam.not (Lam.prim ~primitive:Lam.Prim.js_is_undef ~args:[l])
+            Lam.not_ (Lam.prim ~primitive:Lam.Prim.js_is_undef ~args:[l])
           | Null_undefined
             -> 
-            Lam.not
+            Lam.not_
               ( Lam.prim ~primitive:Lam.Prim.js_is_nil_undef  ~args:[l]) 
           | Normal ->  l1 
         in 
@@ -29757,6 +30273,10 @@ let add_include_path s =
   else 
     Ext_pervasives.failwithf ~loc:__LOC__ "%s is not a directory" s 
 
+let set_noassert () = 
+  Js_config.set_no_any_assert ();
+  Clflags.noassert := true
+
 
 let buckle_script_flags = 
   ("-bs-npm-output-path", Arg.String Js_config.set_npm_package_path, 
@@ -29778,6 +30298,9 @@ let buckle_script_flags =
       " More verbose output")
   :: ("-bs-no-check-div-by-zero", Arg.Clear Js_config.check_div_by_zero, 
       " unsafe mode, don't check div by zero and mod by zero")
+  :: ("-bs-no-any-assert", Arg.Unit set_noassert, 
+      " no code containing any assertion"
+     )
   :: ("-bs-files", Arg.Rest collect_file, 
       " Provide batch of files, the compiler will sort it before compiling"
      )
@@ -29787,11 +30310,13 @@ let buckle_script_flags =
   :: Ocaml_options.mk__ anonymous
   :: Ocaml_options.ocaml_options
 
-let () = 
-  Clflags.unsafe_string := false;
-  Clflags.debug := true
 
-let main () =
+
+
+let _ = 
+  Clflags.unsafe_string := false;
+  Clflags.debug := true;
+
   try
     Compenv.readenv ppf Before_args;
     Arg.parse buckle_script_flags anonymous usage;
@@ -29800,8 +30325,6 @@ let main () =
   with x ->
     Location.report_exception ppf x;
     exit 2
-
-let _ = main ()
 
 
 

--- a/jscomp/common/literals.ml
+++ b/jscomp/common/literals.ml
@@ -51,10 +51,12 @@ let stdlib = "stdlib"
 
 let imul = "imul" (* signed int32 mul *)
 
-let setter_suffix = "_set"
+let setter_suffix = "#="
 let setter_suffix_len = String.length setter_suffix
 
 let case = "case"
 let case_set = "case_set"
 let case_prefix = "case_"
 
+let js_fn_run = "js_fn_run"
+let js_method_run = "js_method_run"

--- a/jscomp/common/literals.mli
+++ b/jscomp/common/literals.mli
@@ -56,3 +56,6 @@ val setter_suffix_len : int
 val case : string 
 val case_set : string 
 val case_prefix : string
+
+val js_fn_run : string
+val js_method_run : string

--- a/jscomp/lam.ml
+++ b/jscomp/lam.ml
@@ -513,7 +513,7 @@ let prim ~primitive:(prim : Prim.t) ~args:(ll : t list)  : t =
   | _ -> default ()
 
 
-let not x : t = 
+let not_ x : t = 
   prim Pnot [x] 
 
 let lam_prim ~primitive:(p : Lambda.primitive) ~args  : t = 
@@ -568,24 +568,20 @@ let lam_prim ~primitive:(p : Lambda.primitive) ~args  : t =
 
   | Pccall a -> 
     let prim_name = a.prim_name in
-    begin match prim_name with 
-    |  "js_debugger"
-      -> prim ~primitive:Pdebugger ~args 
-    | "js_fn_run" 
-      -> 
-      prim ~primitive:(Pjs_fn_run (int_of_string a.prim_native_name)) ~args 
-    |  "js_fn_mk"  
-      -> 
-      prim ~primitive:(Pjs_fn_make (int_of_string a.prim_native_name)) ~args           
-    | "js_fn_method"
-      ->
-      prim ~primitive:(Pjs_fn_method (int_of_string a.prim_native_name)) ~args           
-    | "js_fn_runmethod"
-      ->
-      prim ~primitive:(Pjs_fn_runmethod (int_of_string a.prim_native_name)) ~args           
-    | _ -> 
+    if Pervasives.not @@ Ext_string.starts_with prim_name "js_" then 
+      prim ~primitive:(Pccall a ) ~args else 
+    if prim_name =  "js_debugger" then 
+      prim ~primitive:Pdebugger ~args else 
+    if prim_name =  Literals.js_fn_run || prim_name = Literals.js_method_run then
+      prim ~primitive:(Pjs_fn_run (int_of_string a.prim_native_name)) ~args else 
+    if prim_name = "js_fn_mk" then 
+      prim ~primitive:(Pjs_fn_make (int_of_string a.prim_native_name)) ~args else                
+    if prim_name = "js_fn_method" then 
+      prim ~primitive:(Pjs_fn_method (int_of_string a.prim_native_name)) ~args else
+    if prim_name = "js_fn_runmethod" then 
+      prim ~primitive:(Pjs_fn_runmethod (int_of_string a.prim_native_name)) ~args 
+    else
       prim ~primitive:(Pccall a) ~args
-    end
   | Praise _ ->
     if Js_config.get_no_any_assert () then 
       begin match args with 

--- a/jscomp/lam.mli
+++ b/jscomp/lam.mli
@@ -220,7 +220,7 @@ val unit : t
 
 val sequor : binop
 val sequand : binop
-val not : unop
+val not_ : unop
 val seq : binop
 val while_ : binop
 val event : t -> Lambda.lambda_event -> t  

--- a/jscomp/lam_compile.ml
+++ b/jscomp/lam_compile.ml
@@ -830,6 +830,7 @@ and
                   cont  block0 block1 (Some obj_code) (E.access (E.var obj) value)
               else if  Ext_string.ends_with method_name Literals.setter_suffix then 
                 let property =
+                  Lam_methname.translate ~loc @@ 
                   String.sub method_name 0 
                     (String.length method_name - Literals.setter_suffix_len) in 
                 match Js_ast_util.named_expression  obj with

--- a/jscomp/lam_pass_remove_alias.ml
+++ b/jscomp/lam_pass_remove_alias.ml
@@ -71,13 +71,13 @@ let simplify_alias
         let l1 = 
           match x with 
           | Null 
-            -> Lam.not ( Lam.prim ~primitive:Lam.Prim.js_is_nil ~args:[l]) 
+            -> Lam.not_ ( Lam.prim ~primitive:Lam.Prim.js_is_nil ~args:[l]) 
           | Undefined 
             -> 
-            Lam.not (Lam.prim ~primitive:Lam.Prim.js_is_undef ~args:[l])
+            Lam.not_ (Lam.prim ~primitive:Lam.Prim.js_is_undef ~args:[l])
           | Null_undefined
             -> 
-            Lam.not
+            Lam.not_
               ( Lam.prim ~primitive:Lam.Prim.js_is_nil_undef  ~args:[l]) 
           | Normal ->  l1 
         in 

--- a/jscomp/runtime/caml_float.ml
+++ b/jscomp/runtime/caml_float.ml
@@ -117,7 +117,7 @@ let caml_modf_float (x : float) : float * float =
   else if Js.Float.is_nan x then Js.Float.nan ,  Js.Float.nan 
   else (1. /. x , x)
 
-let caml_ldexp_float : float ->  int -> float [@fn] = [%bs.raw {| function (x,exp) {
+let caml_ldexp_float : float ->  int -> float [@bs] = [%bs.raw {| function (x,exp) {
     exp |= 0;
     if (exp > 1023) {
         exp -= 1023;
@@ -138,7 +138,7 @@ let caml_ldexp_float : float ->  int -> float [@fn] = [%bs.raw {| function (x,ex
 
 
 
-let caml_frexp_float : float -> float * int [@fn]=  [%bs.raw {|function (x) {
+let caml_frexp_float : float -> float * int [@bs]=  [%bs.raw {|function (x) {
     if ((x == 0) || !isFinite(x)) return [ x, 0];
     var neg = x < 0;
     if (neg) x = - x;
@@ -178,7 +178,7 @@ let caml_log1p_float  : float -> float = function x ->
   if z = 0. then x else x *. log y /. z 
 
 
-let caml_hypot_float : float ->  float -> float [@fn] = [%bs.raw {| function (x, y) {
+let caml_hypot_float : float ->  float -> float [@bs] = [%bs.raw {| function (x, y) {
     var x0 = Math.abs(x), y0 = Math.abs(y);
     var a = Math.max(x0, y0), b = Math.min(x0,y0) / (a?a:1);
     return a * Math.sqrt(1 + b*b);
@@ -186,7 +186,7 @@ let caml_hypot_float : float ->  float -> float [@fn] = [%bs.raw {| function (x,
 |}]
 
 
-let caml_log10_float : float -> float [@fn] =  [%bs.raw {| function  (x) { 
+let caml_log10_float : float -> float [@bs] =  [%bs.raw {| function  (x) { 
    return Math.LOG10E * Math.log(x); }
 |} ]
 

--- a/jscomp/runtime/caml_float.mli
+++ b/jscomp/runtime/caml_float.mli
@@ -34,12 +34,12 @@ val caml_int32_bits_of_float : float -> int32
 val caml_classify_float : float -> fpclass
 val caml_modf_float : float -> float * float 
 
-val caml_ldexp_float : float -> int -> float [@fn]
-val caml_frexp_float : float -> float * int [@fn]
+val caml_ldexp_float : float -> int -> float [@bs]
+val caml_frexp_float : float -> float * int [@bs]
 val caml_float_compare : float -> float -> int 
 val caml_copysign_float : float -> float -> float
 val caml_expm1_float : float -> float 
 
-val caml_hypot_float : float -> float -> float  [@fn]
+val caml_hypot_float : float -> float -> float  [@bs]
 
-val caml_log10_float : float -> float [@fn]
+val caml_log10_float : float -> float [@bs]

--- a/jscomp/runtime/caml_format.ml
+++ b/jscomp/runtime/caml_format.ml
@@ -361,7 +361,7 @@ let aux f (i : nativeint)  =
       f.filter <- " ";
       let n = f.prec -Js.String.length !s in 
       if n > 0 then
-        s :=  repeat n "0" [@fn]  ^ !s
+        s :=  repeat n "0" [@bs]  ^ !s
     end ;
   finish_formatting f !s
 
@@ -484,7 +484,7 @@ let caml_int64_format fmt x =
       f.filter <- " ";
       let n = f.prec -Js.String.length !s in
       if n > 0 then
-        s := repeat n "0" [@fn] ^ !s
+        s := repeat n "0" [@bs] ^ !s
     end;
 
   finish_formatting f !s

--- a/jscomp/runtime/caml_int64.ml
+++ b/jscomp/runtime/caml_int64.ml
@@ -388,7 +388,7 @@ let to_hex x =
     if pad <= 0 then             
       aux x.hi ^ lo
     else
-      aux x.hi ^ Caml_utils.repeat pad "0" [@fn] ^ lo 
+      aux x.hi ^ Caml_utils.repeat pad "0" [@bs] ^ lo 
 
 let discard_sign x = {x with hi = Nativeint.logand 0x7fff_ffffn x.hi }  
 

--- a/jscomp/runtime/caml_io.ml
+++ b/jscomp/runtime/caml_io.ml
@@ -44,7 +44,7 @@ let stdout = {
   output = (fun _ s ->
     let v =Js.String.length s - 1 in
     if [%bs.raw{| (typeof process !== "undefined") && process.stdout && process.stdout.write|}] then
-      ([%bs.raw{| process.stdout.write |} ] : string -> unit [@fn]) s [@fn]
+      ([%bs.raw{| process.stdout.write |} ] : string -> unit [@bs]) s [@bs]
     else
     if s.[v] = '\n' then
       Js.log (Js.String.slice s 0 v)
@@ -86,7 +86,7 @@ let caml_ml_output (oc : out_channel) (str : string) offset len  =
     else Js.String.slice str offset len in
   if [%bs.raw{| (typeof process !== "undefined") && process.stdout && process.stdout.write |}] &&
      oc == stdout then
-    ([%bs.raw{| process.stdout.write |}] : string -> unit [@fn] ) str [@fn]
+    ([%bs.raw{| process.stdout.write |}] : string -> unit [@bs] ) str [@bs]
 
   else
     begin     

--- a/jscomp/runtime/caml_utils.ml
+++ b/jscomp/runtime/caml_utils.ml
@@ -31,7 +31,7 @@
 (* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/imul *)
 
 
-let repeat : int -> string -> string [@fn] = [%bs.raw{| (String.prototype.repeat && function (count,self){return self.repeat(count)}) ||
+let repeat : int -> string -> string [@bs] = [%bs.raw{| (String.prototype.repeat && function (count,self){return self.repeat(count)}) ||
                                                   function(count , self) {
         if (self.length == 0 || count == 0) {
             return '';

--- a/jscomp/runtime/caml_utils.mli
+++ b/jscomp/runtime/caml_utils.mli
@@ -27,4 +27,4 @@
 
 
 
-val repeat : int -> string -> string [@fn]
+val repeat : int -> string -> string [@bs]

--- a/jscomp/runtime/js.ml
+++ b/jscomp/runtime/js.ml
@@ -27,8 +27,8 @@ type (-'obj, +'a) meth_callback
 type +'a t (** Js object type *)
 
 
-
-type (-'arg, + 'result)fn (** Js uncurried function *)
+type (-'arg, + 'result) meth
+type (-'arg, + 'result) fn (** Js uncurried function *)
 
 (** This file will also be exported to external users 
     Attention: it should not have any code, all its code will be inlined so that 

--- a/jscomp/runtime/js_unsafe.ml
+++ b/jscomp/runtime/js_unsafe.ml
@@ -28,22 +28,22 @@ external (!)  : 'a Js.t -> 'a = "js_unsafe_downgrade"
 external mk0 : 
   (unit -> 'a0) 
   ->
-  (unit -> 'a0 [@fn]) = 
+  (unit -> 'a0 [@bs]) = 
   "js_fn_mk" "0"
 
 external run0 : 
-  (unit -> 'a0 [@fn])  
+  (unit -> 'a0 [@bs])  
   ->
   'a0 = "js_fn_run" "0"
 
 external mk1 : 
   ('a0 -> 'a1) 
   ->
-  ('a0 -> 'a1 [@fn])  = 
+  ('a0 -> 'a1 [@bs])  = 
   "js_fn_mk" "1"
 
 external run1 : 
-  ('a0 -> 'a1 [@fn]) 
+  ('a0 -> 'a1 [@bs]) 
   ->
   'a0 -> 'a1  = 
   "js_fn_run" "1"
@@ -71,12 +71,12 @@ external run_method1 :
 external mk2 : 
   ('a0 -> 'a1 -> 'a2 ) 
   ->
-  ('a0 -> 'a1 -> 'a2 [@fn])
+  ('a0 -> 'a1 -> 'a2 [@bs])
   = 
   "js_fn_mk" "2"
 
 external run2 : 
-  ('a0 -> 'a1 -> 'a2 [@fn]) ->
+  ('a0 -> 'a1 -> 'a2 [@bs]) ->
   'a0 -> 'a1 -> 'a2  
   = 
   "js_fn_run" "2"
@@ -84,12 +84,12 @@ external run2 :
 external mk3 : 
   ('a0 -> 'a1 -> 'a2 -> 'a3 ) 
   ->
-  ('a0 -> 'a1 -> 'a2 -> 'a3 [@fn]) 
+  ('a0 -> 'a1 -> 'a2 -> 'a3 [@bs]) 
   = 
   "js_fn_mk" "3"
 
 external run3 : 
-   ('a0 -> 'a1 -> 'a2 -> 'a3 [@fn]) 
+   ('a0 -> 'a1 -> 'a2 -> 'a3 [@bs]) 
    ->
    'a0 -> 'a1 -> 'a2 -> 'a3 
   = 
@@ -98,12 +98,12 @@ external run3 :
 external mk4 : 
   ('a0 -> 'a1 -> 'a2 -> 'a3 -> 'a4 ) 
   -> 
-  ('a0 -> 'a1 -> 'a2 -> 'a3 -> 'a4 [@fn]) 
+  ('a0 -> 'a1 -> 'a2 -> 'a3 -> 'a4 [@bs]) 
   = 
   "js_fn_mk" "4"
 
 external run4 : 
-  ('a0 -> 'a1 -> 'a2 -> 'a3 -> 'a4 [@fn])
+  ('a0 -> 'a1 -> 'a2 -> 'a3 -> 'a4 [@bs])
   -> 
   'a0 -> 'a1 -> 'a2 -> 'a3 -> 'a4 
   = 
@@ -112,12 +112,12 @@ external run4 :
 external mk5 : 
   ('a0 -> 'a1 -> 'a2 -> 'a3 -> 'a4 -> 'a5 ) 
   ->
-  ('a0 -> 'a1 -> 'a2 -> 'a3 -> 'a4 -> 'a5 [@fn]) 
+  ('a0 -> 'a1 -> 'a2 -> 'a3 -> 'a4 -> 'a5 [@bs]) 
   =
   "js_fn_mk" "5"
 
 external run5 : 
-  ('a0 -> 'a1 -> 'a2 -> 'a3 -> 'a4 -> 'a5 [@fn])
+  ('a0 -> 'a1 -> 'a2 -> 'a3 -> 'a4 -> 'a5 [@bs])
   -> 
   'a0 -> 'a1 -> 'a2 -> 'a3 -> 'a4 -> 'a5 
   = 
@@ -126,12 +126,12 @@ external run5 :
 external mk6 : 
   ('a0 -> 'a1 -> 'a2 -> 'a3 -> 'a4 -> 'a5 -> 'a6)
   -> 
-  ('a0 -> 'a1 -> 'a2 -> 'a3 -> 'a4 -> 'a5 -> 'a6 [@fn])
+  ('a0 -> 'a1 -> 'a2 -> 'a3 -> 'a4 -> 'a5 -> 'a6 [@bs])
   =
   "js_fn_mk" "6"
 
 external run6 : 
-  ('a0 -> 'a1 -> 'a2 -> 'a3 -> 'a4 -> 'a5 -> 'a6 [@fn])
+  ('a0 -> 'a1 -> 'a2 -> 'a3 -> 'a4 -> 'a5 -> 'a6 [@bs])
   ->
   'a0 -> 'a1 -> 'a2 -> 'a3 -> 'a4 -> 'a5 -> 'a6 
   = 
@@ -140,12 +140,12 @@ external run6 :
 external mk7 : 
   ('a0 -> 'a1 -> 'a2 -> 'a3 -> 'a4 -> 'a5 -> 'a6 -> 'a7) 
   -> 
-  ('a0 -> 'a1 -> 'a2 -> 'a3 -> 'a4 -> 'a5 -> 'a6 -> 'a7 [@fn]) 
+  ('a0 -> 'a1 -> 'a2 -> 'a3 -> 'a4 -> 'a5 -> 'a6 -> 'a7 [@bs]) 
   =
   "js_fn_mk" "7"
 
 external run7 : 
-  ('a0 -> 'a1 -> 'a2 -> 'a3 -> 'a4 -> 'a5 -> 'a6 -> 'a7 [@fn])
+  ('a0 -> 'a1 -> 'a2 -> 'a3 -> 'a4 -> 'a5 -> 'a6 -> 'a7 [@bs])
   ->
   'a0 -> 'a1 -> 'a2 -> 'a3 -> 'a4 -> 'a5 -> 'a6 -> 'a7 
   = 
@@ -154,12 +154,12 @@ external run7 :
 external mk8 :
   ('a0 -> 'a1 -> 'a2 -> 'a3 -> 'a4 -> 'a5 -> 'a6 -> 'a7 -> 'a8 ) 
   ->
-  ('a0 -> 'a1 -> 'a2 -> 'a3 -> 'a4 -> 'a5 -> 'a6 -> 'a7 -> 'a8 [@fn]) 
+  ('a0 -> 'a1 -> 'a2 -> 'a3 -> 'a4 -> 'a5 -> 'a6 -> 'a7 -> 'a8 [@bs]) 
   =
   "js_fn_mk" "8"
 
 external run8 :   
-  ('a0 -> 'a1 -> 'a2 -> 'a3 -> 'a4 -> 'a5 -> 'a6 -> 'a7 -> 'a8 [@fn])
+  ('a0 -> 'a1 -> 'a2 -> 'a3 -> 'a4 -> 'a5 -> 'a6 -> 'a7 -> 'a8 [@bs])
   -> 
   'a0 -> 'a1 -> 'a2 -> 'a3 -> 'a4 -> 'a5 -> 'a6 -> 'a7 -> 'a8 
   = 
@@ -168,12 +168,12 @@ external run8 :
 external mk9 : 
   ('a0 -> 'a1 -> 'a2 -> 'a3 -> 'a4 -> 'a5 -> 'a6 -> 'a7 -> 'a8 -> 'a9) 
   ->
-  ('a0 -> 'a1 -> 'a2 -> 'a3 -> 'a4 -> 'a5 -> 'a6 -> 'a7 -> 'a8 -> 'a9 [@fn]) 
+  ('a0 -> 'a1 -> 'a2 -> 'a3 -> 'a4 -> 'a5 -> 'a6 -> 'a7 -> 'a8 -> 'a9 [@bs]) 
   =
   "js_fn_mk" "9"
 
 external run9 : 
-  ('a0 -> 'a1 -> 'a2 -> 'a3 -> 'a4 -> 'a5 -> 'a6 -> 'a7 -> 'a8 -> 'a9 [@fn])
+  ('a0 -> 'a1 -> 'a2 -> 'a3 -> 'a4 -> 'a5 -> 'a6 -> 'a7 -> 'a8 -> 'a9 [@bs])
   -> 
   'a0 -> 'a1 -> 'a2 -> 'a3 -> 'a4 -> 'a5 -> 'a6 -> 'a7 -> 'a8 -> 'a9 
   = 

--- a/jscomp/syntax/ast_literal.ml
+++ b/jscomp/syntax/ast_literal.ml
@@ -37,6 +37,9 @@ module Lid = struct
   let js_fn = Longident.Ldot (Lident "Js", "fn")
   let pervasives_fn = Longident.Ldot (Lident "Pervasives", "fn")
 
+  let js_meth = Longident.Ldot (Lident "Js", "meth")
+  let pervasives_meth = Longident.Ldot (Lident "Pervasives", "meth")
+
   let pervasives_meth_callback = Longident.Ldot (Lident "Pervasives", "meth_callback")
   let js_obj = Longident.Ldot (Lident "Js", "t") 
 

--- a/jscomp/syntax/ast_literal.mli
+++ b/jscomp/syntax/ast_literal.mli
@@ -30,8 +30,11 @@ module Lid : sig
   val type_unit : t 
   val pervasives_js_obj : t 
 
-  val pervasives_fn : t 
   val js_fn : t 
+  val pervasives_fn : t 
+
+  val js_meth : t 
+  val pervasives_meth : t 
 
   val pervasives_meth_callback : t
   val js_meth_callback : t 

--- a/jscomp/syntax/ast_payload.ml
+++ b/jscomp/syntax/ast_payload.ml
@@ -56,7 +56,8 @@ let as_empty_structure (x : t ) =
 
 let as_record_and_process 
     loc
-    ( x : t ) (action : Longident.t Asttypes.loc * Parsetree.expression -> unit ): unit= 
+    ( x : t )
+    (action : Longident.t Asttypes.loc * Parsetree.expression -> unit ): unit= 
   match  x with 
   | PStr [ {pstr_desc = Pstr_eval
                 ({pexp_desc = Pexp_record (label_exprs, with_obj) ; pexp_loc = loc}, _); 

--- a/jscomp/syntax/ast_util.ml
+++ b/jscomp/syntax/ast_util.ml
@@ -223,9 +223,9 @@ let bs_object_attribute  : Parsetree.attribute
   = {txt = "bs.obj" ; loc = Location.none}, empty_payload
 
 let bs_uncurry_attribute : Parsetree.attribute        
-  =  {txt = "fn" ; loc = Location.none}, empty_payload
+  =  {txt = "bs" ; loc = Location.none}, empty_payload
 let bs_meth_attribute : Parsetree.attribute        
-  =  {txt = "meth_callback" ; loc = Location.none}, empty_payload
+  =  {txt = "bs.this" ; loc = Location.none}, empty_payload
 
 
 
@@ -233,16 +233,16 @@ let process_attributes_rev (attrs : Parsetree.attributes) =
   List.fold_left (fun (acc, st) attr -> 
       let tag = fst attr in
       match tag.Location.txt, st  with 
-      | "fn", (`Nothing | `Uncurry) 
+      | "bs", (`Nothing | `Uncurry) 
         -> 
         (acc, `Uncurry)
-      | "meth_callback", (`Nothing | `Meth)
+      | "bs.this", (`Nothing | `Meth)
         -> (acc, `Meth)
-      | "fn", `Meth 
-      | "meth_callback", `Uncurry
+      | "bs", `Meth 
+      | "bs.this", `Uncurry
         -> Location.raise_errorf 
              ~loc:tag.Location.loc 
-             "[@meth_callback] and [@fn] can not be applied at the same time"
+             "[@bs.this] and [@bs] can not be applied at the same time"
       | _ , _ -> 
         (attr::acc , st)
     ) ([], `Nothing) attrs
@@ -276,7 +276,7 @@ let destruct_arrow loc (first_arg : Parsetree.core_type)
   let rec aux acc (typ : Parsetree.core_type) = 
     (* in general, 
        we should collect [typ] in [int -> typ] before transformation, 
-       however: when attributes [fn] and [meth_callback] found in typ, 
+       however: when attributes [bs] and [bs.this] found in typ, 
        we should stop 
     *)
     match process_attributes_rev typ.ptyp_attributes with 
@@ -309,7 +309,7 @@ let destruct_arrow_as_meth_type loc (first_arg : Parsetree.core_type)
   let rec aux acc (typ : Parsetree.core_type) = 
     (* in general, 
        we should collect [typ] in [int -> typ] before transformation, 
-       however: when attributes [fn] and [meth_callback] found in typ, 
+       however: when attributes [bs] and [bs.this] found in typ, 
        we should stop 
     *)
     match process_attributes_rev typ.ptyp_attributes with 

--- a/jscomp/syntax/ast_util.mli
+++ b/jscomp/syntax/ast_util.mli
@@ -38,9 +38,25 @@ val method_run :
   (string * Parsetree.expression) list ->
   Parsetree.expression -> Ast_mapper.mapper -> Parsetree.expression
 
+val property_run : 
+  Ast_helper.loc ->
+  Parsetree.expression ->
+  string ->
+  (string * Parsetree.expression) list ->
+  Parsetree.expression -> Ast_mapper.mapper -> Parsetree.expression
+
+
 val process_attributes_rev : 
   Parsetree.attributes ->
   Parsetree.attributes * [ `Meth | `Nothing | `Uncurry ]
+
+type ('a,'b) st = 
+  { get : 'a option ; 
+    set : 'b option }
+
+val process_method_attributes_rev : 
+  Parsetree.attributes ->
+  Parsetree.attribute list * (Parsetree.payload, Parsetree.payload) st
 
 (** turn {[ fun [@fn] (x,y) -> x]} into an uncurried function 
     TODO: Future 
@@ -68,7 +84,12 @@ val destruct_arrow :
   Parsetree.core_type ->
   Parsetree.core_type -> Ast_mapper.mapper -> Parsetree.core_type
 
-val destruct_arrow_as_meth : 
+val destruct_arrow_as_meth_type : 
+  Ast_helper.loc ->
+  Parsetree.core_type ->
+  Parsetree.core_type -> Ast_mapper.mapper -> Parsetree.core_type
+
+val destruct_arrow_as_meth_callback_type : 
   Ast_helper.loc ->
   Parsetree.core_type ->
   Parsetree.core_type -> Ast_mapper.mapper -> Parsetree.core_type

--- a/jscomp/syntax/ast_util.mli
+++ b/jscomp/syntax/ast_util.mli
@@ -58,7 +58,7 @@ val process_method_attributes_rev :
   Parsetree.attributes ->
   Parsetree.attribute list * (Parsetree.payload, Parsetree.payload) st
 
-(** turn {[ fun [@fn] (x,y) -> x]} into an uncurried function 
+(** turn {[ fun [@bs] x y -> x]} into an uncurried function 
     TODO: Future 
     {[ fun%bs this (a,b,c) -> 
     ]}

--- a/jscomp/syntax/ppx_entry.ml
+++ b/jscomp/syntax/ppx_entry.ml
@@ -217,7 +217,7 @@ let handle_typ
     let methods, ptyp_attributes  =
       begin match Ext_list.exclude_with_fact
                     (function 
-                      | {Location.txt = "fn"; _}, _ -> true
+                      | {Location.txt = "bs"; _}, _ -> true
                       | _ -> false)
                     ptyp_attributes with 
       | None, _  ->
@@ -374,7 +374,7 @@ let rec unsafe_mapper : Ast_mapper.mapper =
             | _ -> 
 
               begin match Ext_list.exclude_with_fact (function 
-                  | {Location.txt = "fn"; _}, _ -> true 
+                  | {Location.txt = "bs"; _}, _ -> true 
                   | _ -> false) e.pexp_attributes with 
               | None, _ -> Ast_mapper.default_mapper.expr self e 
               | Some _, attrs -> 

--- a/jscomp/test/.depend
+++ b/jscomp/test/.depend
@@ -136,8 +136,10 @@ debug_keep_test.cmj :
 debug_keep_test.cmx :
 debugger_test.cmj : ../runtime/js.cmj
 debugger_test.cmx : ../runtime/js.cmx
-demo.cmj : ../runtime/js.cmj
-demo.cmx : ../runtime/js.cmx
+demo.cmj : ../runtime/js.cmj demo_binding.cmj
+demo.cmx : ../runtime/js.cmx demo_binding.cmx
+demo_binding.cmj : ../runtime/js.cmj
+demo_binding.cmx : ../runtime/js.cmx
 demo_int_map.cmj : ../stdlib/map.cmi demo_int_map.cmi
 demo_int_map.cmx : ../stdlib/map.cmx demo_int_map.cmi
 demo_page.cmj :
@@ -148,6 +150,8 @@ digest_test.cmx : ../stdlib/string.cmx ../stdlib/printf.cmx mt.cmx \
     ext_array.cmx ../stdlib/digest.cmx ../stdlib/array.cmx
 div_by_zero_test.cmj : mt.cmi ../stdlib/int64.cmi ../stdlib/int32.cmi
 div_by_zero_test.cmx : mt.cmx ../stdlib/int64.cmx ../stdlib/int32.cmx
+dom.cmj :
+dom.cmx :
 empty_obj.cmj :
 empty_obj.cmx :
 epsilon_test.cmj : mt.cmi
@@ -252,8 +256,8 @@ hashtbl_test.cmj : mt.cmi ../stdlib/moreLabels.cmi ../stdlib/list.cmi \
     ../stdlib/hashtbl.cmi ../stdlib/array.cmi
 hashtbl_test.cmx : mt.cmx ../stdlib/moreLabels.cmx ../stdlib/list.cmx \
     ../stdlib/hashtbl.cmx ../stdlib/array.cmx
-http_types.cmj :
-http_types.cmx :
+http_types.cmj : ../runtime/js.cmj
+http_types.cmx : ../runtime/js.cmx
 ignore_test.cmj : mt.cmi ../runtime/js.cmj
 ignore_test.cmx : mt.cmx ../runtime/js.cmx
 inline_edge_cases.cmj : inline_edge_cases.cmi
@@ -298,8 +302,8 @@ js_date.cmj : ../runtime/js.cmj
 js_date.cmx : ../runtime/js.cmx
 js_date_test.cmj : mt.cmi js_date.cmj
 js_date_test.cmx : mt.cmx js_date.cmx
-js_obj_test.cmj : mt.cmi ../runtime/js.cmj
-js_obj_test.cmx : mt.cmx ../runtime/js.cmx
+js_obj_test.cmj : mt.cmi
+js_obj_test.cmx : mt.cmx
 js_val.cmj :
 js_val.cmx :
 largest_int_flow.cmj :
@@ -498,6 +502,8 @@ test_bug.cmj : ../stdlib/bytes.cmi
 test_bug.cmx : ../stdlib/bytes.cmx
 test_bytes.cmj : ../stdlib/bytes.cmi
 test_bytes.cmx : ../stdlib/bytes.cmx
+test_case_set.cmj :
+test_case_set.cmx :
 test_char.cmj :
 test_char.cmx :
 test_closure.cmj : ../stdlib/array.cmi
@@ -676,8 +682,8 @@ test_unsafe_cmp.cmj : ../runtime/js.cmj
 test_unsafe_cmp.cmx : ../runtime/js.cmx
 test_unsafe_obj_ffi.cmj : ../runtime/js_unsafe.cmj test_unsafe_obj_ffi.cmi
 test_unsafe_obj_ffi.cmx : ../runtime/js_unsafe.cmx test_unsafe_obj_ffi.cmi
-test_unsafe_obj_ffi_ppx.cmj : test_unsafe_obj_ffi_ppx.cmi
-test_unsafe_obj_ffi_ppx.cmx : test_unsafe_obj_ffi_ppx.cmi
+test_unsafe_obj_ffi_ppx.cmj : ../runtime/js.cmj test_unsafe_obj_ffi_ppx.cmi
+test_unsafe_obj_ffi_ppx.cmx : ../runtime/js.cmx test_unsafe_obj_ffi_ppx.cmi
 test_unsupported_primitive.cmj : ../stdlib/bytes.cmi
 test_unsupported_primitive.cmx : ../stdlib/bytes.cmx
 test_while_closure.cmj : ../stdlib/array.cmi
@@ -830,8 +836,10 @@ debug_keep_test.cmo :
 debug_keep_test.cmj :
 debugger_test.cmo : ../runtime/js.cmo
 debugger_test.cmj : ../runtime/js.cmj
-demo.cmo : ../runtime/js.cmo
-demo.cmj : ../runtime/js.cmj
+demo.cmo : ../runtime/js.cmo demo_binding.cmo
+demo.cmj : ../runtime/js.cmj demo_binding.cmj
+demo_binding.cmo : ../runtime/js.cmo
+demo_binding.cmj : ../runtime/js.cmj
 demo_int_map.cmo : ../stdlib/map.cmi demo_int_map.cmi
 demo_int_map.cmj : ../stdlib/map.cmj demo_int_map.cmi
 demo_page.cmo :
@@ -842,6 +850,8 @@ digest_test.cmj : ../stdlib/string.cmj ../stdlib/printf.cmj mt.cmj \
     ext_array.cmj ../stdlib/digest.cmj ../stdlib/array.cmj
 div_by_zero_test.cmo : mt.cmi ../stdlib/int64.cmi ../stdlib/int32.cmi
 div_by_zero_test.cmj : mt.cmj ../stdlib/int64.cmj ../stdlib/int32.cmj
+dom.cmo :
+dom.cmj :
 empty_obj.cmo :
 empty_obj.cmj :
 epsilon_test.cmo : mt.cmi
@@ -946,8 +956,8 @@ hashtbl_test.cmo : mt.cmi ../stdlib/moreLabels.cmi ../stdlib/list.cmi \
     ../stdlib/hashtbl.cmi ../stdlib/array.cmi
 hashtbl_test.cmj : mt.cmj ../stdlib/moreLabels.cmj ../stdlib/list.cmj \
     ../stdlib/hashtbl.cmj ../stdlib/array.cmj
-http_types.cmo :
-http_types.cmj :
+http_types.cmo : ../runtime/js.cmo
+http_types.cmj : ../runtime/js.cmj
 ignore_test.cmo : mt.cmi ../runtime/js.cmo
 ignore_test.cmj : mt.cmj ../runtime/js.cmj
 inline_edge_cases.cmo : inline_edge_cases.cmi
@@ -992,8 +1002,8 @@ js_date.cmo : ../runtime/js.cmo
 js_date.cmj : ../runtime/js.cmj
 js_date_test.cmo : mt.cmi js_date.cmo
 js_date_test.cmj : mt.cmj js_date.cmj
-js_obj_test.cmo : mt.cmi ../runtime/js.cmo
-js_obj_test.cmj : mt.cmj ../runtime/js.cmj
+js_obj_test.cmo : mt.cmi
+js_obj_test.cmj : mt.cmj
 js_val.cmo :
 js_val.cmj :
 largest_int_flow.cmo :
@@ -1192,6 +1202,8 @@ test_bug.cmo : ../stdlib/bytes.cmi
 test_bug.cmj : ../stdlib/bytes.cmj
 test_bytes.cmo : ../stdlib/bytes.cmi
 test_bytes.cmj : ../stdlib/bytes.cmj
+test_case_set.cmo :
+test_case_set.cmj :
 test_char.cmo :
 test_char.cmj :
 test_closure.cmo : ../stdlib/array.cmi
@@ -1370,8 +1382,8 @@ test_unsafe_cmp.cmo : ../runtime/js.cmo
 test_unsafe_cmp.cmj : ../runtime/js.cmj
 test_unsafe_obj_ffi.cmo : ../runtime/js_unsafe.cmo test_unsafe_obj_ffi.cmi
 test_unsafe_obj_ffi.cmj : ../runtime/js_unsafe.cmj test_unsafe_obj_ffi.cmi
-test_unsafe_obj_ffi_ppx.cmo : test_unsafe_obj_ffi_ppx.cmi
-test_unsafe_obj_ffi_ppx.cmj : test_unsafe_obj_ffi_ppx.cmi
+test_unsafe_obj_ffi_ppx.cmo : ../runtime/js.cmo test_unsafe_obj_ffi_ppx.cmi
+test_unsafe_obj_ffi_ppx.cmj : ../runtime/js.cmj test_unsafe_obj_ffi_ppx.cmi
 test_unsupported_primitive.cmo : ../stdlib/bytes.cmi
 test_unsupported_primitive.cmj : ../stdlib/bytes.cmj
 test_while_closure.cmo : ../stdlib/array.cmi

--- a/jscomp/test/attr_test.ml
+++ b/jscomp/test/attr_test.ml
@@ -1,15 +1,15 @@
 
-let u = fun [@fn] x y -> x + y 
+let u = fun [@bs] x y -> x + y 
 
-let h = u 1 2 [@fn]
+let h = u 1 2 [@bs]
 
-type u = < v : int ; y : int > [@fn]
+type u = < v : int ; y : int > [@bs]
 type ('a,'b) xx = 
-  (< case : (int ->  (int -> 'a [@fn]) [@fn]); .. >   as 'b) 
+  (< case : (int ->  (int -> 'a [@bs]) [@bs]); .. >   as 'b) 
 type ('a,'b) xx_uncurry = 
-  (< case : int ->  (int -> 'a ); .. >  [@fn]) as 'b
+  (< case : int ->  (int -> 'a ); .. >  [@bs]) as 'b
 
-type yy_uncurry = < x : int > [@fn]
+type yy_uncurry = < x : int > [@bs]
 type yy = < x : int > 
 type number = float
 
@@ -28,7 +28,7 @@ class type date =
   end
 
 
-let max2 : float -> float -> float [@fn] = 
-  fun [@fn] x y ->   x +. y 
+let max2 : float -> float -> float [@bs] = 
+  fun [@bs] x y ->   x +. y 
 
-let hh = max2 1. 2. [@fn]
+let hh = max2 1. 2. [@bs]

--- a/jscomp/test/attr_test.ml
+++ b/jscomp/test/attr_test.ml
@@ -14,7 +14,7 @@ type yy = < x : int >
 type number = float
 
 class type date = 
-  object [@fn]
+  object
     method toDateString : unit -> string 
     method getTime : unit ->  number 
     method setMilliseconds : number ->  number 

--- a/jscomp/test/chain_code_test.ml
+++ b/jscomp/test/chain_code_test.ml
@@ -16,7 +16,9 @@ let f3 h x y =
   (h##paint x y)##draw x y
 
 let f4 h x y = 
-  (h##paint_set (x,y))##draw_set (x,y)
+  h
+  ##paint#=(x,y)
+  ##draw#= (x,y)
 
 
 (* let g h =  *)

--- a/jscomp/test/class_type_ffi_test.ml
+++ b/jscomp/test/class_type_ffi_test.ml
@@ -30,7 +30,7 @@ let sum_int_array (arr : intArray Js.t) =
 let sum_poly zero add (arr : _ arrayLike Js.t) = 
   let v = ref zero in 
   for i = 0 to arr##length - 1 do 
-    v := add  !v  (arr##case_unsafe i ) [@fn] 
+    v := add  !v  (arr##case_unsafe i ) [@bs] 
   done;
   !v 
 

--- a/jscomp/test/class_type_ffi_test.ml
+++ b/jscomp/test/class_type_ffi_test.ml
@@ -1,6 +1,6 @@
-
+[@@@bs.config{bs_class_type = true }]
 class type ['k,'v] arrayLike = 
-  object [@fn]
+  object 
     method case : 'k -> 'v Js.Null.t 
     method caseSet : 'k * 'v -> unit 
     method case_unsafe : 'k -> 'v 
@@ -33,3 +33,10 @@ let sum_poly zero add (arr : _ arrayLike Js.t) =
     v := add  !v  (arr##case_unsafe i ) [@fn] 
   done;
   !v 
+
+
+(* TODO: create a special type 
+   ['a Js.prop_set] for better error message
+*)
+let test_set x = 
+  x##length_aux #= 3 

--- a/jscomp/test/class_type_ffi_test.ml
+++ b/jscomp/test/class_type_ffi_test.ml
@@ -1,4 +1,4 @@
-[@@@bs.config{bs_class_type = true }]
+[@@@bs.config{bs_class_type  }]
 class type ['k,'v] arrayLike = 
   object 
     method case : 'k -> 'v Js.Null.t 

--- a/jscomp/test/config1_test.ml
+++ b/jscomp/test/config1_test.ml
@@ -1,7 +1,7 @@
 
 ;;[@@@bs.config{
-  obj_type_auto_uncurry = true;
-  non_export = true;
+  obj_type_auto_uncurry ;
+  non_export ;
 }]
 ;;
 

--- a/jscomp/test/config2_test.ml
+++ b/jscomp/test/config2_test.ml
@@ -1,11 +1,12 @@
 [@@@bs.config{
   obj_type_auto_uncurry = true;
+  bs_class_type = true 
   (* non_export = true; *)
 }]
 
 
 
-class type v = object [@fn]
+class type v = object 
   method hey : int -> int -> int 
 end 
 
@@ -33,4 +34,4 @@ let test_v (x : v Js.t) =
   x##hey 1 2
 
 let test_vv (h : vv) =
-  h##hey 1 2
+  let hey = h##hey in hey  1 2 [@fn]

--- a/jscomp/test/config2_test.ml
+++ b/jscomp/test/config2_test.ml
@@ -1,6 +1,6 @@
 [@@@bs.config{
-  obj_type_auto_uncurry = true;
-  bs_class_type = true 
+  obj_type_auto_uncurry ;
+  bs_class_type 
   (* non_export = true; *)
 }]
 

--- a/jscomp/test/config2_test.ml
+++ b/jscomp/test/config2_test.ml
@@ -17,7 +17,7 @@ end
 type vv = 
   [%bs.obj: < 
     hey : int -> int -> int 
-  >  [@fn] ]
+  >  [@bs] ]
 
 type vv2 = 
   [%bs.obj: < 
@@ -34,4 +34,4 @@ let test_v (x : v Js.t) =
   x##hey 1 2
 
 let test_vv (h : vv) =
-  let hey = h##hey in hey  1 2 [@fn]
+  let hey = h##hey in hey  1 2 [@bs]

--- a/jscomp/test/config2_test.mli
+++ b/jscomp/test/config2_test.mli
@@ -1,5 +1,5 @@
-[@@@bs.config {obj_type_auto_uncurry = true ; (* non_export = true *) 
-bs_class_type = true
+[@@@bs.config {obj_type_auto_uncurry  ; (* non_export = true *) 
+bs_class_type 
 } ]
 
 

--- a/jscomp/test/config2_test.mli
+++ b/jscomp/test/config2_test.mli
@@ -1,7 +1,9 @@
-[@@@bs.config {obj_type_auto_uncurry = true ; (* non_export = true *) } ]
+[@@@bs.config {obj_type_auto_uncurry = true ; (* non_export = true *) 
+bs_class_type = true
+} ]
 
 
-class type v = object [@fn]
+class type v = object
   method hey : int -> int -> int 
 end 
 

--- a/jscomp/test/config2_test.mli
+++ b/jscomp/test/config2_test.mli
@@ -14,7 +14,7 @@ end
 type vv = 
   [%bs.obj: < 
     hey : int -> int -> int 
-  >  [@fn]]
+  >  [@bs]]
 
 type vv2 = 
   [%bs.obj: < 

--- a/jscomp/test/demo.ml
+++ b/jscomp/test/demo.ml
@@ -1,116 +1,4 @@
-
-
-class type widget = 
-  object [@fn]
-      method on : string ->  (event -> unit ) -> unit 
-  end
-and  event = 
-  object 
-    method source : widget
-    method target : widget
-  end
-
-
-class type title = 
-  object [@fn]
-    method title_set : string -> unit 
-    method title : string
-  end
-
-class type text = 
-    object [@fn]
-      method text_set : string -> unit 
-      method text : string 
-    end
-class type measure =
-    object [@fn]
-      method minHeight_set : int -> unit 
-      method minHeight : int
-      method minWidth_set : int -> unit 
-      method minWidth : int 
-      method maxHeight_set : int -> unit 
-      method maxHeight : int 
-      method maxWidth_set : int -> unit 
-      method maxWidth : int 
-    end
-
-class type layout = 
-    object [@fn]
-      method orientation_set : string -> unit  
-      method orientation : string
-    end
-
-class type applicationContext = 
-  object [@fn]
-      method exit : int -> unit 
-  end
-class type contentable = 
-  object[@fn]
-    method content_set : #widget Js.t -> unit 
-    method content : #widget Js.t 
-    method contentWidth : int  
-    method contentWidth_set : int -> unit 
-  end
-
-class type hostedWindow =
-  object [@fn]
-    inherit widget 
-    inherit title
-    inherit contentable
-    method show : unit -> unit 
-    method hide : unit -> unit 
-    method focus : unit -> unit 
-    method appContext_set : applicationContext -> unit 
-  end
-
-class type hostedContent =
-  object 
-    inherit widget
-    inherit contentable
-  end
-
-
-class type stackPanel = 
-  object [@fn]
-    inherit measure
-    inherit layout 
-    inherit widget
-
-    method addChild : #widget Js.t -> unit 
-
-  end
-
-class type grid  = 
-  object [@fn]
-    inherit widget
-    inherit measure
-    method columns_set : [%bs.obj: <width : int; .. >  ]  array -> unit 
-    method titleRows_set : 
-      [%bs.obj: <label : <text : string; .. >   ; ..> ]   array -> unit 
-    method dataSource_set :
-      [%bs.obj: <label : <text : string; .. >   ; ..>  ]  array array -> unit  
-  end
-
-external set_interval : (unit -> unit [@fn]) -> float -> unit  =  "setInterval"
-    [@@bs.call] [@@bs.module "@runtime" "Runtime"]
-
-
-external to_fixed : float -> int -> string = "toFixed" [@@bs.send ]
-
-class type button = 
-  object
-    inherit widget
-    inherit text
-    inherit measure
-  end
-
-class type textArea = 
-    object
-      inherit widget
-      inherit measure
-      inherit text 
-    end
-
+open Demo_binding
 external addChild : stackPanel -> #widget -> unit = "x" [@@bs.send]
 
 
@@ -171,36 +59,36 @@ let ui_layout
   let button = new_button () in
   let grid = new_grid () in
   begin 
-    hw1##appContext_set appContext;
-    hw1##title_set "Test Application From OCaml";
-    hw1##content_set hc;
+    hw1##appContext#= appContext;
+    hw1##title#= "Test Application From OCaml";
+    hw1##content#= hc;
 
 
-    hc##contentWidth_set 700;
-    hc##content_set stackPanel;
+    hc##contentWidth#= 700;
+    hc##content#= stackPanel;
 
-    stackPanel##orientation_set "vertical";
-    stackPanel##minHeight_set 10000; (* FIXME -> 1e4 *)
-    stackPanel##minWidth_set 4000;
+    stackPanel##orientation #= "vertical";
+    stackPanel##minHeight #= 10000; (* FIXME -> 1e4 *)
+    stackPanel##minWidth #= 4000;
 
     stackPanel##addChild grid;
     stackPanel##addChild inputCode;
     stackPanel##addChild button;
     let mk_titleRow text = [%bs.obj {label =  {text }  } ] in
     let u =  [%bs.obj {width =  200} ]  in
-    grid##minHeight_set 300;
-    grid##titleRows_set
+    grid##minHeight #= 300;
+    grid##titleRows #=
         [| mk_titleRow "Ticker";
            mk_titleRow "Bid";
            mk_titleRow "Ask";
            mk_titleRow "Result" |] ;
-    grid##columns_set [| u;u;u;u |];
+    grid##columns #=  [| u;u;u;u |];
 
-    inputCode##text_set " bid - ask";
-    inputCode##minHeight_set 100;
+    inputCode##text #= " bid - ask";
+    inputCode##minHeight #= 100;
 
-    button##text_set "update formula";
-    button##minHeight_set 20;
+    button##text #= "update formula";
+    button##minHeight #= 20;
     button##on "click" begin fun [@fn] _event -> (* FIXME both [_] and () should work*)
       try 
         let hot_function = compile inputCode##text in
@@ -210,7 +98,7 @@ let ui_layout
     let fmt v = to_fixed v 2 in
     set_interval (fun [@fn] () -> 
 
-      grid##dataSource_set
+      grid##dataSource #=
         ( array_map data (fun [@fn] {ticker; price } -> 
           let bid = price +. 20. *. random () in
           let ask = price +. 20. *. random () in

--- a/jscomp/test/demo.ml
+++ b/jscomp/test/demo.ml
@@ -28,7 +28,7 @@ external stringify : 'a -> string = ""
 external random : unit -> float = ""
     [@@bs.call "Math.random"] 
 
-external array_map : 'a array -> ('a -> 'b [@fn]) -> 'b array = ""
+external array_map : 'a array -> ('a -> 'b [@bs]) -> 'b array = ""
     [@@bs.call"Array.prototype.map.call"] 
 
 type env 
@@ -89,17 +89,17 @@ let ui_layout
 
     button##text #= "update formula";
     button##minHeight #= 20;
-    button##on "click" begin fun [@fn] _event -> (* FIXME both [_] and () should work*)
+    button##on "click" begin fun [@bs] _event -> (* FIXME both [_] and () should work*)
       try 
         let hot_function = compile inputCode##text in
         computeFunction := fun env ->  hot_function (fun key -> lookup env key) 
       with  e -> ()
     end;
     let fmt v = to_fixed v 2 in
-    set_interval (fun [@fn] () -> 
+    set_interval (fun [@bs] () -> 
 
       grid##dataSource #=
-        ( array_map data (fun [@fn] {ticker; price } -> 
+        ( array_map data (fun [@bs] {ticker; price } -> 
           let bid = price +. 20. *. random () in
           let ask = price +. 20. *. random () in
           let result = !computeFunction (mk_bid_ask ~bid ~ask ) in

--- a/jscomp/test/demo_binding.ml
+++ b/jscomp/test/demo_binding.ml
@@ -7,7 +7,7 @@ class type titlex =
 
 class type widget = 
   object 
-      method on : string ->  (event -> unit [@fn]) -> unit 
+      method on : string ->  (event -> unit [@bs]) -> unit 
   end
 and  event = 
   object 
@@ -104,7 +104,7 @@ class type textArea =
   end
 
 
-external set_interval : (unit -> unit [@fn]) -> float -> unit  =  "setInterval"
+external set_interval : (unit -> unit [@bs]) -> float -> unit  =  "setInterval"
     [@@bs.call] [@@bs.module "@runtime" "Runtime"]
 
 external to_fixed : float -> int -> string = "toFixed" [@@bs.send ]

--- a/jscomp/test/demo_binding.ml
+++ b/jscomp/test/demo_binding.ml
@@ -1,4 +1,4 @@
-[@@@bs.config{bs_class_type = true }]
+[@@@bs.config{bs_class_type }]
 
 class type titlex = 
   object 

--- a/jscomp/test/demo_binding.ml
+++ b/jscomp/test/demo_binding.ml
@@ -1,0 +1,110 @@
+[@@@bs.config{bs_class_type = true }]
+
+class type titlex = 
+  object 
+    method title : string [@@bs.set] [@@bs.get {null ; undefined}]
+  end
+
+class type widget = 
+  object 
+      method on : string ->  (event -> unit [@fn]) -> unit 
+  end
+and  event = 
+  object 
+    method source : widget
+    method target : widget
+  end
+
+
+class type title = 
+  object 
+    method title : string [@@bs.set]
+  end
+
+class type text = 
+  object
+    method text : string [@@bs.set]
+  end
+
+class type measure =
+    object
+      method minHeight : int [@@bs.set]
+      method minWidth : int [@@bs.set]
+      method maxHeight : int  [@@bs.set]
+      method maxWidth : int [@@bs.set]
+    end
+
+class type layout = 
+    object 
+      method orientation : string [@@bs.set]
+    end
+
+class type applicationContext = 
+  object 
+    method exit : int -> unit 
+  end
+class type contentable = 
+  object
+    method content : #widget Js.t [@@bs.set]
+    method contentWidth : int  [@@bs.set]
+  end
+
+class type hostedWindow =
+  object
+    inherit widget 
+    inherit title
+    inherit contentable
+    method show : unit -> unit 
+    method hide : unit -> unit 
+    method focus : unit -> unit 
+    method appContext : applicationContext [@@bs.set]
+  end
+
+class type hostedContent =
+  object 
+    inherit widget
+    inherit contentable
+  end
+
+
+class type stackPanel = 
+  object
+    inherit measure
+    inherit layout 
+    inherit widget
+
+    method addChild : #widget Js.t -> unit 
+
+  end
+
+class type grid  = 
+  object
+    inherit widget
+    inherit measure
+    method columns : [%bs.obj: <width : int; .. >  ]  array [@@bs.set]
+    method titleRows : 
+      [%bs.obj: <label : <text : string; .. >   ; ..> ]   array [@@bs.set]
+    method dataSource :
+      [%bs.obj: <label : <text : string; .. >   ; ..>  ]  array array [@@bs.set]
+  end
+
+
+class type button = 
+  object
+    inherit widget
+    inherit text
+    inherit measure
+  end
+
+class type textArea = 
+  object
+    inherit widget
+    inherit measure
+    inherit text 
+  end
+
+
+external set_interval : (unit -> unit [@fn]) -> float -> unit  =  "setInterval"
+    [@@bs.call] [@@bs.module "@runtime" "Runtime"]
+
+external to_fixed : float -> int -> string = "toFixed" [@@bs.send ]

--- a/jscomp/test/dom.ml
+++ b/jscomp/test/dom.ml
@@ -1,0 +1,1 @@
+[@@@bs.config{bs_class_type= true}]

--- a/jscomp/test/dom.ml
+++ b/jscomp/test/dom.ml
@@ -1,1 +1,1 @@
-[@@@bs.config{bs_class_type= true}]
+[@@@bs.config{bs_class_type }]

--- a/jscomp/test/ffi_arity_test.ml
+++ b/jscomp/test/ffi_arity_test.ml
@@ -1,7 +1,7 @@
 
 
-external map : 'a array -> ('a -> 'b [@fn])  -> 'b array = "map" [@@bs.send]
-external mapi : 'a array -> ('a -> int -> 'b [@fn])  -> 'b array = "map" [@@bs.send]
+external map : 'a array -> ('a -> 'b [@bs])  -> 'b array = "map" [@@bs.send]
+external mapi : 'a array -> ('a -> int -> 'b [@bs])  -> 'b array = "map" [@@bs.send]
 
 external parseInt : string -> int = "parseInt" [@@bs.call]
 external parseInt_radix : string -> int -> int = "parseInt" [@@bs.call]

--- a/jscomp/test/ffi_js.ml
+++ b/jscomp/test/ffi_js.ml
@@ -1,1 +1,1 @@
-let keys :  Obj.t -> string array [@fn] = [%bs.raw " function (x){return Object.keys(x)}" ]
+let keys :  Obj.t -> string array [@bs] = [%bs.raw " function (x){return Object.keys(x)}" ]

--- a/jscomp/test/gpr_459_test.ml
+++ b/jscomp/test/gpr_459_test.ml
@@ -1,4 +1,4 @@
-[@@@bs.config{non_export=true}]
+[@@@bs.config{non_export}]
 
 let suites :  Mt.pair_suites ref  = ref []
 let test_id = ref 0

--- a/jscomp/test/http_types.ml
+++ b/jscomp/test/http_types.ml
@@ -1,3 +1,4 @@
+[@@@bs.config{bs_class_type = true }]
   (** 
      [%bs (req Js.t * resp Js.t => unit ) => server Js.t 
      ]
@@ -14,24 +15,25 @@
 
 type req 
 
-type resp = 
-  [%bs.obj: <
-   statusCode_set : int -> unit  ;
-   setHeader : string -> string -> unit ;
-   end_ : string ->  unit 
-  >  [@fn] ]
+class type _resp = 
+  object 
+    method statusCode : int [@@bs.set]
+    method setHeader : string -> string -> unit
+    method end_ : string -> unit 
+  end
+type resp = _resp Js.t 
+class type _server = 
+  object 
+    method listen : int ->  string -> (unit -> unit [@fn]) -> unit
+  end
+type server = _server Js.t 
+class type _http = 
+  object 
+    method createServer : (req  -> resp  -> unit [@fn]) ->  server
+  end
+type http = _http Js.t
 
-type server = 
-  [%bs.obj: <
-    listen : int ->  string -> (unit -> unit) -> unit 
-  >  [@fn] ]
 
-
-
-type http = 
-  [%bs.obj: <
-   createServer : (req  -> resp  -> unit ) ->  server
-  >  [@fn] ]
 
 
 external http : http  = "http"  [@@bs.val_of_module ]

--- a/jscomp/test/http_types.ml
+++ b/jscomp/test/http_types.ml
@@ -5,7 +5,7 @@
 
      A syntax extension
 
-     (req Js.t ->  resp Js.t -> unit  [@fn] )-> server Js.t [@fn]
+     (req Js.t ->  resp Js.t -> unit  [@bs] )-> server Js.t [@bs]
      type a = [%bs (req Js.t * resp Js.t => unit ) => server Js.t ]
   *)
 
@@ -24,12 +24,12 @@ class type _resp =
 type resp = _resp Js.t 
 class type _server = 
   object 
-    method listen : int ->  string -> (unit -> unit [@fn]) -> unit
+    method listen : int ->  string -> (unit -> unit [@bs]) -> unit
   end
 type server = _server Js.t 
 class type _http = 
   object 
-    method createServer : (req  -> resp  -> unit [@fn]) ->  server
+    method createServer : (req  -> resp  -> unit [@bs]) ->  server
   end
 type http = _http Js.t
 

--- a/jscomp/test/http_types.ml
+++ b/jscomp/test/http_types.ml
@@ -1,4 +1,4 @@
-[@@@bs.config{bs_class_type = true }]
+[@@@bs.config{bs_class_type  }]
   (** 
      [%bs (req Js.t * resp Js.t => unit ) => server Js.t 
      ]

--- a/jscomp/test/js_date.ml
+++ b/jscomp/test/js_date.ml
@@ -1,4 +1,4 @@
-[@@@bs.config{bs_class_type = true }]
+[@@@bs.config{bs_class_type }]
 (* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date *)
 (* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Default_parameters *)
 (* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/split *)

--- a/jscomp/test/js_date.ml
+++ b/jscomp/test/js_date.ml
@@ -1,3 +1,4 @@
+[@@@bs.config{bs_class_type = true }]
 (* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date *)
 (* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Default_parameters *)
 (* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/split *)
@@ -22,81 +23,81 @@ type number = float
 
 class type date = 
   object
-    method toDateString : unit -> string [@fn]
-    method toTimeString : unit -> string [@fn]
-    method toLocaleString : unit -> string [@fn]
-    method toLocaleDateString : unit -> string [@fn]
-    method toLocaleTimeString : unit -> string [@fn]
-    method valueOf : unit -> number [@fn]
-    method getTime : unit ->  number [@fn]
-    method getFullYear : unit ->  number [@fn]
-    method getUTCFullYear : unit ->  number [@fn]
-    method getMonth : unit -> number [@fn]
-    method getUTCMonth : unit -> number[@fn]
-    method getDate : unit -> number [@fn]
-    method getUTCDate : unit -> number [@fn]
-    method getDay : unit -> number [@fn]
-    method getUTCDay : unit -> number [@fn]
-    method getHours :  unit -> number [@fn]
-    method getUTCHours :  unit -> number [@fn]
-    method getMinutes :    unit -> number [@fn]
-    method getUTCMinutes :  unit -> number [@fn]
-    method getSeconds :  unit -> number [@fn]
-    method getUTCSeconds :  unit -> number [@fn]
-    method getMilliseconds : unit -> number [@fn]
-    method getUTCMilliseconds : unit -> number [@fn]
-    method getTimezoneOffset : unit -> number [@fn]
-    method setTime  : number ->  number [@fn]
+    method toDateString : unit -> string 
+    method toTimeString : unit -> string 
+    method toLocaleString : unit -> string 
+    method toLocaleDateString : unit -> string 
+    method toLocaleTimeString : unit -> string 
+    method valueOf : unit -> number 
+    method getTime : unit ->  number 
+    method getFullYear : unit ->  number 
+    method getUTCFullYear : unit ->  number 
+    method getMonth : unit -> number 
+    method getUTCMonth : unit -> number
+    method getDate : unit -> number 
+    method getUTCDate : unit -> number 
+    method getDay : unit -> number 
+    method getUTCDay : unit -> number 
+    method getHours :  unit -> number 
+    method getUTCHours :  unit -> number 
+    method getMinutes :    unit -> number 
+    method getUTCMinutes :  unit -> number 
+    method getSeconds :  unit -> number 
+    method getUTCSeconds :  unit -> number 
+    method getMilliseconds : unit -> number 
+    method getUTCMilliseconds : unit -> number 
+    method getTimezoneOffset : unit -> number 
+    method setTime  : number ->  number 
 
-    method setMilliseconds : number ->  number [@fn]
-    method setUTCMilliseconds : number ->  number [@fn]
+    method setMilliseconds : number ->  number 
+    method setUTCMilliseconds : number ->  number 
 
-    method setSeconds : number -> number[@fn]
-    method setSeconds__2 :  number -> number ->  number[@fn]
+    method setSeconds : number -> number
+    method setSeconds__2 :  number -> number ->  number
 
-    method setUTCSeconds : number -> number[@fn]
-    method setUTCSeconds__2 : number -> number -> number[@fn]
+    method setUTCSeconds : number -> number
+    method setUTCSeconds__2 : number -> number -> number
 
-    method setMinutes : number -> number[@fn]
-    method setMinutes__2 : number -> number -> number[@fn]
-    method setMinutes__3 : number -> number -> number -> number[@fn]
+    method setMinutes : number -> number
+    method setMinutes__2 : number -> number -> number
+    method setMinutes__3 : number -> number -> number -> number
 
-    method setUTCMinutes : number -> number[@fn]
-    method setUTCMinutes__2 : number -> number -> number[@fn]
-    method setUTCMinutes__3 : number -> number -> number -> number[@fn]
+    method setUTCMinutes : number -> number
+    method setUTCMinutes__2 : number -> number -> number
+    method setUTCMinutes__3 : number -> number -> number -> number
 
-    method setHours : number -> number[@fn]
-    method setHours__2 : number -> number -> number[@fn]
-    method setHours__3 : number -> number -> number -> number[@fn]
-    method setHours__4 : number -> number -> number -> number -> number[@fn]
+    method setHours : number -> number
+    method setHours__2 : number -> number -> number
+    method setHours__3 : number -> number -> number -> number
+    method setHours__4 : number -> number -> number -> number -> number
 
-    method setUTCHours : number -> number[@fn]
-    method setUTCHours__2 : number -> number -> number[@fn]
-    method setUTCHours__3 : number -> number -> number -> number[@fn]
-    method setUTCHours__4 : number -> number -> number -> number -> number[@fn]
-
-
-
-    method setDate :  number ->  number[@fn]
-    method setUTCDate : number ->  number [@fn]
-    method setMonth : number -> number[@fn]
-    method setMonth__2 : number -> number -> number[@fn]
-    method setUTCMonth : number -> number[@fn]
-    method setUTCMonth__2 : number -> number -> number[@fn]
+    method setUTCHours : number -> number
+    method setUTCHours__2 : number -> number -> number
+    method setUTCHours__3 : number -> number -> number -> number
+    method setUTCHours__4 : number -> number -> number -> number -> number
 
 
-    method setFullYear : number -> number[@fn]
-    method setFullYear__2 : number -> number -> number[@fn]
-    method setFullYear__3 : number -> number -> number -> number[@fn]
 
-    method setUTCFullYear : number -> number[@fn]
-    method setUTCFullYear__2 : number -> number -> number[@fn]
-    method setUTCFullYear__3 : number -> number -> number -> number[@fn]
+    method setDate :  number ->  number
+    method setUTCDate : number ->  number 
+    method setMonth : number -> number
+    method setMonth__2 : number -> number -> number
+    method setUTCMonth : number -> number
+    method setUTCMonth__2 : number -> number -> number
 
-    method toUTCString : unit -> string[@fn]
-    method toISOString : unit -> string[@fn]
-    method toJSON__ : unit -> string [@fn]
-    method toJSON__1 : 'a -> string[@fn]
+
+    method setFullYear : number -> number
+    method setFullYear__2 : number -> number -> number
+    method setFullYear__3 : number -> number -> number -> number
+
+    method setUTCFullYear : number -> number
+    method setUTCFullYear__2 : number -> number -> number
+    method setUTCFullYear__3 : number -> number -> number -> number
+
+    method toUTCString : unit -> string
+    method toISOString : unit -> string
+    method toJSON__ : unit -> string 
+    method toJSON__1 : 'a -> string
   end
 
 type t = date Js.t 

--- a/jscomp/test/js_obj_test.ml
+++ b/jscomp/test/js_obj_test.ml
@@ -1,4 +1,4 @@
-[@@@bs.config{bs_class_type = true }]
+[@@@bs.config{bs_class_type  }]
 
 
 type  x = < say : int -> int >

--- a/jscomp/test/js_obj_test.ml
+++ b/jscomp/test/js_obj_test.ml
@@ -1,25 +1,32 @@
+[@@@bs.config{bs_class_type = true }]
 
 
+type  x = < say : int -> int >
 
-class type  x = 
-  object
-    method say : int -> int
-  end
 
 
 
 let f  (u : x ) = u # say 32
 
-let f_js u = u##say 32
+let f_js u = u#@say 32
 
 let suites = Mt.[
   "caml_obj", (fun _ -> Eq (33, f (object method say x = 1 + x end)));
-  "js_obj", (fun _ -> let module N = 
-    struct
-      external mk : say:'a -> <say:'a> Js.t = ""[@@bs.obj] 
-    end 
-  in 
-  Eq(34, f_js (N.mk ~say:(fun [@fn]  x -> x + 2))))
+  "js_obj", (fun _ ->
+  Eq(34, f_js [%bs.obj{ say = fun [@fn]  x -> x + 2 } ]));
+  "js_obj2",(fun _ -> 
+  Eq(34,  [%bs.obj { say = fun [@fn]  x -> x + 2 } #@say 32 ]));
+    
 ]
 
 ;; Mt.from_pair_suites __FILE__ suites
+
+(* class type say = object  *)
+(*     method say : int -> int *)
+(* end *)
+(* create real js object with [this] semantics *)
+(* fun _ -> let module N =  *)
+(*     struct *)
+(*       external mk : say:'a -> say Js.t = ""[@@bs.obj]  *)
+(*     end  *)
+(*   in  *)

--- a/jscomp/test/js_obj_test.ml
+++ b/jscomp/test/js_obj_test.ml
@@ -13,9 +13,9 @@ let f_js u = u#@say 32
 let suites = Mt.[
   "caml_obj", (fun _ -> Eq (33, f (object method say x = 1 + x end)));
   "js_obj", (fun _ ->
-  Eq(34, f_js [%bs.obj{ say = fun [@fn]  x -> x + 2 } ]));
+  Eq(34, f_js [%bs.obj{ say = fun [@bs]  x -> x + 2 } ]));
   "js_obj2",(fun _ -> 
-  Eq(34,  [%bs.obj { say = fun [@fn]  x -> x + 2 } #@say 32 ]));
+  Eq(34,  [%bs.obj { say = fun [@bs]  x -> x + 2 } #@say 32 ]));
     
 ]
 

--- a/jscomp/test/method_name_test.ml
+++ b/jscomp/test/method_name_test.ml
@@ -16,13 +16,14 @@ let f x i file v =
 let ff x i v = 
   x##make_config ;
   x##make_config_;
-  x##make_config_set v ;
+  x##make_config #= v ;
+  x##make_config_ #= v ;
   x##case_unsafe i ;
   x##__open_ 3
   (* x##__open 32; *)
   (* x##case_setUnsafe (i,v) *)
-(* do we need polymorphism over [case_set]
-   I can only think of [case_set] will have one type
+(* do we need polymorphism over [case#=]
+   I can only think of [case#=] will have one type
    ['key -> 'value -> void ]
    unlike [case] which may have different return types
 *)

--- a/jscomp/test/obj_literal_ppx.ml
+++ b/jscomp/test/obj_literal_ppx.ml
@@ -3,7 +3,7 @@
 let a = [%bs.obj { x = 3 ; y = [| 1|]} ]
 
 let b = 
-  [%bs.obj { x = 3 ; y = [| 1 |]; z = 3; u = fun [@fn] x y -> x + y } ]
+  [%bs.obj { x = 3 ; y = [| 1 |]; z = 3; u = fun [@bs] x y -> x + y } ]
 
 let f obj = 
   obj ## x + Array.length (obj ## y)

--- a/jscomp/test/obj_literal_ppx.ml
+++ b/jscomp/test/obj_literal_ppx.ml
@@ -8,11 +8,12 @@ let b =
 let f obj = 
   obj ## x + Array.length (obj ## y)
 
-let h obj = obj##u 1 2
+let h obj = obj#@u 1 2
+
 
 let u = f  a
 
 let v = f b 
 
-let vv = h b 
+let vv = h b
 

--- a/jscomp/test/polymorphism_test.ml
+++ b/jscomp/test/polymorphism_test.ml
@@ -1,3 +1,3 @@
 let rec map f = function
     [] -> []
-  | a::l -> let r = f a [@fn] in r :: map f l
+  | a::l -> let r = f a [@bs] in r :: map f l

--- a/jscomp/test/polymorphism_test.mli
+++ b/jscomp/test/polymorphism_test.mli
@@ -1,3 +1,3 @@
 
 
-val map : ('a -> 'b [@fn]) -> 'a list -> 'b list
+val map : ('a -> 'b [@bs]) -> 'a list -> 'b list

--- a/jscomp/test/ppx_apply_test.ml
+++ b/jscomp/test/ppx_apply_test.ml
@@ -6,13 +6,13 @@ let eq loc x y =
     (loc ^" id " ^ (string_of_int !test_id), (fun _ -> Mt.Eq(x,y))) :: !suites
 
 
-let u = (fun [@fn] a  b -> a + b )  1  2  [@fn]
+let u = (fun [@bs] a  b -> a + b )  1  2  [@bs]
 
-let nullary = fun [@fn] () -> 3 
+let nullary = fun [@bs] () -> 3 
 
-let unary = fun [@fn] a -> a + 3 
+let unary = fun [@bs] a -> a + 3 
 
-let xx = unary  3 [@fn]
+let xx = unary  3 [@bs]
 let () = 
   eq __LOC__ u 3 
 

--- a/jscomp/test/promise.ml
+++ b/jscomp/test/promise.ml
@@ -10,7 +10,7 @@ class type promise =
   object
     method then_ : 'a -> 'b
     method catch : 'a -> 'b
-  end [@fn]
+  end [@bs]
 
 external new_promise : unit -> promise Js.t = 
   "Promise" [@@bs.new] [@@bs.module "sys-bluebird"]

--- a/jscomp/test/promise.ml
+++ b/jscomp/test/promise.ml
@@ -1,4 +1,4 @@
-[@@@bs.config{bs_class_type = true }]
+[@@@bs.config{bs_class_type }]
 type t
 
 external catch : t -> 'a -> 'b = "catch" [@@bs.send]

--- a/jscomp/test/promise.ml
+++ b/jscomp/test/promise.ml
@@ -1,4 +1,4 @@
-
+[@@@bs.config{bs_class_type = true }]
 type t
 
 external catch : t -> 'a -> 'b = "catch" [@@bs.send]

--- a/jscomp/test/test.mllib
+++ b/jscomp/test/test.mllib
@@ -32,6 +32,7 @@ test_fib
 test_list
 test_pervasive
 simple_lexer_test
+demo_binding
 demo
 test_char
 test_generative_module

--- a/jscomp/test/test_case_set.ml
+++ b/jscomp/test/test_case_set.ml
@@ -1,0 +1,8 @@
+
+
+
+let f x = 
+  x##case 3 #= 3 
+
+let g x = 
+  x#.item 3

--- a/jscomp/test/test_http_server.ml
+++ b/jscomp/test/test_http_server.ml
@@ -4,12 +4,12 @@
 let port = 3000
 let hostname = "127.0.0.1"
 let create_server  http = 
-  let server = http##createServer begin fun [@fn] req  resp  -> 
+  let server = http##createServer begin fun [@bs] req  resp  -> 
       resp##statusCode #= 200;
       resp##setHeader "Content-Type" "text/plain";
       resp##end_ "Hello world\n"
     end in
-  server##listen port hostname  begin fun [@fn] () -> 
+  server##listen port hostname  begin fun [@bs] () -> 
     Js.log ("Server running at http://"^ hostname ^ ":" ^ string_of_int port ^ "/")
   end
 

--- a/jscomp/test/test_http_server.ml
+++ b/jscomp/test/test_http_server.ml
@@ -5,7 +5,7 @@ let port = 3000
 let hostname = "127.0.0.1"
 let create_server  http = 
   let server = http##createServer begin fun [@fn] req  resp  -> 
-      resp##statusCode_set 200;
+      resp##statusCode #= 200;
       resp##setHeader "Content-Type" "text/plain";
       resp##end_ "Hello world\n"
     end in

--- a/jscomp/test/test_index.ml
+++ b/jscomp/test/test_index.ml
@@ -10,7 +10,7 @@ end
 
 (* let f (x : [%bs.obj: < case : int ->  'a ;  *)
 (*             case_set : int ->  int -> unit ; *)
-(*             .. > [@fn] ] ) *)
+(*             .. > [@bs] ] ) *)
 (*  =  *)
 (*   x ## case_set 3 2 ; *)
 (*   x ## case 3  *)
@@ -22,10 +22,10 @@ let ff (x : int case  Js.t)
   x##case 3 
 
 
-type 'a return = int -> 'a [@fn]
+type 'a return = int -> 'a [@bs]
 let h (x : 
-         [%bs.obj:< cse : (int -> 'a return  ); .. >  [@fn] ]) = 
-   (x#@cse 3) 2 [@fn]
+         [%bs.obj:< cse : (int -> 'a return  ); .. >  [@bs] ]) = 
+   (x#@cse 3) 2 [@bs]
 
 
 
@@ -33,7 +33,7 @@ type x_obj =
   [%bs.obj: < 
     cse : int ->  int ; 
     cse_st : int -> int -> unit ;
-  >  [@fn] ]
+  >  [@bs] ]
 
 let f_ext 
     (x : x_obj)
@@ -45,7 +45,7 @@ let f_ext
 type 'a h_obj = 
   [%bs.obj: < 
     cse : int ->  'a return 
-  > [@fn] ]
+  > [@bs] ]
 
 let h_ext  (x : 'a h_obj) = 
-   (x #@cse 3) 2 [@fn]
+   (x #@cse 3) 2 [@bs]

--- a/jscomp/test/test_index.ml
+++ b/jscomp/test/test_index.ml
@@ -1,5 +1,5 @@
 
-[@@@bs.config{bs_class_type = true }]
+[@@@bs.config{bs_class_type }]
 class type ['a] case = object 
   method case : int -> 'a 
   method case_set : int -> 'a -> unit 

--- a/jscomp/test/test_index.ml
+++ b/jscomp/test/test_index.ml
@@ -1,20 +1,20 @@
 
-
-
-
-
-
-let f (x : [%bs.obj: < case : int ->  'a ; 
-            case_set : int ->  int -> unit ;
-            .. > [@fn] ] )
- = 
-  x ## case_set 3 2 ;
-  x ## case 3 
-
-class type ['a] case = object [@fn]
+[@@@bs.config{bs_class_type = true }]
+class type ['a] case = object 
   method case : int -> 'a 
   method case_set : int -> 'a -> unit 
 end
+
+
+
+
+(* let f (x : [%bs.obj: < case : int ->  'a ;  *)
+(*             case_set : int ->  int -> unit ; *)
+(*             .. > [@fn] ] ) *)
+(*  =  *)
+(*   x ## case_set 3 2 ; *)
+(*   x ## case 3  *)
+
 
 let ff (x : int case  Js.t)
  = 
@@ -24,29 +24,28 @@ let ff (x : int case  Js.t)
 
 type 'a return = int -> 'a [@fn]
 let h (x : 
-         [%bs.obj:< case : (int -> 'a return  ); .. >  [@fn] ]) = 
-  let a = x##case 3 in 
-  a 2 [@fn]   
+         [%bs.obj:< cse : (int -> 'a return  ); .. >  [@fn] ]) = 
+   (x#@cse 3) 2 [@fn]
+
 
 
 type x_obj =  
   [%bs.obj: < 
-    case : int ->  int ; 
-    case_set : int -> int -> unit ;
+    cse : int ->  int ; 
+    cse_st : int -> int -> unit ;
   >  [@fn] ]
 
 let f_ext 
     (x : x_obj)
  = 
-  x ## case_set 3 2 ;
-  x ## case 3 
+ x #@ cse_st  3 2;
+ x #@ cse  3
 
 
 type 'a h_obj = 
   [%bs.obj: < 
-    case : int ->  'a return 
+    cse : int ->  'a return 
   > [@fn] ]
 
 let h_ext  (x : 'a h_obj) = 
-  let  a = x ##case 3 in 
-  a 2 [@fn] 
+   (x #@cse 3) 2 [@fn]

--- a/jscomp/test/test_obj_simple_ffi.ml
+++ b/jscomp/test/test_obj_simple_ffi.ml
@@ -8,19 +8,19 @@ let v3  = mk_obj_spec ~test:3 ~config:3 ~hi:"ghos" ~displayName:"display" ()
 
 
 class type x = object 
-  method tet : (x Js.t -> int -> int -> int  [@meth_callback])
+  method tet : (x Js.t -> int -> int -> int  [@bs.this])
 end
 
 
 class type y = object 
-  method tet : y Js.t -> int -> int -> int  [@meth_callback]
+  method tet : y Js.t -> int -> int -> int  [@bs.this]
 end
 
 
 let u (x : x) : y = x 
 
-type h = < bark : 'self -> int -> int [@meth_callback] > Js.t as 'self
-type hh = < bark :( 'self -> int -> int [@meth_callback]) > Js.t as 'self
+type h = < bark : 'self -> int -> int [@bs.this] > Js.t as 'self
+type hh = < bark :( 'self -> int -> int [@bs.this]) > Js.t as 'self
 
 let ff (x  : h) : hh = x 
 
@@ -28,12 +28,12 @@ let ff (x  : h) : hh = x
 (*   u#.tet (1,2) *)
 
 
-type 'a return = int -> 'a [@fn]
-type 'a u = int -> string -> 'a return  [@fn]
+type 'a return = int -> 'a [@bs]
+type 'a u = int -> string -> 'a return  [@bs]
 
-type 'a u2 = int -> string -> int -> 'a [@fn]
+type 'a u2 = int -> string -> int -> 'a [@bs]
 
-type 'a u3 = int -> string -> (int -> 'a [@fn]) [@fn]
+type 'a u3 = int -> string -> (int -> 'a [@bs]) [@bs]
 
 (* let fff (x : 'a u) :  'a u2 =  *)
 (*   x  *)
@@ -43,42 +43,42 @@ let fff (x : 'a u) :  'a u3 =
   x 
 
 
-type 'a ret = 'a -> int [@fn]
+type 'a ret = 'a -> int [@bs]
 
 type 'a u4 = < case : (int -> 'a ret ) > 
 
-type 'a u5 = < case : (int -> (int -> 'a [@fn])) > 
+type 'a u5 = < case : (int -> (int -> 'a [@bs])) > 
 
 let ff ( x : 'a u4) : 'a u5 =  x 
 
 
-type 'a v0 = int -> 'a ret [@fn]
-type 'a v1 =  int -> ('a -> int [@fn]) [@fn]
+type 'a v0 = int -> 'a ret [@bs]
+type 'a v1 =  int -> ('a -> int [@bs]) [@bs]
 
-type 'a xx = int -> 'a [@meth_callback]
-type 'a w0 = int -> 'a xx [@fn]
-type 'a w1 =  int -> (int -> 'a [@meth_callback]) [@fn]
+type 'a xx = int -> 'a [@bs.this]
+type 'a w0 = int -> 'a xx [@bs]
+type 'a w1 =  int -> (int -> 'a [@bs.this]) [@bs]
 let f (x : 'a w0) : 'a w1 =  x
 
-type 'a v2 = int -> 'a ret [@meth_callback]
-type 'a v3 = int -> ('a -> int [@fn]) [@meth_callback]
+type 'a v2 = int -> 'a ret [@bs.this]
+type 'a v3 = int -> ('a -> int [@bs]) [@bs.this]
 
 
 let f (x : 'a v0) : 'a v1 = x
 let ff (x : 'a v2 ) : 'a v3 = x 
  
-type 'a u6 = < case : int -> 'a ret  ; >  [@fn] 
+type 'a u6 = < case : int -> 'a ret  ; >  [@bs] 
 
-type 'a u7 = < case : int -> ('a  -> int [@fn])  ; >  [@fn]
+type 'a u7 = < case : int -> ('a  -> int [@bs])  ; >  [@bs]
 
 let fff (x : 'a u6) : 'a u7= x 
 
-let f : int -> int -> (int -> int -> int [@fn]) [@fn] = 
-  fun [@fn] x y -> fun [@fn] u v -> x + y + u + v
+let f : int -> int -> (int -> int -> int [@bs]) [@bs] = 
+  fun [@bs] x y -> fun [@bs] u v -> x + y + u + v
 
 
-type 'a xx0 = < hi : int -> int [@meth_callback] > 
-type 'a xx1 = < hi : (int -> int [@meth_callback]) > 
+type 'a xx0 = < hi : int -> int [@bs.this] > 
+type 'a xx1 = < hi : (int -> int [@bs.this]) > 
 
 
 let f (x : 'a xx0) : 'a xx1 = x  

--- a/jscomp/test/test_react.ml
+++ b/jscomp/test/test_react.ml
@@ -1,20 +1,20 @@
-
+[@@@bs.config{bs_class_type = true }]
 (** TODO: binding -- document.getElementById -- to mount node *)
 
 type html_element 
 
 class type document = 
   object
-    method getElementById : string -> html_element [@fn]
+    method getElementById : string -> html_element 
   end
 
 type doc = document Js.t 
 external doc :  doc  = "doc" [@@bs.val ]
 
 class type con = 
-    object [@fn]
-        method log : 'a -> unit 
-    end
+  object
+    method log : 'a -> unit 
+  end
 
 type console = con Js.t 
 external console : console  = "console" [@@bs.val ]

--- a/jscomp/test/test_react.ml
+++ b/jscomp/test/test_react.ml
@@ -1,4 +1,4 @@
-[@@@bs.config{bs_class_type = true }]
+[@@@bs.config{bs_class_type  }]
 (** TODO: binding -- document.getElementById -- to mount node *)
 
 type html_element 

--- a/jscomp/test/test_unsafe_obj_ffi.ml
+++ b/jscomp/test/test_unsafe_obj_ffi.ml
@@ -1,4 +1,4 @@
-
+[@@@bs.config{bs_class_type = true }]
 
 open Js_unsafe
 
@@ -9,9 +9,12 @@ let g x : unit  =
   let () = run1 !x # method1 3 in
   run2 !x # method2 3 3
 
+class type _metric = object  method height : int [@@bs.set] method width : int [@@bs.set] end 
 let h x : unit  = 
-   run1 !x # height_set 3 ;
-   run1 !x # width_set 3 
+  x##height #= 3 ; 
+  x##width #= 3 
+(* can not write set api without syntax extension, any more
+*)
 
 (**
 imagine you have 

--- a/jscomp/test/test_unsafe_obj_ffi.ml
+++ b/jscomp/test/test_unsafe_obj_ffi.ml
@@ -1,4 +1,4 @@
-[@@@bs.config{bs_class_type = true }]
+[@@@bs.config{bs_class_type }]
 
 open Js_unsafe
 

--- a/jscomp/test/test_unsafe_obj_ffi.mli
+++ b/jscomp/test/test_unsafe_obj_ffi.mli
@@ -1,4 +1,4 @@
-
+[@@@bs.config{bs_class_type = true }]
 
 val f : < height : int; width : int; .. > Js.t -> int
 
@@ -7,7 +7,5 @@ val g :
   < method1 : int -> unit [@fn];
     method2 : int ->  int -> unit [@fn]; .. > 
   Js.t -> unit
-
-val h :
-  < height_set : int -> 'a [@fn]; 
-    width_set : int -> unit [@fn]; .. > Js.t -> unit
+class type _metric = object method height : int [@@bs.set] method width : int [@@bs.set] end
+val h : _metric Js.t -> unit

--- a/jscomp/test/test_unsafe_obj_ffi.mli
+++ b/jscomp/test/test_unsafe_obj_ffi.mli
@@ -1,4 +1,4 @@
-[@@@bs.config{bs_class_type = true }]
+[@@@bs.config{bs_class_type }]
 
 val f : < height : int; width : int; .. > Js.t -> int
 

--- a/jscomp/test/test_unsafe_obj_ffi.mli
+++ b/jscomp/test/test_unsafe_obj_ffi.mli
@@ -4,8 +4,8 @@ val f : < height : int; width : int; .. > Js.t -> int
 
 
 val g : 
-  < method1 : int -> unit [@fn];
-    method2 : int ->  int -> unit [@fn]; .. > 
+  < method1 : int -> unit [@bs];
+    method2 : int ->  int -> unit [@bs]; .. > 
   Js.t -> unit
 class type _metric = object method height : int [@@bs.set] method width : int [@@bs.set] end
 val h : _metric Js.t -> unit

--- a/jscomp/test/test_unsafe_obj_ffi_ppx.ml
+++ b/jscomp/test/test_unsafe_obj_ffi_ppx.ml
@@ -1,13 +1,23 @@
+[@@@bs.config{bs_class_type = true}]
+class type _v = object 
+  method height : int [@@bs.set]
+  method width  : int [@@bs.set]
 
-
+end
+type v = _v Js.t 
+class type ['a] _g = object 
+  method method1 : int -> unit 
+  method method2 : int -> int -> 'a
+end
+type 'a g = 'a _g Js.t
 
 let  f x = 
   x##length +. x##width
 let i () =  ()
 
 let h x : unit = 
-  x ##height_set 3 ;
-  i @@ x ##width_set 3 
+  x ##height #= 3 ;
+  i @@ x ##width #= 3 
 
 let chain x = 
   x##element##length + x##element##length

--- a/jscomp/test/test_unsafe_obj_ffi_ppx.ml
+++ b/jscomp/test/test_unsafe_obj_ffi_ppx.ml
@@ -1,4 +1,4 @@
-[@@@bs.config{bs_class_type = true}]
+[@@@bs.config{bs_class_type }]
 class type _v = object 
   method height : int [@@bs.set]
   method width  : int [@@bs.set]

--- a/jscomp/test/test_unsafe_obj_ffi_ppx.mli
+++ b/jscomp/test/test_unsafe_obj_ffi_ppx.mli
@@ -1,21 +1,23 @@
+[@@@bs.config{bs_class_type = true}]
+class type _v = object 
+  method height : int  [@@bs.set]
+  method width  : int [@@bs.set]
+end
+type v = _v Js.t 
 
+class type ['a] _g = object 
+  method method1 : int -> unit 
+  method method2 : int -> int -> 'a
+end
+type 'a g = 'a _g Js.t
 
 val f : < length : float; width : float; .. > Js.t -> float
 
-val h : < height_set : int -> unit [@fn];
-          width_set : int -> unit [@fn];
-          .. > Js.t -> unit
+val h : v -> unit
 
 val chain : < element : < length : int; .. > Js.t; .. > Js.t -> int
 
-val g :
-  < method1 : 
-      (int -> unit [@fn][@hey]); 
-
-    method2 : 
-      (int ->  int -> 'a [@fn]);
-    .. > Js.t ->
-  'a
+val g : 'a g -> 'a
 
 (** Another proposal :
 

--- a/jscomp/test/test_unsafe_obj_ffi_ppx.mli
+++ b/jscomp/test/test_unsafe_obj_ffi_ppx.mli
@@ -1,4 +1,4 @@
-[@@@bs.config{bs_class_type = true}]
+[@@@bs.config{bs_class_type }]
 class type _v = object 
   method height : int  [@@bs.set]
   method width  : int [@@bs.set]

--- a/jscomp/test/uncurry_glob_test.ml
+++ b/jscomp/test/uncurry_glob_test.ml
@@ -12,3 +12,7 @@ let f = fun [@fn] () -> 3
 
 
 let u = f () [@fn]
+
+let (+>) = fun [@fn]  a (h : _ -> int [@fn]) -> h a [@fn]
+
+let u h = 3 +> h  [@fn]

--- a/jscomp/test/uncurry_glob_test.ml
+++ b/jscomp/test/uncurry_glob_test.ml
@@ -1,18 +1,18 @@
 
 
-let v = Caml_utils.repeat 100 "x" [@fn]
+let v = Caml_utils.repeat 100 "x" [@bs]
 
-module M ( U : sig val f : int -> string -> string [@fn] end ) = 
+module M ( U : sig val f : int -> string -> string [@bs] end ) = 
 struct
-  let v = U.f 100 "x" [@fn]
+  let v = U.f 100 "x" [@bs]
 end
 
 
-let f = fun [@fn] () -> 3 
+let f = fun [@bs] () -> 3 
 
 
-let u = f () [@fn]
+let u = f () [@bs]
 
-let (+>) = fun [@fn]  a (h : _ -> int [@fn]) -> h a [@fn]
+let (+>) = fun [@bs]  a (h : _ -> int [@bs]) -> h a [@bs]
 
-let u h = 3 +> h  [@fn]
+let u h = 3 +> h  [@bs]

--- a/jscomp/test/unsafe_ppx_test.ml
+++ b/jscomp/test/unsafe_ppx_test.ml
@@ -3,10 +3,10 @@
 
 let x : string = [%bs.raw{|"\x01\x02\x03"|}]
 
-let max : float -> float -> float [@fn] =
+let max : float -> float -> float [@bs] =
   [%bs.raw "Math.max"  ]  
 
-let u v = max 1. v [@fn] 
+let u v = max 1. v [@bs] 
 (* let max2 : float -> float -> float = [%bs.raw {Math.max} ]   *)
 [%%bs.raw {|
 
@@ -16,9 +16,9 @@ function $$test(x,y){
 |}]
 
 
-let regression3 : float -> float -> float [@fn] = [%bs.raw "Math.max"] 
+let regression3 : float -> float -> float [@bs] = [%bs.raw "Math.max"] 
 
-let regression4 : float ->  (float -> float [@fn]) -> float [@fn] =
+let regression4 : float ->  (float -> float [@bs]) -> float [@bs] =
   [%bs.raw "Math.max"] 
 let g a 
 
@@ -30,31 +30,31 @@ let regression  = ([%bs.raw{|function(x,y){
   let regression2 : float -> float -> float = [%bs.raw "Math.max"] in 
   ignore @@ regression a failwith;
   ignore @@ regression2  3. 2.;
-  ignore @@ regression3 3.  2. [@fn];
-  ignore @@ regression4 3. (fun[@fn] x-> x) [@fn]
+  ignore @@ regression3 3.  2. [@bs];
+  ignore @@ regression4 3. (fun[@bs] x-> x) [@bs]
 
 
-let max2 : float -> float -> float [@fn] = [%bs.raw "Math.max"]
+let max2 : float -> float -> float [@bs] = [%bs.raw "Math.max"]
 
-let umax a b = max2 a b  [@fn]
-let u h = max2 3. h [@fn]
+let umax a b = max2 a b  [@bs]
+let u h = max2 3. h [@bs]
 
-let max3 = ([%bs.raw "Math.max"] :  float * float -> float [@fn])
-let uu h = max2 3. h [@fn]
+let max3 = ([%bs.raw "Math.max"] :  float * float -> float [@bs])
+let uu h = max2 3. h [@bs]
     
 external test : int -> int -> int = "" [@@bs.call "$$test"]
 
-let empty = ([%bs.raw {| Object.keys|} ] :  _ -> string array [@fn]) 3 [@fn]
+let empty = ([%bs.raw {| Object.keys|} ] :  _ -> string array [@bs]) 3 [@bs]
 
 let v = test 1 2 
 
 
 
 ;; Mt.from_pair_suites __FILE__ Mt.[
-    "unsafe_max", (fun _ -> Eq(2., max 1. 2. [@fn]));
+    "unsafe_max", (fun _ -> Eq(2., max 1. 2. [@bs]));
     "unsafe_test", (fun _ -> Eq(3,v));
-    "unsafe_max2", (fun _ -> Eq(2, ([%bs.raw {|Math.max|} ] : int ->  int -> int [@fn]) 1 2 [@fn] ));
-    "ffi_keys", ( fun _ -> Eq ([|"a"|], Ffi_js.keys [%bs.raw{| {a : 3}|}] [@fn]))
+    "unsafe_max2", (fun _ -> Eq(2, ([%bs.raw {|Math.max|} ] : int ->  int -> int [@bs]) 1 2 [@bs] ));
+    "ffi_keys", ( fun _ -> Eq ([|"a"|], Ffi_js.keys [%bs.raw{| {a : 3}|}] [@bs]))
 ]
 
 

--- a/jscomp/test/unsafe_this.ml
+++ b/jscomp/test/unsafe_this.ml
@@ -18,7 +18,8 @@ let u : 'self =
       length : int >       )
   ]
 
-let v = u##bark u 1 2
+
+let u  = u#@bark u 1 2 [@fn]
 
 
 (* let bark2  = fun [@bs.this] (this, x, y) -> Js.log (this##x,x+y)  *)

--- a/jscomp/test/unsafe_this.ml
+++ b/jscomp/test/unsafe_this.ml
@@ -8,18 +8,18 @@ let u : 'self =
       {
         x = 3 ;
         y = 32 ;
-        bark = (fun [@fn] this x y -> Js.log (this##length, this##x, this##y));
+        bark = (fun [@bs] this x y -> Js.log (this##length, this##x, this##y));
         length = 32
       } : 
         <
         x : int ; 
       y : int ;
-      bark : 'self -> int ->  int -> unit [@fn]; 
+      bark : 'self -> int ->  int -> unit [@bs]; 
       length : int >       )
   ]
 
 
-let u  = u#@bark u 1 2 [@fn]
+let u  = u#@bark u 1 2 [@bs]
 
 
 (* let bark2  = fun [@bs.this] (this, x, y) -> Js.log (this##x,x+y)  *)
@@ -65,14 +65,14 @@ let uu : 'self =
         x = 3 ;
         y = 32 ;
         bark = 
-          (fun [@meth_callback] (o : 'self) (x : int) (y : int) -> 
+          (fun [@bs.this] (o : 'self) (x : int) (y : int) -> 
                Js.log (o##length, o##x, o##y,x,y));
         length = 32
       } : 
         <
         x : int ; 
       y : int ;
-      bark : ('self -> int -> int -> _ [@meth_callback]); 
+      bark : ('self -> int -> int -> _ [@bs.this]); 
       length : int >       )
   ]
 
@@ -82,7 +82,7 @@ let js_obj : 'self =
         x = 3 ;
         y = 32 ;
         bark = 
-          (fun [@meth_callback] (o : 'self) x y -> 
+          (fun [@bs.this] (o : 'self) x y -> 
             Js.log (o##length, o##x, o##y,x,y);
             x + y
           );

--- a/jscomp/test/unsafe_this.mli
+++ b/jscomp/test/unsafe_this.mli
@@ -2,7 +2,7 @@
 
 val js_obj :
   [%bs.obj: <
-         bark :  ('a ->  int ->  int -> int [@meth_callback]) ;
+         bark :  ('a ->  int ->  int -> int [@bs.this]) ;
          length : int; 
          x : int;
          y : int

--- a/lib/js/test/chain_code_test.js
+++ b/lib/js/test/chain_code_test.js
@@ -48,7 +48,7 @@ function f4(h, x, y) {
         ];
 }
 
-eq('File "chain_code_test.ml", line 27, characters 5-12', 32, f2({
+eq('File "chain_code_test.ml", line 29, characters 5-12', 32, f2({
           x: {
             y: {
               z: 32

--- a/lib/js/test/class_type_ffi_test.js
+++ b/lib/js/test/class_type_ffi_test.js
@@ -26,7 +26,12 @@ function sum_poly(zero, add, arr) {
   return v;
 }
 
+function test_set(x) {
+  return x.length = 3;
+}
+
 exports.sum_float_array = sum_float_array;
 exports.sum_int_array   = sum_int_array;
 exports.sum_poly        = sum_poly;
+exports.test_set        = test_set;
 /* No side effect */

--- a/lib/js/test/config2_test.js
+++ b/lib/js/test/config2_test.js
@@ -7,7 +7,8 @@ function test_v(x) {
 }
 
 function test_vv(h) {
-  return h.hey(1, 2);
+  var hey = h.hey;
+  return hey(1, 2);
 }
 
 exports.test_v  = test_v;

--- a/lib/js/test/demo.js
+++ b/lib/js/test/demo.js
@@ -1,10 +1,10 @@
 // GENERATED CODE BY BUCKLESCRIPT VERSION 0.6.2 , PLEASE EDIT WITH CARE
 'use strict';
 
-var UI      = require("@ui");
-var Runtime = require("@runtime");
 var BUI     = require("@blp/ui");
+var UI      = require("@ui");
 var Curry   = require("../curry");
+var Runtime = require("@runtime");
 
 var data = /* array */[
   /* record */[
@@ -108,4 +108,4 @@ function ui_layout(compile, lookup, appContext) {
 
 exports.data      = data;
 exports.ui_layout = ui_layout;
-/* @ui Not a pure module */
+/* @blp/ui Not a pure module */

--- a/lib/js/test/demo_binding.js
+++ b/lib/js/test/demo_binding.js
@@ -1,0 +1,6 @@
+// GENERATED CODE BY BUCKLESCRIPT VERSION 0.6.2 , PLEASE EDIT WITH CARE
+'use strict';
+
+
+
+/* No side effect */

--- a/lib/js/test/js_obj_test.js
+++ b/lib/js/test/js_obj_test.js
@@ -56,7 +56,22 @@ var suites_001 = /* :: */[
               ]);
     }
   ],
-  /* [] */0
+  /* :: */[
+    /* tuple */[
+      "js_obj2",
+      function () {
+        return /* Eq */Block.__(0, [
+                  34,
+                  {
+                      say: function (x) {
+                        return x + 2 | 0;
+                      }
+                    }.say(32)
+                ]);
+      }
+    ],
+    /* [] */0
+  ]
 ];
 
 var suites = /* :: */[

--- a/lib/js/test/method_name_test.js
+++ b/lib/js/test/method_name_test.js
@@ -35,6 +35,7 @@ function f(x, i, file, v) {
 function ff(x, _, v) {
   x.make;
   x.make_config;
+  x.make = v;
   x.make_config = v;
   return x._open(3);
 }
@@ -52,7 +53,7 @@ function hg(x) {
   return x.open + x.end | 0;
 }
 
-eq('File "method_name_test.ml", line 38, characters 12-19', 35, hg(h));
+eq('File "method_name_test.ml", line 39, characters 12-19', 35, hg(h));
 
 Mt.from_pair_suites("method_name_test.ml", suites[0]);
 

--- a/lib/js/test/test_index.js
+++ b/lib/js/test/test_index.js
@@ -2,32 +2,24 @@
 'use strict';
 
 
-function f(x) {
-  x[3] = 2;
-  return x[3];
-}
-
 function ff(x) {
   x[3] = 2;
   return x[3];
 }
 
 function h(x) {
-  var a = x[3];
-  return a(2);
+  return x.cse(3)(2);
 }
 
 function f_ext(x) {
-  x[3] = 2;
-  return x[3];
+  x.cse(3, 2);
+  return x.cse(3);
 }
 
 function h_ext(x) {
-  var a = x[3];
-  return a(2);
+  return x.cse(3)(2);
 }
 
-exports.f     = f;
 exports.ff    = ff;
 exports.h     = h;
 exports.f_ext = f_ext;

--- a/lib/js/test/uncurry_glob_test.js
+++ b/lib/js/test/uncurry_glob_test.js
@@ -14,10 +14,19 @@ function f() {
   return 3;
 }
 
-var u = f();
+f();
 
-exports.v = v;
-exports.M = M;
-exports.f = f;
-exports.u = u;
+function $plus$great(a, h) {
+  return h(a);
+}
+
+function u(h) {
+  return $plus$great(3, h);
+}
+
+exports.v           = v;
+exports.M           = M;
+exports.f           = f;
+exports.$plus$great = $plus$great;
+exports.u           = u;
 /* v Not a pure module */


### PR DESCRIPTION
note completely hiding `Js.t` is not easy to do, since people can write

```ocaml
type widget = XX.widget

class type v = object
  inherit widget (* how to track ?*)
end
``` 

Note that such part is not covered by bucklescript object FFI, but it can be done using `external` the part of external FFI, we will revisit it later see how users would like this feature

```ts
interface IRawParams {
    [key: string]: any
}
```

here are three proposals, (I am not satisfied with any, since the added value does not justify the added complexity)

- introducing index syntax without property name
```ocaml 
 x #. [i]
 x #. [i] #= v 
```
since this proposal does not have property name, we do need some overloading for `safe/unsafe` version, so `x#![i]` or `x#![i] #= 3` is needed
- introducing one syntax
 ```ocaml
x#.item i 
x#.item i #= v 
```
note that since item is a name, we can use it for overloading

- no new syntax but reserve a property name, `case` for example
```ocaml
x##case i 
x##case i #= v 
```