### PR TITLE
support bs.method

### DIFF
--- a/jscomp/syntax/ast_attributes.ml
+++ b/jscomp/syntax/ast_attributes.ml
@@ -88,9 +88,9 @@ let process_attributes_rev (attrs : t) =
       | "bs", (`Nothing | `Uncurry) 
         -> 
         `Uncurry, acc
-      | "bs.this", (`Nothing | `Meth)
-        ->  `Meth, acc
-      | "bs", `Meth 
+      | "bs.this", (`Nothing | `Meth_callback)
+        ->  `Meth_callback, acc
+      | "bs", `Meth_callback 
       | "bs.this", `Uncurry
         -> Location.raise_errorf 
              ~loc

--- a/jscomp/syntax/ast_attributes.ml
+++ b/jscomp/syntax/ast_attributes.ml
@@ -90,11 +90,13 @@ let process_attributes_rev (attrs : t) =
         `Uncurry, acc
       | "bs.this", (`Nothing | `Meth_callback)
         ->  `Meth_callback, acc
-      | "bs", `Meth_callback 
-      | "bs.this", `Uncurry
+      | "bs.meth",  (`Nothing | `Method)
+        -> `Method, acc
+      | "bs", _
+      | "bs.this", _
         -> Location.raise_errorf 
              ~loc
-             "[@bs.this] and [@bs] can not be applied at the same time"
+             "[@bs.this], [@bs], [@bs.meth] can not be applied at the same time"
       | _ , _ -> 
         st, attr::acc 
     ) ( `Nothing, []) attrs
@@ -127,3 +129,7 @@ let bs : attr
   =  {txt = "bs" ; loc = Location.none}, Ast_payload.empty
 let bs_this : attr
   =  {txt = "bs.this" ; loc = Location.none}, Ast_payload.empty
+
+let bs_method : attr 
+  =  {txt = "bs.meth"; loc = Location.none}, Ast_payload.empty
+

--- a/jscomp/syntax/ast_attributes.mli
+++ b/jscomp/syntax/ast_attributes.mli
@@ -33,7 +33,7 @@ val process_method_attributes_rev :
   (bool * bool , [`Get | `No_get ]) st * t 
 
 val process_attributes_rev : 
-  t -> [ `Meth_callback | `Nothing | `Uncurry ] * t 
+  t -> [ `Meth_callback | `Nothing | `Uncurry | `Method ] * t 
 
 val process_class_type_decl_rev : 
   t -> [ `Nothing | `Has] * t 
@@ -41,6 +41,8 @@ val process_class_type_decl_rev :
 val process_const_string_rev : 
   t -> 
   [> `Has_re | `Nothing ] * t 
+
 val bs_obj : attr 
 val bs : attr 
 val bs_this : attr
+val bs_method : attr

--- a/jscomp/syntax/ast_attributes.mli
+++ b/jscomp/syntax/ast_attributes.mli
@@ -33,7 +33,7 @@ val process_method_attributes_rev :
   (bool * bool , [`Get | `No_get ]) st * t 
 
 val process_attributes_rev : 
-  t -> [ `Meth | `Nothing | `Uncurry ] * t 
+  t -> [ `Meth_callback | `Nothing | `Uncurry ] * t 
 
 val process_class_type_decl_rev : 
   t -> [ `Nothing | `Has] * t 

--- a/jscomp/syntax/ppx_entry.ml
+++ b/jscomp/syntax/ppx_entry.ml
@@ -181,7 +181,7 @@ let handle_typ
     begin match  Ast_attributes.process_attributes_rev ptyp_attributes with 
       | `Uncurry , ptyp_attributes ->
         Ast_util.to_uncurry_type loc self args body 
-      |  `Meth, ptyp_attributes -> 
+      |  `Meth_callback, ptyp_attributes -> 
         Ast_util.to_method_callback_type loc self args body
       | `Nothing , _ -> 
         if !uncurry_type then 
@@ -217,7 +217,7 @@ let handle_typ
                 { core_type with 
                   ptyp_attributes = 
                     Ast_attributes.bs :: core_type.ptyp_attributes}
-            |  `Meth, ptyp_attrs 
+            |  `Meth_callback, ptyp_attrs 
               ->  
               label , ptyp_attrs, 
               check_auto_uncurry
@@ -235,7 +235,7 @@ let handle_typ
                   { core_type with 
                     ptyp_attributes = 
                       Ast_attributes.bs :: core_type.ptyp_attributes}
-              |  `Meth, ptyp_attrs -> 
+              |  `Meth_callback, ptyp_attrs -> 
                 label , ptyp_attrs, self.typ self 
                   { core_type with 
                     ptyp_attributes = 
@@ -298,7 +298,7 @@ let rec unsafe_mapper : Ast_mapper.mapper =
             {e with 
              pexp_desc = Ast_util.to_uncurry_fn loc self pat body  ;
              pexp_attributes}
-          | `Meth , pexp_attributes
+          | `Meth_callback , pexp_attributes
             -> 
             {e with pexp_desc = Ast_util.to_method_callback loc  self pat body ;
                     pexp_attributes }

--- a/jscomp/test/class_type_ffi_test.js
+++ b/jscomp/test/class_type_ffi_test.js
@@ -29,8 +29,13 @@ function test_set(x) {
   return x.length = 3;
 }
 
+function f(x) {
+  return x.bark("he");
+}
+
 exports.sum_float_array = sum_float_array;
 exports.sum_int_array   = sum_int_array;
 exports.sum_poly        = sum_poly;
 exports.test_set        = test_set;
+exports.f               = f;
 /* No side effect */

--- a/jscomp/test/class_type_ffi_test.ml
+++ b/jscomp/test/class_type_ffi_test.ml
@@ -41,4 +41,5 @@ let sum_poly zero add (arr : _ arrayLike Js.t) =
 let test_set x = 
   x##length_aux #= 3 
 
-(* let f (x : y0)  =  *)
+let f (x : < bark : string -> unit [@bs.meth] > Js.t)  =
+  x##bark "he"


### PR DESCRIPTION
so user can use short-cut syntax without declaring class type

```ocaml
let f (x : < bark : string  -> unit [@bs.meth] > Js.t) = 
   x ##bark "hi"
```

TODO: documentation

@mransan can not use `method` since `method` is a keyword