### PR TITLE
Remove "Language Extensions" from SUMMARY.md

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -22,7 +22,6 @@
 
 * BuckleScript FFI
 
-  * [Language Extensions](./Extensions.md)
   * [JS calling OCaml](./JS-call-OCaml.md)
   * [OCaml calling JS](./OCaml-call-JS.md)
   * [Runtime representation](./Runtime-representation.md)


### PR DESCRIPTION
The Extensions.md document was deleted in 0f12773