### PR TITLE
Update dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,12 +6,13 @@
     "diff": "^2.2.2",
     "glob": "^7.0.3",
     "istanbul": "^0.4.2",
-    "karma": "^0.13.9",
-    "karma-jasmine-html-reporter": "^0.1.8",
+    "jasmine-core": "^2.4.1",
+    "karma": "^1.1.2",
+    "karma-jasmine-html-reporter": "^0.2.1",
     "mocha": "^2.3.4",
     "mocha-lcov-reporter": "^1.2.0",
-    "should": "^7.0.4",
-    "should-equal": "^0.5.0",
+    "should": "^10.0.0",
+    "should-equal": "^1.0.0",
     "uglify-js": "^2.6.1"
   },
   "scripts": {


### PR DESCRIPTION
This PR just updates the dev dependencies flagged by `npm outdated` and includes `jasmine-core` which is needed as a peer dependency.