### PR TITLE
[Docs] Make live demo header better on small screen width

### DIFF
--- a/js-demo/examples/examples.json
+++ b/js-demo/examples/examples.json
@@ -1,8 +1,8 @@
 {
-    "Default" :
+    "Default Example" :
     { "file" : "default.ml",
       "eval" : true
-    }, 
+    },
     "Event Handler" :
     { "file" :  "event_handler.ml",
       "eval" : false},
@@ -20,24 +20,24 @@
       "file" : "fp.ml",
       "eval" : true
     },
-    "Curry optimization" : 
+    "Curry Optimization" :
     {
       "file" : "curry.ml",
       "eval" : true
     },
-    "For loop" : {
+    "For Loop" : {
       "file" : "for_loop.ml",
       "eval" : true
     },
-    "Use standard library" : {
+    "Use Standard Library" : {
       "file" : "use_stdlib.ml",
       "eval" : true
     },
-    "JS objects" : {
+    "JS Objects" : {
       "file" : "js_object.ml",
       "eval" : true
     },
-    "Left pad" : {
+    "Left Pad" : {
       "file" : "left_pad.ml",
       "eval" : true
     }

--- a/js-demo/index.html
+++ b/js-demo/index.html
@@ -12,7 +12,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.17.0/addon/edit/closebrackets.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/1.5.12/clipboard.min.js"></script>
     <link rel="stylesheet" type="text/css" href="theme.css">
-  <script src="https://code.jquery.com/jquery-2.2.4.min.js" 
+  <script src="https://code.jquery.com/jquery-2.2.4.min.js"
     integrity="sha256-BbhdlvQf/xTY9gja0Dq3HiwQF8LaCRTXxZKRutelT44="
    crossorigin="anonymous"></script>
    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
@@ -23,36 +23,36 @@
 
 <nav class="navbar navbar-inverse navbar-static-top" style="margin-bottom: 0px">
   <div class="container-fluid">
-    <div class="navbar-brand" style="color: white">BuckleScript</div>
+    <div class="collapse navbar-collapse navbar-header"> <!-- Hides brand on small width -->
+      <div class="navbar-brand" style="color: white">BuckleScript</div>
+    </div>
 
     <div>
       <ul class="nav navbar-nav">
         <li><a href="https://github.com/bloomberg/bucklescript" target="_blank">Fork me on GitHub</a></li>
-        <div class="navbar-brand examples">  Examples:</div>
+
         <li class="dropdown">
-          <a href="#" id = "examplesLabel" class="dropdown-toggle" data-toggle="dropdown">Default<span class="caret"></span></a>
+          <a href="#" id = "examplesLabel" class="dropdown-toggle" data-toggle="dropdown">Default Example<span class="caret"></span></a>
           <ul id="examplesDropdown" class="dropdown-menu">
           </ul>
         </li>
         <li><button class="btn navbar-btn navbar-button" data-loading-text="Getting link..."type="button" id="share">Share</button></li>
       </ul>
 
-        <div class="checkbox navbar-btn navbar-right">
-          <label class="navbar-link repl-toolbar" >
-              <input type="checkbox" id="option-non-export">
-              Remove unused code
-          </label>
-          <label class="navbar-link repl-toolbar">
-              <input type="checkbox" id="option-eval" checked>
-              Eval
-          </label>
-        </div>
-
+      <div class="checkbox navbar-btn navbar-right">
+        <label class="navbar-link repl-toolbar" >
+          <input type="checkbox" id="option-non-export">
+          Remove unused code
+        </label>
+        <label class="navbar-link repl-toolbar">
+          <input type="checkbox" id="option-eval" checked>
+          Eval
+        </label>
+      </div>
 
     </div><!-- /.navbar-collapse -->
   </div><!-- /.container-fluid -->
 </nav>
-
 
 <div id="shareModal" class="modal fade" tabindex="-1" role="dialog">
   <div class="modal-dialog" role="document">
@@ -92,7 +92,7 @@
 
     <div class = "right-border" style="width: 50%;float:left">
         <textarea id="ocamlcode#1">
-Js.log "Hello BuckleScript!"             
+Js.log "Hello BuckleScript!"
         </textarea>
     </div>
     <div style="width: 50%; float:right">


### PR DESCRIPTION
The reason why I changed "Examples:" to "Default Example" is because the "Example: " nav item by itself doesn't easily position itself correctly on small screen.

Also make some title casing consistent.

Before:
<img width="874" alt="screenshot 2016-08-15 02 23 45" src="https://cloud.githubusercontent.com/assets/1909539/17660653/61436f08-628f-11e6-9208-39dd2f264f5f.png">
<img width="763" alt="screenshot 2016-08-15 02 19 22" src="https://cloud.githubusercontent.com/assets/1909539/17660545/bdac808c-628e-11e6-8654-98270f24f6db.png">

After:
<img width="873" alt="screenshot 2016-08-15 02 23 37" src="https://cloud.githubusercontent.com/assets/1909539/17660638/51fe96a8-628f-11e6-9c30-0c53dc1fc4e0.png">
<img width="764" alt="screenshot 2016-08-15 02 19 38" src="https://cloud.githubusercontent.com/assets/1909539/17660549/c0964224-628e-11e6-987c-cfe5146823d8.png">