### PR TITLE
[Docs] Prevent compiled output from display in diff views

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+js-demo/exports.js binary
+reason-demo/exports.js binary


### PR DESCRIPTION
So that github & git viewing tools don't have to display the huge diff

<img width="897" alt="screenshot 2016-08-15 16 13 03" src="https://cloud.githubusercontent.com/assets/1909539/17682861/68b3c84a-6303-11e6-81ee-d10822a8a74b.png">
