### PR TITLE
Fix typo in manual getElementById should be get_by_id

### DIFF
--- a/docs/Manual.html
+++ b/docs/Manual.html
@@ -1491,7 +1491,7 @@ give the JavaScript foreign function a different name:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-n">getElementById</span> <span class="tok-n">dom</span> <span class="tok-s2">&quot;xx&quot;</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-n">get_by_id</span> <span class="tok-n">dom</span> <span class="tok-s2">&quot;xx&quot;</span></code></pre>
 </div>
 </div>
 <div class="paragraph">

--- a/site/docsource/OCaml-call-JS.adoc
+++ b/site/docsource/OCaml-call-JS.adoc
@@ -156,7 +156,7 @@ The object is always the first argument and actual arguments follow.
 Input:
 [source,ocaml]
 --------
-getElementById dom "xx"
+get_by_id dom "xx"
 --------
 
 Output:


### PR DESCRIPTION
See (here)[http://bloomberg.github.io/bucklescript/Manual.html#_binding_to_method_bs_send_bs_send_pipe].