### PR TITLE
enforce #= always return unit for better error message

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -12,6 +12,8 @@
 
 * Bug fixes and enhancment
 
+- Enforce `#=` always return unit {issues}718[#718] for better error messages
+
 * Tools (bspack)
 
 

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -9,9 +9,11 @@
 	and private method {issues}/694[#694]
 - Introduce phantom arguments (`bs.ignore`) for ad-hoc
 	polymorphism {issues}/686[#686]
-* Bug fixes
+
+* Bug fixes and enhancment
 
 * Tools (bspack)
+
 
 
 == 1.0

--- a/jscomp/test/CCSexpM.js
+++ b/jscomp/test/CCSexpM.js
@@ -410,7 +410,7 @@ function _get(t) {
     throw [
           Caml_builtin_exceptions.assert_failure,
           [
-            "./CCSexpM.ml",
+            "CCSexpM.ml",
             152,
             4
           ]
@@ -568,7 +568,7 @@ function expr_starting_with(c, k, t) {
         throw [
               Caml_builtin_exceptions.assert_failure,
               [
-                "./CCSexpM.ml",
+                "CCSexpM.ml",
                 183,
                 27
               ]
@@ -1100,7 +1100,7 @@ function MakeDecode(funarg) {
       throw [
             Caml_builtin_exceptions.assert_failure,
             [
-              "./CCSexpM.ml",
+              "CCSexpM.ml",
               152,
               4
             ]
@@ -1254,7 +1254,7 @@ function MakeDecode(funarg) {
           throw [
                 Caml_builtin_exceptions.assert_failure,
                 [
-                  "./CCSexpM.ml",
+                  "CCSexpM.ml",
                   183,
                   27
                 ]

--- a/jscomp/test/chain_code_test.js
+++ b/jscomp/test/chain_code_test.js
@@ -37,11 +37,11 @@ function f3(h, x, y) {
 }
 
 function f4(h, x, y) {
-  var tmp = h.paint = /* tuple */[
+  h.paint = /* tuple */[
     x,
     y
   ];
-  return tmp.draw = /* tuple */[
+  return h.paint.draw = /* tuple */[
           x,
           y
         ];
@@ -55,7 +55,7 @@ var h = {
   }
 };
 
-eq('File "chain_code_test.ml", line 29, characters 5-12', 32, h.x.y.z);
+eq('File "chain_code_test.ml", line 28, characters 5-12', 32, h.x.y.z);
 
 Mt.from_pair_suites("chain_code_test.ml", suites[0]);
 

--- a/jscomp/test/chain_code_test.ml
+++ b/jscomp/test/chain_code_test.ml
@@ -16,9 +16,8 @@ let f3 h x y =
   (h##paint x y)##draw x y
 
 let f4 h x y = 
-  h
-  ##paint#=(x,y)
-  ##draw#= (x,y)
+  h##paint#=(x,y);
+  h##paint##draw#= (x,y)
 
 
 (* let g h =  *)

--- a/jscomp/test/ppx_this_obj_field.js
+++ b/jscomp/test/ppx_this_obj_field.js
@@ -98,7 +98,42 @@ var test_type = /* :: */[
   test_type_001
 ];
 
-eq('File "ppx_this_obj_field.ml", line 60, characters 5-12', /* tuple */[
+var z = {
+  x: [3],
+  setX: function (x) {
+    var self = this ;
+    self.x[0] = x;
+    return /* () */0;
+  },
+  getX: function () {
+    var self = this ;
+    return self.x[0];
+  }
+};
+
+var zz = {
+  x: 3,
+  setX: function (x) {
+    var self = this ;
+    return self.x = x;
+  },
+  getX: function () {
+    var self = this ;
+    return self.x;
+  }
+};
+
+var test_type2_001 = /* :: */[
+  zz,
+  /* [] */0
+];
+
+var test_type2 = /* :: */[
+  z,
+  test_type2_001
+];
+
+eq('File "ppx_this_obj_field.ml", line 76, characters 5-12', /* tuple */[
       6,
       v5.say()
     ]);
@@ -115,7 +150,7 @@ var c = v.say();
 
 v.incr();
 
-eq('File "ppx_this_obj_field.ml", line 67, characters 5-12', /* tuple */[
+eq('File "ppx_this_obj_field.ml", line 83, characters 5-12', /* tuple */[
       /* tuple */[
         3,
         4,
@@ -128,13 +163,33 @@ eq('File "ppx_this_obj_field.ml", line 67, characters 5-12', /* tuple */[
       ]
     ]);
 
+var aa = z.getX();
+
+z.setX(32);
+
+var bb = z.getX();
+
+eq('File "ppx_this_obj_field.ml", line 87, characters 5-12', /* tuple */[
+      /* tuple */[
+        3,
+        32
+      ],
+      /* tuple */[
+        aa,
+        bb
+      ]
+    ]);
+
 Mt.from_pair_suites("ppx_this_obj_field.ml", suites[0]);
 
-exports.suites    = suites;
-exports.test_id   = test_id;
-exports.eq        = eq;
-exports.v5        = v5;
-exports.v         = v;
-exports.u         = u;
-exports.test_type = test_type;
+exports.suites     = suites;
+exports.test_id    = test_id;
+exports.eq         = eq;
+exports.v5         = v5;
+exports.v          = v;
+exports.u          = u;
+exports.test_type  = test_type;
+exports.z          = z;
+exports.zz         = zz;
+exports.test_type2 = test_type2;
 /* v5 Not a pure module */

--- a/jscomp/test/ppx_this_obj_field.ml
+++ b/jscomp/test/ppx_this_obj_field.ml
@@ -56,6 +56,22 @@ let u =
 
 let test_type = [u ; v]
 
+let z =
+  object (self)
+    val x = ref 3 
+    method setX x = self##x := x
+    method getX () =  ! (self##x)
+  end [@bs]
+
+let zz =
+  object (self)
+    val mutable x =  3 
+    method setX x = self##x #= x
+    method getX () =   (self##x)
+  end [@bs]
+
+let test_type2 = [z;zz]
+
 let () = 
   eq __LOC__ (6, v5##say ());
   let a = v##say () in 
@@ -64,7 +80,11 @@ let () =
   v##incr ();
   let c = v##say () in 
   v##incr ();
-  eq __LOC__ ((3,4,5) , (a,b,c))
+  eq __LOC__ ((3,4,5) , (a,b,c));
+  let aa = z##getX () in
+  let () = z##setX 32 in 
+  let bb = z##getX () in
+  eq __LOC__ ((3, 32), (aa,bb))
 
 let () =
   Mt.from_pair_suites __FILE__ !suites


### PR DESCRIPTION
Note that another issue: `h##property`  will not generate constraints for `h##property#=` (and vice versa), this in general will not be an issue, since users  can not create such object, but   we have to wait for users to call it to cause type error), actually it is not very easy to generate constraints since nullable/undefined)