### PR TITLE
correct the installed version in documentation

### DIFF
--- a/docs/Manual.html
+++ b/docs/Manual.html
@@ -418,69 +418,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 .show-for-print{display:inherit!important}}
 </style>
 <style>
-.listingblock .pygments .hll { background-color: #ffffcc }
-.listingblock .pygments  { background: #f8f8f8; }
-.listingblock .pygments .tok-c { color: #408080; font-style: italic } /* Comment */
-.listingblock .pygments .tok-err { border: 1px solid #FF0000 } /* Error */
-.listingblock .pygments .tok-k { color: #008000; font-weight: bold } /* Keyword */
-.listingblock .pygments .tok-o { color: #666666 } /* Operator */
-.listingblock .pygments .tok-cm { color: #408080; font-style: italic } /* Comment.Multiline */
-.listingblock .pygments .tok-cp { color: #BC7A00 } /* Comment.Preproc */
-.listingblock .pygments .tok-c1 { color: #408080; font-style: italic } /* Comment.Single */
-.listingblock .pygments .tok-cs { color: #408080; font-style: italic } /* Comment.Special */
-.listingblock .pygments .tok-gd { color: #A00000 } /* Generic.Deleted */
-.listingblock .pygments .tok-ge { font-style: italic } /* Generic.Emph */
-.listingblock .pygments .tok-gr { color: #FF0000 } /* Generic.Error */
-.listingblock .pygments .tok-gh { color: #000080; font-weight: bold } /* Generic.Heading */
-.listingblock .pygments .tok-gi { color: #00A000 } /* Generic.Inserted */
-.listingblock .pygments .tok-go { color: #888888 } /* Generic.Output */
-.listingblock .pygments .tok-gp { color: #000080; font-weight: bold } /* Generic.Prompt */
-.listingblock .pygments .tok-gs { font-weight: bold } /* Generic.Strong */
-.listingblock .pygments .tok-gu { color: #800080; font-weight: bold } /* Generic.Subheading */
-.listingblock .pygments .tok-gt { color: #0044DD } /* Generic.Traceback */
-.listingblock .pygments .tok-kc { color: #008000; font-weight: bold } /* Keyword.Constant */
-.listingblock .pygments .tok-kd { color: #008000; font-weight: bold } /* Keyword.Declaration */
-.listingblock .pygments .tok-kn { color: #008000; font-weight: bold } /* Keyword.Namespace */
-.listingblock .pygments .tok-kp { color: #008000 } /* Keyword.Pseudo */
-.listingblock .pygments .tok-kr { color: #008000; font-weight: bold } /* Keyword.Reserved */
-.listingblock .pygments .tok-kt { color: #B00040 } /* Keyword.Type */
-.listingblock .pygments .tok-m { color: #666666 } /* Literal.Number */
-.listingblock .pygments .tok-s { color: #BA2121 } /* Literal.String */
-.listingblock .pygments .tok-na { color: #7D9029 } /* Name.Attribute */
-.listingblock .pygments .tok-nb { color: #008000 } /* Name.Builtin */
-.listingblock .pygments .tok-nc { color: #0000FF; font-weight: bold } /* Name.Class */
-.listingblock .pygments .tok-no { color: #880000 } /* Name.Constant */
-.listingblock .pygments .tok-nd { color: #AA22FF } /* Name.Decorator */
-.listingblock .pygments .tok-ni { color: #999999; font-weight: bold } /* Name.Entity */
-.listingblock .pygments .tok-ne { color: #D2413A; font-weight: bold } /* Name.Exception */
-.listingblock .pygments .tok-nf { color: #0000FF } /* Name.Function */
-.listingblock .pygments .tok-nl { color: #A0A000 } /* Name.Label */
-.listingblock .pygments .tok-nn { color: #0000FF; font-weight: bold } /* Name.Namespace */
-.listingblock .pygments .tok-nt { color: #008000; font-weight: bold } /* Name.Tag */
-.listingblock .pygments .tok-nv { color: #19177C } /* Name.Variable */
-.listingblock .pygments .tok-ow { color: #AA22FF; font-weight: bold } /* Operator.Word */
-.listingblock .pygments .tok-w { color: #bbbbbb } /* Text.Whitespace */
-.listingblock .pygments .tok-mb { color: #666666 } /* Literal.Number.Bin */
-.listingblock .pygments .tok-mf { color: #666666 } /* Literal.Number.Float */
-.listingblock .pygments .tok-mh { color: #666666 } /* Literal.Number.Hex */
-.listingblock .pygments .tok-mi { color: #666666 } /* Literal.Number.Integer */
-.listingblock .pygments .tok-mo { color: #666666 } /* Literal.Number.Oct */
-.listingblock .pygments .tok-sb { color: #BA2121 } /* Literal.String.Backtick */
-.listingblock .pygments .tok-sc { color: #BA2121 } /* Literal.String.Char */
-.listingblock .pygments .tok-sd { color: #BA2121; font-style: italic } /* Literal.String.Doc */
-.listingblock .pygments .tok-s2 { color: #BA2121 } /* Literal.String.Double */
-.listingblock .pygments .tok-se { color: #BB6622; font-weight: bold } /* Literal.String.Escape */
-.listingblock .pygments .tok-sh { color: #BA2121 } /* Literal.String.Heredoc */
-.listingblock .pygments .tok-si { color: #BB6688; font-weight: bold } /* Literal.String.Interpol */
-.listingblock .pygments .tok-sx { color: #008000 } /* Literal.String.Other */
-.listingblock .pygments .tok-sr { color: #BB6688 } /* Literal.String.Regex */
-.listingblock .pygments .tok-s1 { color: #BA2121 } /* Literal.String.Single */
-.listingblock .pygments .tok-ss { color: #19177C } /* Literal.String.Symbol */
-.listingblock .pygments .tok-bp { color: #008000 } /* Name.Builtin.Pseudo */
-.listingblock .pygments .tok-vc { color: #19177C } /* Name.Variable.Class */
-.listingblock .pygments .tok-vg { color: #19177C } /* Name.Variable.Global */
-.listingblock .pygments .tok-vi { color: #19177C } /* Name.Variable.Instance */
-.listingblock .pygments .tok-il { color: #666666 } /* Literal.Number.Integer.Long */
+/* Pygments styles disabled. Pygments is not available. */
 </style>
 </head>
 <body class="article toc2 toc-left">
@@ -855,7 +793,7 @@ is installed, run the following command:</p>
 <div class="title">Instructions:</div>
 <div class="content">
 <pre class="pygments highlight"><code data-lang="sh">git clone https://github.com/bloomberg/bucklescript
-<span class="tok-nb">cd </span>bucklescript
+cd bucklescript
 npm install</code></pre>
 </div>
 </div>
@@ -878,8 +816,8 @@ easily be done.</p>
 <div class="title">Build OCaml compiler</div>
 <div class="content">
 <pre class="pygments highlight"><code data-lang="sh">git clone --recursive https://github.com/bloomberg/bucklescript
-<span class="tok-nb">cd </span>bucklescript/ocaml
-./configure -prefix <span class="tok-sb">`</span><span class="tok-nb">pwd</span><span class="tok-sb">`</span> <span class="tok-c"># put your preferred directory</span>
+cd bucklescript/ocaml
+./configure -prefix `pwd` # put your preferred directory
 make world.opt
 make install</code></pre>
 </div>
@@ -898,7 +836,7 @@ the previous section.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="sh"><span class="tok-nb">export </span><span class="tok-nv">BS_RELEASE_BUILD</span><span class="tok-o">=</span>1
+<pre class="pygments highlight"><code data-lang="sh">export BS_RELEASE_BUILD=1
 make world</code></pre>
 </div>
 </div>
@@ -939,7 +877,7 @@ version of the compiler:</p>
 <div class="content">
 <pre class="pygments highlight"><code data-lang="sh">opam update
 opam switch 4.02.3
-<span class="tok-nb">eval</span> <span class="tok-sb">`</span>opam config env<span class="tok-sb">`</span></code></pre>
+eval `opam config env`</code></pre>
 </div>
 </div>
 </div>
@@ -958,14 +896,14 @@ as below:</p>
 <div class="listingblock">
 <div class="title">package.json</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-p">{</span>
-    <span class="tok-s2">&quot;dependencies&quot;</span><span class="tok-o">:</span> <span class="tok-p">{</span>
-        <span class="tok-s2">&quot;bs-platform&quot;</span><span class="tok-o">:</span> <span class="tok-s2">&quot;0.9.3&quot;</span> <b class="conum">(1)</b>
-    <span class="tok-p">},</span>
-    <span class="tok-s2">&quot;scripts&quot;</span> <span class="tok-o">:</span> <span class="tok-p">{</span>
-        <span class="tok-s2">&quot;build&quot;</span> <span class="tok-o">:</span> <span class="tok-s2">&quot;bsc -c  main_entry.ml&quot;</span>
-    <span class="tok-p">}</span>
-<span class="tok-p">}</span></code></pre>
+<pre class="pygments highlight"><code data-lang="js">{
+    "dependencies": {
+        "bs-platform": "1.0.1" <b class="conum">(1)</b>
+    },
+    "scripts" : {
+        "build" : "bsc -c  main_entry.ml"
+    }
+}</code></pre>
 </div>
 </div>
 <div class="colist arabic">
@@ -981,8 +919,8 @@ as below:</p>
 <div class="listingblock">
 <div class="title">main_entry.ml</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-bp">()</span> <span class="tok-o">=</span>
-  <span class="tok-n">print_endline</span> <span class="tok-s2">&quot;hello world&quot;</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">let () =
+  print_endline "hello world"</code></pre>
 </div>
 </div>
 </li>
@@ -1002,13 +940,13 @@ as below:</p>
 <div class="listingblock">
 <div class="title">main_entry.js</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-c1">// GENERATED CODE BY BUCKLESCRIPT VERSION 0.9.3 , PLEASE EDIT WITH CARE</span>
-<span class="tok-s1">&#39;use strict&#39;</span><span class="tok-p">;</span>
+<pre class="pygments highlight"><code data-lang="js">// GENERATED CODE BY BUCKLESCRIPT VERSION 1.0.1 , PLEASE EDIT WITH CARE
+'use strict';
 
 
-<span class="tok-nx">console</span><span class="tok-p">.</span><span class="tok-nx">log</span><span class="tok-p">(</span><span class="tok-s2">&quot;hello world&quot;</span><span class="tok-p">);</span>
+console.log("hello world");
 
-<span class="tok-cm">/*  Not a pure module */</span> <b class="conum">(1)</b></code></pre>
+/*  Not a pure module */ <b class="conum">(1)</b></code></pre>
 </div>
 </div>
 <div class="colist arabic">
@@ -1045,14 +983,14 @@ will call <code>fib</code>.</p>
 <div class="listingblock">
 <div class="title">package.json</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-p">{</span>
-    <span class="tok-s2">&quot;dependencies&quot;</span><span class="tok-o">:</span> <span class="tok-p">{</span>
-        <span class="tok-s2">&quot;bs-platform&quot;</span><span class="tok-o">:</span> <span class="tok-s2">&quot;0.9.4&quot;</span>
-    <span class="tok-p">},</span>
-    <span class="tok-s2">&quot;scripts&quot;</span> <span class="tok-o">:</span> <span class="tok-p">{</span>
-        <span class="tok-s2">&quot;build&quot;</span> <span class="tok-o">:</span> <span class="tok-s2">&quot;bsc -c -bs-main main_entry.ml&quot;</span> <b class="conum">(1)</b>
-    <span class="tok-p">}</span>
-<span class="tok-p">}</span></code></pre>
+<pre class="pygments highlight"><code data-lang="js">{
+    "dependencies": {
+        "bs-platform": "1.0.1"
+    },
+    "scripts" : {
+        "build" : "bsc -c -bs-main main_entry.ml" <b class="conum">(1)</b>
+    }
+}</code></pre>
 </div>
 </div>
 <div class="colist arabic">
@@ -1069,21 +1007,21 @@ its dependency accordingly</p>
 <div class="listingblock">
 <div class="title">fib.ml</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span>  <span class="tok-n">fib</span> <span class="tok-n">n</span>  <span class="tok-o">=</span>
-  <span class="tok-k">let</span> <span class="tok-k">rec</span> <span class="tok-n">aux</span> <span class="tok-n">n</span> <span class="tok-n">a</span> <span class="tok-n">b</span> <span class="tok-o">=</span>
-    <span class="tok-k">if</span> <span class="tok-n">n</span> <span class="tok-o">=</span> <span class="tok-mi">0</span> <span class="tok-k">then</span> <span class="tok-n">a</span>
-    <span class="tok-k">else</span>
-      <span class="tok-n">aux</span> <span class="tok-o">(</span><span class="tok-n">n</span> <span class="tok-o">-</span> <span class="tok-mi">1</span><span class="tok-o">)</span> <span class="tok-n">b</span> <span class="tok-o">(</span><span class="tok-n">a</span><span class="tok-o">+</span><span class="tok-n">b</span><span class="tok-o">)</span>
-  <span class="tok-k">in</span> <span class="tok-n">aux</span> <span class="tok-n">n</span> <span class="tok-mi">1</span> <span class="tok-mi">1</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">let  fib n  =
+  let rec aux n a b =
+    if n = 0 then a
+    else
+      aux (n - 1) b (a+b)
+  in aux n 1 1</code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="title">main_entry.ml</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-bp">()</span> <span class="tok-o">=</span>
-  <span class="tok-k">for</span> <span class="tok-n">i</span> <span class="tok-o">=</span> <span class="tok-mi">0</span> <span class="tok-k">to</span> <span class="tok-mi">10</span> <span class="tok-k">do</span>
-    <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">log</span> <span class="tok-o">(</span><span class="tok-nn">Fib</span><span class="tok-p">.</span><span class="tok-n">fib</span> <span class="tok-n">i</span><span class="tok-o">)</span> <b class="conum">(1)</b>
-  <span class="tok-k">done</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">let () =
+  for i = 0 to 10 do
+    Js.log (Fib.fib i) <b class="conum">(1)</b>
+  done</code></pre>
 </div>
 </div>
 <div class="colist arabic">
@@ -1147,7 +1085,7 @@ directories, we have a flag</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="sh">bsc -bs-package-name <span class="tok-nv">$npm_package_name</span> -bs-package-output modulesystem:path/to/your/js/dir -c a.ml</code></pre>
+<pre class="pygments highlight"><code data-lang="sh">bsc -bs-package-name $npm_package_name -bs-package-output modulesystem:path/to/your/js/dir -c a.ml</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -1184,7 +1122,7 @@ pretty straightforward:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="sh">bsc -bs-package-include ocaml-package1 -bs-package-include ocaml-package2  -bs-package-name <span class="tok-nv">$npm_package_name</span> -bs-package-output commonjs:path/to/lib/js/ -c a.ml</code></pre>
+<pre class="pygments highlight"><code data-lang="sh">bsc -bs-package-include ocaml-package1 -bs-package-include ocaml-package2  -bs-package-name $npm_package_name -bs-package-output commonjs:path/to/lib/js/ -c a.ml</code></pre>
 </div>
 </div>
 </div>
@@ -1236,9 +1174,9 @@ we recommend users to export it as functions.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml">  <span class="tok-k">type</span> <span class="tok-n">t</span> <span class="tok-o">=</span>
-    <span class="tok-o">|</span> <span class="tok-nc">Cons</span> <span class="tok-k">of</span> <span class="tok-kt">int</span> <span class="tok-o">*</span> <span class="tok-n">t</span>
-    <span class="tok-o">|</span> <span class="tok-nc">Nil</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">  type t =
+    | Cons of int * t
+    | Nil</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -1247,8 +1185,8 @@ so that it can be constructed from the JS side.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">cons</span> <span class="tok-n">x</span> <span class="tok-n">y</span> <span class="tok-o">=</span> <span class="tok-nc">Cons</span> <span class="tok-o">(</span><span class="tok-n">x</span><span class="tok-o">,</span><span class="tok-n">y</span><span class="tok-o">)</span>
-<span class="tok-k">let</span> <span class="tok-n">nil</span> <span class="tok-o">=</span> <span class="tok-nc">Nil</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">let cons x y = Cons (x,y)
+let nil = Nil</code></pre>
 </div>
 </div>
 <div class="admonitionblock note">
@@ -1315,8 +1253,8 @@ with syntax as described below:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">external</span> <span class="tok-k">value</span><span class="tok-o">-</span><span class="tok-n">name</span> <span class="tok-o">:</span>  <span class="tok-n">typexpr</span> <span class="tok-o">=</span>  <span class="tok-k">external</span><span class="tok-o">-</span><span class="tok-n">declaration</span>  <span class="tok-n">attributes</span>
-<span class="tok-k">external</span><span class="tok-o">-</span><span class="tok-n">declaration</span> <span class="tok-o">:=</span>  <span class="tok-kt">string</span><span class="tok-o">-</span><span class="tok-n">literal</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">external value-name :  typexpr =  external-declaration  attributes
+external-declaration :=  string-literal</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -1328,10 +1266,10 @@ and provide customized <code>attributes</code>.</p>
 <h4 id="_binding_to_global_value_bs_val"><a class="anchor" href="#_binding_to_global_value_bs_val"></a>Binding to global value: bs.val</h4>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">external</span> <span class="tok-n">imul</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;Math.imul&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">val</span><span class="tok-o">]</span>
-<span class="tok-k">type</span> <span class="tok-n">dom</span>
-<span class="tok-c">(* Abstract type for the DOM *)</span>
-<span class="tok-k">external</span> <span class="tok-n">dom</span> <span class="tok-o">:</span> <span class="tok-n">dom</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;document&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">val</span><span class="tok-o">]</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">external imul : int -&gt; int -&gt; int = "Math.imul" [@@bs.val]
+type dom
+(* Abstract type for the DOM *)
+external dom : dom = "document" [@@bs.val]</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -1352,7 +1290,7 @@ it can be a function or plain value.</p>
 for example:</p>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">external</span> <span class="tok-n">document</span> <span class="tok-o">:</span> <span class="tok-n">dom</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">val</span><span class="tok-o">]</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">external document : dom = "" [@@bs.val]</code></pre>
 </div>
 </div>
 </li>
@@ -1362,8 +1300,8 @@ JavaScript functions, you can
 give the JavaScript foreign function a different name:</p>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">external</span> <span class="tok-n">imul</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">=</span>
-  <span class="tok-s2">&quot;c_imul&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">val</span> <span class="tok-s2">&quot;Math.imul&quot;</span><span class="tok-o">]</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">external imul : int -&gt; int -&gt; int =
+  "c_imul" [@@bs.val "Math.imul"]</code></pre>
 </div>
 </div>
 </li>
@@ -1381,8 +1319,8 @@ give the JavaScript foreign function a different name:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">external</span> <span class="tok-n">create_date</span> <span class="tok-o">:</span> <span class="tok-kt">unit</span> <span class="tok-o">-&gt;</span> <span class="tok-n">t</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;Date&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">new</span><span class="tok-o">]</span>
-<span class="tok-k">let</span> <span class="tok-n">date</span> <span class="tok-o">=</span> <span class="tok-n">create_date</span> <span class="tok-bp">()</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">external create_date : unit -&gt; t = "Date" [@@bs.new]
+let date = create_date ()</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -1390,7 +1328,7 @@ give the JavaScript foreign function a different name:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-kd">var</span> <span class="tok-nx">date</span> <span class="tok-o">=</span> <span class="tok-k">new</span> <span class="tok-nb">Date</span><span class="tok-p">();</span></code></pre>
+<pre class="pygments highlight"><code data-lang="js">var date = new Date();</code></pre>
 </div>
 </div>
 </div>
@@ -1401,10 +1339,10 @@ give the JavaScript foreign function a different name:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">external</span> <span class="tok-n">add</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;add&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">module</span> <span class="tok-s2">&quot;x&quot;</span><span class="tok-o">]</span>
-<span class="tok-k">external</span> <span class="tok-n">add2</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;add2&quot;</span><span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">module</span> <span class="tok-s2">&quot;y&quot;</span><span class="tok-o">,</span> <span class="tok-s2">&quot;U&quot;</span><span class="tok-o">]</span> <b class="conum">(1)</b>
-<span class="tok-k">let</span> <span class="tok-n">f</span> <span class="tok-o">=</span> <span class="tok-n">add</span> <span class="tok-mi">3</span> <span class="tok-mi">4</span>
-<span class="tok-k">let</span> <span class="tok-n">g</span> <span class="tok-o">=</span> <span class="tok-n">add2</span> <span class="tok-mi">3</span> <span class="tok-mi">4</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">external add : int -&gt; int -&gt; int = "add" [@@bs.module "x"]
+external add2 : int -&gt; int -&gt; int = "add2"[@@bs.module "y", "U"] <b class="conum">(1)</b>
+let f = add 3 4
+let g = add2 3 4</code></pre>
 </div>
 </div>
 <div class="colist arabic">
@@ -1419,10 +1357,10 @@ give the JavaScript foreign function a different name:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-kd">var</span> <span class="tok-nx">U</span> <span class="tok-o">=</span> <span class="tok-nx">require</span><span class="tok-p">(</span><span class="tok-s2">&quot;y&quot;</span><span class="tok-p">);</span>
-<span class="tok-kd">var</span> <span class="tok-nx">X</span> <span class="tok-o">=</span> <span class="tok-nx">require</span><span class="tok-p">(</span><span class="tok-s2">&quot;x&quot;</span><span class="tok-p">);</span>
-<span class="tok-kd">var</span> <span class="tok-nx">f</span> <span class="tok-o">=</span> <span class="tok-nx">X</span><span class="tok-p">.</span><span class="tok-nx">add</span><span class="tok-p">(</span><span class="tok-mi">3</span><span class="tok-p">,</span> <span class="tok-mi">4</span><span class="tok-p">);</span>
-<span class="tok-kd">var</span> <span class="tok-nx">g</span> <span class="tok-o">=</span> <span class="tok-nx">U</span><span class="tok-p">.</span><span class="tok-nx">add2</span><span class="tok-p">(</span><span class="tok-mi">3</span><span class="tok-p">,</span> <span class="tok-mi">4</span><span class="tok-p">);</span></code></pre>
+<pre class="pygments highlight"><code data-lang="js">var U = require("y");
+var X = require("x");
+var f = X.add(3, 4);
+var g = U.add2(3, 4);</code></pre>
 </div>
 </div>
 <div class="admonitionblock note">
@@ -1438,7 +1376,7 @@ give the JavaScript foreign function a different name:</p>
 <p>if <code>external-declaration</code> is the same as value-name, it can be left empty, for example,</p>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">external</span> <span class="tok-n">add</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">module</span> <span class="tok-s2">&quot;x&quot;</span><span class="tok-o">]</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">external add : int -&gt; int -&gt; int = "" [@@bs.module "x"]</code></pre>
 </div>
 </div>
 </li>
@@ -1453,8 +1391,8 @@ give the JavaScript foreign function a different name:</p>
 <h4 id="_binding_the_whole_module_as_a_value_or_function"><a class="anchor" href="#_binding_the_whole_module_as_a_value_or_function"></a>Binding the whole module as a value or function</h4>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">type</span> <span class="tok-n">http</span>
-<span class="tok-k">external</span> <span class="tok-n">http</span> <span class="tok-o">:</span> <span class="tok-n">http</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;http&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">module</span><span class="tok-o">]</span> <b class="conum">(1)</b></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">type http
+external http : http = "http" [@@bs.module] <b class="conum">(1)</b></code></pre>
 </div>
 </div>
 <div class="colist arabic">
@@ -1477,7 +1415,7 @@ give the JavaScript foreign function a different name:</p>
 <p>if <code>external-declaration</code> is the same as value-name, it can be left empty, for example,</p>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">external</span> <span class="tok-n">http</span> <span class="tok-o">:</span> <span class="tok-n">http</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">module</span><span class="tok-o">]</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">external http : http = "" [@@bs.module]</code></pre>
 </div>
 </div>
 </li>
@@ -1495,9 +1433,9 @@ give the JavaScript foreign function a different name:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">type</span> <span class="tok-n">id</span> <span class="tok-c">(** Abstract type for id object *)</span>
-<span class="tok-k">external</span> <span class="tok-n">get_by_id</span> <span class="tok-o">:</span> <span class="tok-n">dom</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">string</span> <span class="tok-o">-&gt;</span> <span class="tok-n">id</span> <span class="tok-o">=</span>
-  <span class="tok-s2">&quot;getElementById&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">send</span><span class="tok-o">]</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">type id (** Abstract type for id object *)
+external get_by_id : dom -&gt; string -&gt; id =
+  "getElementById" [@@bs.send]</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -1508,7 +1446,7 @@ give the JavaScript foreign function a different name:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-n">get_by_id</span> <span class="tok-n">dom</span> <span class="tok-s2">&quot;xx&quot;</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">get_by_id dom "xx"</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -1516,7 +1454,7 @@ give the JavaScript foreign function a different name:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-nx">dom</span><span class="tok-p">.</span><span class="tok-nx">getElementById</span><span class="tok-p">(</span><span class="tok-s2">&quot;xx&quot;</span><span class="tok-p">)</span></code></pre>
+<pre class="pygments highlight"><code data-lang="js">dom.getElementById("xx")</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -1525,14 +1463,14 @@ is put in the position of last argument to help user write in a <em>chaining sty
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">external</span> <span class="tok-n">map</span> <span class="tok-o">:</span> <span class="tok-o">(</span><span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">b</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">])</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">b</span> <span class="tok-kt">array</span> <span class="tok-o">=</span>
-  <span class="tok-s2">&quot;&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">send</span><span class="tok-o">.</span><span class="tok-n">pipe</span><span class="tok-o">:</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-kt">array</span><span class="tok-o">]</span> <b class="conum">(1)</b>
-<span class="tok-k">external</span> <span class="tok-n">forEach</span><span class="tok-o">:</span> <span class="tok-o">(</span><span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">unit</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">])</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-kt">array</span> <span class="tok-o">=</span>
-  <span class="tok-s2">&quot;&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">send</span><span class="tok-o">.</span><span class="tok-n">pipe</span><span class="tok-o">:</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-kt">array</span><span class="tok-o">]</span>
-<span class="tok-k">let</span> <span class="tok-n">test</span> <span class="tok-n">arr</span> <span class="tok-o">=</span>
-    <span class="tok-n">arr</span>
-    <span class="tok-o">|&gt;</span> <span class="tok-n">map</span> <span class="tok-o">(</span><span class="tok-k">fun</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">]</span> <span class="tok-n">x</span> <span class="tok-o">-&gt;</span> <span class="tok-n">x</span> <span class="tok-o">+</span> <span class="tok-mi">1</span><span class="tok-o">)</span>
-    <span class="tok-o">|&gt;</span> <span class="tok-n">forEach</span> <span class="tok-o">(</span><span class="tok-k">fun</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">]</span> <span class="tok-n">x</span> <span class="tok-o">-&gt;</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">log</span> <span class="tok-n">x</span><span class="tok-o">)</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">external map : ('a -&gt; 'b [@bs]) -&gt; 'b array =
+  "" [@@bs.send.pipe: 'a array] <b class="conum">(1)</b>
+external forEach: ('a -&gt; unit [@bs]) -&gt; 'a array =
+  "" [@@bs.send.pipe: 'a array]
+let test arr =
+    arr
+    |&gt; map (fun [@bs] x -&gt; x + 1)
+    |&gt; forEach (fun [@bs] x -&gt; Js.log x)</code></pre>
 </div>
 </div>
 <div class="colist arabic">
@@ -1555,8 +1493,8 @@ is put in the position of last argument to help user write in a <em>chaining sty
 <p>if <code>external-declaration</code> is the same as value-name, it can be left empty, for example,</p>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">external</span> <span class="tok-n">getElementById</span> <span class="tok-o">:</span> <span class="tok-n">dom</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">string</span> <span class="tok-o">-&gt;</span> <span class="tok-n">id</span> <span class="tok-o">=</span>
-  <span class="tok-s2">&quot;&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">send</span><span class="tok-o">]</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">external getElementById : dom -&gt; string -&gt; id =
+  "" [@@bs.send]</code></pre>
 </div>
 </div>
 </li>
@@ -1574,10 +1512,10 @@ is put in the position of last argument to help user write in a <em>chaining sty
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">type</span> <span class="tok-n">t</span>
-<span class="tok-k">external</span> <span class="tok-n">create</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-n">t</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;Int32Array&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">new</span><span class="tok-o">]</span>
-<span class="tok-k">external</span> <span class="tok-n">get</span> <span class="tok-o">:</span> <span class="tok-n">t</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">get_index</span><span class="tok-o">]</span>
-<span class="tok-k">external</span> <span class="tok-n">set</span> <span class="tok-o">:</span> <span class="tok-n">t</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">unit</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">set_index</span><span class="tok-o">]</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">type t
+external create : int -&gt; t = "Int32Array" [@@bs.new]
+external get : t -&gt; int -&gt; int = "" [@@bs.get_index]
+external set : t -&gt; int -&gt; int -&gt; unit = "" [@@bs.set_index]</code></pre>
 </div>
 </div>
 </div>
@@ -1588,9 +1526,9 @@ is put in the position of last argument to help user write in a <em>chaining sty
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">type</span> <span class="tok-n">textarea</span>
-<span class="tok-k">external</span> <span class="tok-n">set_name</span> <span class="tok-o">:</span> <span class="tok-n">textarea</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">string</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">unit</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;name&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">set</span><span class="tok-o">]</span>
-<span class="tok-k">external</span> <span class="tok-n">get_name</span> <span class="tok-o">:</span> <span class="tok-n">textarea</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">string</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;name&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">get</span><span class="tok-o">]</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">type textarea
+external set_name : textarea -&gt; string -&gt; unit = "name" [@@bs.set]
+external get_name : textarea -&gt; string = "name" [@@bs.get]</code></pre>
 </div>
 </div>
 </div>
@@ -1606,16 +1544,16 @@ way by using annotated polymorphic variant.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">external</span> <span class="tok-n">readFileSync</span> <span class="tok-o">:</span>
-  <span class="tok-n">name</span><span class="tok-o">:</span><span class="tok-kt">string</span> <span class="tok-o">-&gt;</span>
-  <span class="tok-o">([</span> <span class="tok-o">`</span><span class="tok-n">utf8</span>
-   <span class="tok-o">|</span> <span class="tok-o">`</span><span class="tok-n">my_name</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">as</span> <span class="tok-s2">&quot;ascii&quot;</span><span class="tok-o">]</span> <b class="conum">(1)</b>
-   <span class="tok-o">]</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-kt">string</span><span class="tok-o">])</span> <span class="tok-o">-&gt;</span>
-  <span class="tok-kt">string</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;&quot;</span>
-  <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">module</span> <span class="tok-s2">&quot;fs&quot;</span><span class="tok-o">]</span>
+<pre class="pygments highlight"><code data-lang="ocaml">external readFileSync :
+  name:string -&gt;
+  ([ `utf8
+   | `my_name [@bs.as "ascii"] <b class="conum">(1)</b>
+   ] [@bs.string]) -&gt;
+  string = ""
+  [@@bs.module "fs"]
 
-<span class="tok-k">let</span> <span class="tok-o">_</span> <span class="tok-o">=</span>
-  <span class="tok-n">readFileSync</span> <span class="tok-o">~</span><span class="tok-n">name</span><span class="tok-o">:</span><span class="tok-s2">&quot;xx.txt&quot;</span> <span class="tok-o">`</span><span class="tok-n">my_name</span></code></pre>
+let _ =
+  readFileSync ~name:"xx.txt" `my_name</code></pre>
 </div>
 </div>
 <div class="colist arabic">
@@ -1630,8 +1568,8 @@ way by using annotated polymorphic variant.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-kd">var</span> <span class="tok-nx">Fs</span> <span class="tok-o">=</span> <span class="tok-nx">require</span><span class="tok-p">(</span><span class="tok-s2">&quot;fs&quot;</span><span class="tok-p">);</span>
-<span class="tok-nx">Fs</span><span class="tok-p">.</span><span class="tok-nx">readFileSync</span><span class="tok-p">(</span><span class="tok-s2">&quot;xx.txt&quot;</span><span class="tok-p">,</span> <span class="tok-s2">&quot;ascii&quot;</span><span class="tok-p">);</span></code></pre>
+<pre class="pygments highlight"><code data-lang="js">var Fs = require("fs");
+Fs.readFileSync("xx.txt", "ascii");</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -1639,13 +1577,13 @@ way by using annotated polymorphic variant.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">external</span> <span class="tok-n">test_int_type</span> <span class="tok-o">:</span>
-  <span class="tok-o">([</span> <span class="tok-o">`</span><span class="tok-n">on_closed</span> <b class="conum">(1)</b>
-   <span class="tok-o">|</span> <span class="tok-o">`</span><span class="tok-n">on_open</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">as</span> <span class="tok-mi">3</span><span class="tok-o">]</span>  <b class="conum">(2)</b>
-   <span class="tok-o">|</span> <span class="tok-o">`</span><span class="tok-n">in_bin</span> <b class="conum">(3)</b>
-   <span class="tok-o">]</span>
-   <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-kt">int</span><span class="tok-o">])</span>  <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span>  <span class="tok-o">=</span>
-  <span class="tok-s2">&quot;&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">val</span><span class="tok-o">]</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">external test_int_type :
+  ([ `on_closed <b class="conum">(1)</b>
+   | `on_open [@bs.as 3]  <b class="conum">(2)</b>
+   | `in_bin <b class="conum">(3)</b>
+   ]
+   [@bs.int])  -&gt; int  =
+  "" [@@bs.val]</code></pre>
 </div>
 </div>
 <div class="colist arabic">
@@ -1669,18 +1607,18 @@ way by using annotated polymorphic variant.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">type</span> <span class="tok-n">readline</span>
-<span class="tok-k">external</span> <span class="tok-n">on</span> <span class="tok-o">:</span>
-    <span class="tok-o">(</span>
-    <span class="tok-o">[</span> <span class="tok-o">`</span><span class="tok-n">close</span> <span class="tok-k">of</span> <span class="tok-kt">unit</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">unit</span>
-    <span class="tok-o">|</span> <span class="tok-o">`</span><span class="tok-n">line</span> <span class="tok-k">of</span> <span class="tok-kt">string</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">unit</span>
-    <span class="tok-o">]</span> <b class="conum">(1)</b>
-    <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-kt">string</span><span class="tok-o">])</span>
-    <span class="tok-o">-&gt;</span> <span class="tok-n">readline</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">send</span><span class="tok-o">.</span><span class="tok-n">pipe</span><span class="tok-o">:</span> <span class="tok-n">readline</span><span class="tok-o">]</span>
-<span class="tok-k">let</span> <span class="tok-n">register</span> <span class="tok-n">rl</span> <span class="tok-o">=</span>
-  <span class="tok-n">rl</span>
-  <span class="tok-o">|&gt;</span> <span class="tok-n">on</span> <span class="tok-o">(`</span><span class="tok-n">close</span> <span class="tok-o">(</span><span class="tok-k">fun</span> <span class="tok-n">event</span> <span class="tok-o">-&gt;</span> <span class="tok-bp">()</span> <span class="tok-o">))</span>
-  <span class="tok-o">|&gt;</span> <span class="tok-n">on</span> <span class="tok-o">(`</span><span class="tok-n">line</span> <span class="tok-o">(</span><span class="tok-k">fun</span> <span class="tok-n">line</span> <span class="tok-o">-&gt;</span> <span class="tok-n">print_endline</span> <span class="tok-n">line</span><span class="tok-o">))</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">type readline
+external on :
+    (
+    [ `close of unit -&gt; unit
+    | `line of string -&gt; unit
+    ] <b class="conum">(1)</b>
+    [@bs.string])
+    -&gt; readline = "" [@@bs.send.pipe: readline]
+let register rl =
+  rl
+  |&gt; on (`close (fun event -&gt; () ))
+  |&gt; on (`line (fun line -&gt; print_endline line))</code></pre>
 </div>
 </div>
 <div class="colist arabic">
@@ -1695,15 +1633,15 @@ way by using annotated polymorphic variant.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-kd">function</span> <span class="tok-nx">register</span><span class="tok-p">(</span><span class="tok-nx">rl</span><span class="tok-p">)</span> <span class="tok-p">{</span>
-  <span class="tok-k">return</span> <span class="tok-nx">rl</span><span class="tok-p">.</span><span class="tok-nx">on</span><span class="tok-p">(</span><span class="tok-s2">&quot;close&quot;</span><span class="tok-p">,</span> <span class="tok-kd">function</span> <span class="tok-p">()</span> <span class="tok-p">{</span>
-                <span class="tok-k">return</span> <span class="tok-cm">/* () */</span><span class="tok-mi">0</span><span class="tok-p">;</span>
-              <span class="tok-p">})</span>
-           <span class="tok-p">.</span><span class="tok-nx">on</span><span class="tok-p">(</span><span class="tok-s2">&quot;line&quot;</span><span class="tok-p">,</span> <span class="tok-kd">function</span> <span class="tok-p">(</span><span class="tok-nx">line</span><span class="tok-p">)</span> <span class="tok-p">{</span>
-              <span class="tok-nx">console</span><span class="tok-p">.</span><span class="tok-nx">log</span><span class="tok-p">(</span><span class="tok-nx">line</span><span class="tok-p">);</span>
-              <span class="tok-k">return</span> <span class="tok-cm">/* () */</span><span class="tok-mi">0</span><span class="tok-p">;</span>
-            <span class="tok-p">});</span>
-<span class="tok-p">}</span></code></pre>
+<pre class="pygments highlight"><code data-lang="js">function register(rl) {
+  return rl.on("close", function () {
+                return /* () */0;
+              })
+           .on("line", function (line) {
+              console.log(line);
+              return /* () */0;
+            });
+}</code></pre>
 </div>
 </div>
 <div class="admonitionblock warning">
@@ -1745,9 +1683,9 @@ still be recorded.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">external</span> <span class="tok-n">add</span> <span class="tok-o">:</span> <span class="tok-o">(</span><span class="tok-kt">int</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">ignore</span><span class="tok-o">])</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;&quot;</span>
-<span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">val</span><span class="tok-o">]</span>
-<span class="tok-k">let</span> <span class="tok-n">v</span> <span class="tok-o">=</span> <span class="tok-n">add</span> <span class="tok-mi">0</span> <span class="tok-mi">1</span> <span class="tok-mi">2</span> <b class="conum">(1)</b></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">external add : (int [@bs.ignore]) -&gt; int -&gt; int = ""
+[@@bs.val]
+let v = add 0 1 2 <b class="conum">(1)</b></code></pre>
 </div>
 </div>
 <div class="colist arabic">
@@ -1762,7 +1700,7 @@ still be recorded.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="javascript"><span class="tok-kd">var</span> <span class="tok-nx">v</span> <span class="tok-o">=</span> <span class="tok-nx">add</span> <span class="tok-p">(</span><span class="tok-mi">1</span><span class="tok-p">,</span><span class="tok-mi">2</span><span class="tok-p">)</span></code></pre>
+<pre class="pygments highlight"><code data-lang="javascript">var v = add (1,2)</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -1770,14 +1708,14 @@ still be recorded.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">type</span> <span class="tok-o">_</span> <span class="tok-n">kind</span> <span class="tok-o">=</span>
-  <span class="tok-o">|</span> <span class="tok-nc">Float</span> <span class="tok-o">:</span> <span class="tok-kt">float</span> <span class="tok-n">kind</span>
-  <span class="tok-o">|</span> <span class="tok-nc">String</span> <span class="tok-o">:</span> <span class="tok-kt">string</span> <span class="tok-n">kind</span>
-<span class="tok-k">external</span> <span class="tok-n">add</span> <span class="tok-o">:</span> <span class="tok-o">(</span><span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-n">kind</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">ignore</span><span class="tok-o">])</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">val</span><span class="tok-o">]</span>
+<pre class="pygments highlight"><code data-lang="ocaml">type _ kind =
+  | Float : float kind
+  | String : string kind
+external add : ('a kind [@bs.ignore]) -&gt; 'a -&gt; 'a -&gt; 'a = "" [@@bs.val]
 
-<span class="tok-k">let</span> <span class="tok-bp">()</span> <span class="tok-o">=</span>
-  <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">log</span> <span class="tok-o">(</span><span class="tok-n">add</span> <span class="tok-nc">Float</span> <span class="tok-mi">3</span><span class="tok-o">.</span><span class="tok-mi">0</span> <span class="tok-mi">2</span><span class="tok-o">.</span><span class="tok-mi">0</span><span class="tok-o">);</span>
-  <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">log</span> <span class="tok-o">(</span><span class="tok-n">add</span> <span class="tok-nc">String</span> <span class="tok-s2">&quot;x&quot;</span> <span class="tok-s2">&quot;y&quot;</span><span class="tok-o">);</span></code></pre>
+let () =
+  Js.log (add Float 3.0 2.0);
+  Js.log (add String "x" "y");</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -1785,16 +1723,16 @@ still be recorded.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">string_of_kind</span> <span class="tok-o">(</span><span class="tok-k">type</span> <span class="tok-n">t</span><span class="tok-o">)</span> <span class="tok-o">(</span><span class="tok-n">kind</span> <span class="tok-o">:</span> <span class="tok-n">t</span> <span class="tok-n">kind</span><span class="tok-o">)</span> <span class="tok-o">=</span>
-  <span class="tok-k">match</span> <span class="tok-n">kind</span> <span class="tok-k">with</span>
-  <span class="tok-o">|</span> <span class="tok-nc">Float</span> <span class="tok-o">-&gt;</span> <span class="tok-s2">&quot;float&quot;</span>
-  <span class="tok-o">|</span> <span class="tok-nc">String</span> <span class="tok-o">-&gt;</span> <span class="tok-s2">&quot;string&quot;</span>
+<pre class="pygments highlight"><code data-lang="ocaml">let string_of_kind (type t) (kind : t kind) =
+  match kind with
+  | Float -&gt; "float"
+  | String -&gt; "string"
 
-<span class="tok-k">external</span> <span class="tok-n">add_dyn</span> <span class="tok-o">:</span> <span class="tok-o">(</span><span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-n">kind</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">ignore</span><span class="tok-o">])</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">string</span> <span class="tok-o">-&gt;</span>  <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;&quot;</span>
-<span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">val</span><span class="tok-o">]</span>
+external add_dyn : ('a kind [@bs.ignore]) -&gt; string -&gt;  'a -&gt; 'a -&gt; 'a = ""
+[@@bs.val]
 
-<span class="tok-k">let</span> <span class="tok-n">add2</span> <span class="tok-n">k</span> <span class="tok-n">x</span> <span class="tok-n">y</span> <span class="tok-o">=</span>
-  <span class="tok-n">add_dyn</span> <span class="tok-n">k</span> <span class="tok-o">(</span><span class="tok-n">string_of_kind</span> <span class="tok-n">k</span><span class="tok-o">)</span> <span class="tok-n">x</span> <span class="tok-n">y</span></code></pre>
+let add2 k x y =
+  add_dyn k (string_of_kind k) x y</code></pre>
 </div>
 </div>
 </div>
@@ -1810,10 +1748,10 @@ their semantics are more like macros instead of functions.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">dirname</span> <span class="tok-o">:</span> <span class="tok-kt">string</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">undefined</span> <span class="tok-o">=</span> <span class="tok-o">[%</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">node</span> <span class="tok-o">__</span><span class="tok-n">dirname</span><span class="tok-o">]</span>
-<span class="tok-k">let</span> <span class="tok-n">filename</span> <span class="tok-o">:</span> <span class="tok-kt">string</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">undefined</span> <span class="tok-o">=</span> <span class="tok-o">[%</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">node</span> <span class="tok-o">__</span><span class="tok-n">filename</span><span class="tok-o">]</span>
-<span class="tok-k">let</span> <span class="tok-n">module_</span> <span class="tok-o">:</span> <span class="tok-nn">Node</span><span class="tok-p">.</span><span class="tok-n">node_module</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">undefined</span> <span class="tok-o">=</span> <span class="tok-o">[%</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">node</span> <span class="tok-n">module_</span><span class="tok-o">]</span>
-<span class="tok-k">let</span> <span class="tok-n">require</span> <span class="tok-o">:</span> <span class="tok-nn">Node</span><span class="tok-p">.</span><span class="tok-n">node_require</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">undefined</span> <span class="tok-o">=</span> <span class="tok-o">[%</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">node</span> <span class="tok-n">require</span><span class="tok-o">]</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">let dirname : string Js.undefined = [%bs.node __dirname]
+let filename : string Js.undefined = [%bs.node __filename]
+let module_ : Node.node_module Js.undefined = [%bs.node module_]
+let require : Node.node_require Js.undefined = [%bs.node require]</code></pre>
 </div>
 </div>
 </div>
@@ -1826,14 +1764,14 @@ JS has a map function as below:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-kd">function</span> <span class="tok-nx">map</span> <span class="tok-p">(</span><span class="tok-nx">a</span><span class="tok-p">,</span> <span class="tok-nx">b</span><span class="tok-p">,</span> <span class="tok-nx">f</span><span class="tok-p">){</span>
-  <span class="tok-kd">var</span> <span class="tok-nx">i</span> <span class="tok-o">=</span> <span class="tok-nb">Math</span><span class="tok-p">.</span><span class="tok-nx">min</span><span class="tok-p">(</span><span class="tok-nx">a</span><span class="tok-p">.</span><span class="tok-nx">length</span><span class="tok-p">,</span> <span class="tok-nx">b</span><span class="tok-p">.</span><span class="tok-nx">length</span><span class="tok-p">);</span>
-  <span class="tok-kd">var</span> <span class="tok-nx">c</span> <span class="tok-o">=</span> <span class="tok-k">new</span> <span class="tok-nb">Array</span><span class="tok-p">(</span><span class="tok-nx">i</span><span class="tok-p">);</span>
-  <span class="tok-k">for</span><span class="tok-p">(</span><span class="tok-kd">var</span> <span class="tok-nx">j</span> <span class="tok-o">=</span> <span class="tok-mi">0</span><span class="tok-p">;</span> <span class="tok-nx">j</span> <span class="tok-o">&lt;</span> <span class="tok-nx">i</span><span class="tok-p">;</span> <span class="tok-o">++</span><span class="tok-nx">j</span><span class="tok-p">){</span>
-    <span class="tok-nx">c</span><span class="tok-p">[</span><span class="tok-nx">j</span><span class="tok-p">]</span> <span class="tok-o">=</span> <span class="tok-nx">f</span><span class="tok-p">(</span><span class="tok-nx">a</span><span class="tok-p">[</span><span class="tok-nx">i</span><span class="tok-p">],</span><span class="tok-nx">b</span><span class="tok-p">[</span><span class="tok-nx">i</span><span class="tok-p">])</span>
-  <span class="tok-p">}</span>
-  <span class="tok-k">return</span> <span class="tok-nx">c</span> <span class="tok-p">;</span>
-<span class="tok-p">}</span></code></pre>
+<pre class="pygments highlight"><code data-lang="js">function map (a, b, f){
+  var i = Math.min(a.length, b.length);
+  var c = new Array(i);
+  for(var j = 0; j &lt; i; ++j){
+    c[j] = f(a[i],b[i])
+  }
+  return c ;
+}</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -1841,7 +1779,7 @@ JS has a map function as below:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">external</span> <span class="tok-n">map</span> <span class="tok-o">:</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-kt">array</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">b</span> <span class="tok-kt">array</span> <span class="tok-o">-&gt;</span> <span class="tok-o">(</span><span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">b</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">c</span><span class="tok-o">)</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">c</span> <span class="tok-kt">array</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">val</span><span class="tok-o">]</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">external map : 'a array -&gt; 'b array -&gt; ('a -&gt; 'b -&gt; 'c) -&gt; 'c array = "" [@@bs.val]</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -1850,12 +1788,12 @@ reading the type <code>'a &#8594; 'b &#8594; 'c</code>, it can be in several cas
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">f</span> <span class="tok-n">x</span> <span class="tok-n">y</span> <span class="tok-o">=</span> <span class="tok-n">x</span> <span class="tok-o">+</span> <span class="tok-n">y</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">let f x y = x + y</code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">g</span> <span class="tok-n">x</span>  <span class="tok-o">=</span> <span class="tok-k">let</span> <span class="tok-n">z</span>  <span class="tok-o">=</span> <span class="tok-n">x</span> <span class="tok-o">+</span> <span class="tok-mi">1</span> <span class="tok-k">in</span> <span class="tok-k">fun</span> <span class="tok-n">y</span> <span class="tok-o">-&gt;</span> <span class="tok-n">x</span> <span class="tok-o">+</span> <span class="tok-n">z</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">let g x  = let z  = x + 1 in fun y -&gt; x + z</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -1868,22 +1806,22 @@ different arities.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">f</span> <span class="tok-o">=</span> <span class="tok-k">fun</span> <span class="tok-n">x</span> <span class="tok-o">-&gt;</span> <span class="tok-k">fun</span> <span class="tok-n">y</span> <span class="tok-o">-&gt;</span> <span class="tok-n">x</span> <span class="tok-o">+</span> <span class="tok-n">y</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">let f = fun x -&gt; fun y -&gt; x + y</code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-kd">function</span> <span class="tok-nx">f</span><span class="tok-p">(</span><span class="tok-nx">x</span><span class="tok-p">){</span>
-  <span class="tok-k">return</span> <span class="tok-kd">function</span> <span class="tok-p">(</span><span class="tok-nx">y</span><span class="tok-p">){</span>
-    <span class="tok-k">return</span> <span class="tok-nx">x</span> <span class="tok-o">+</span> <span class="tok-nx">y</span><span class="tok-p">;</span>
-  <span class="tok-p">}</span>
-<span class="tok-p">}</span>
-<span class="tok-kd">function</span> <span class="tok-nx">g</span><span class="tok-p">(</span><span class="tok-nx">x</span><span class="tok-p">){</span>
-  <span class="tok-kd">var</span> <span class="tok-nx">z</span> <span class="tok-o">=</span> <span class="tok-nx">x</span> <span class="tok-o">+</span> <span class="tok-mi">1</span> <span class="tok-p">;</span>
-  <span class="tok-k">return</span> <span class="tok-kd">function</span> <span class="tok-p">(</span><span class="tok-nx">y</span><span class="tok-p">){</span>
-    <span class="tok-k">return</span> <span class="tok-nx">x</span> <span class="tok-o">+</span> <span class="tok-nx">z</span> <span class="tok-p">;</span>
-  <span class="tok-p">}</span>
-<span class="tok-p">}</span></code></pre>
+<pre class="pygments highlight"><code data-lang="js">function f(x){
+  return function (y){
+    return x + y;
+  }
+}
+function g(x){
+  var z = x + 1 ;
+  return function (y){
+    return x + z ;
+  }
+}</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -1895,9 +1833,9 @@ however, we expect <em>its arity to be 2</em>.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-kd">function</span> <span class="tok-nx">f</span><span class="tok-p">(</span><span class="tok-nx">x</span><span class="tok-p">,</span><span class="tok-nx">y</span><span class="tok-p">){</span>
-  <span class="tok-k">return</span> <span class="tok-nx">x</span> <span class="tok-o">+</span> <span class="tok-nx">y</span> <span class="tok-p">;</span>
-<span class="tok-p">}</span></code></pre>
+<pre class="pygments highlight"><code data-lang="js">function f(x,y){
+  return x + y ;
+}</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -1910,8 +1848,8 @@ we support a special attribute <code>[@bs]</code> at the type level.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">external</span> <span class="tok-n">map</span> <span class="tok-o">:</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-kt">array</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">b</span> <span class="tok-kt">array</span> <span class="tok-o">-&gt;</span> <span class="tok-o">(</span><span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">b</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">c</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">])</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">c</span> <span class="tok-kt">array</span>
-<span class="tok-o">=</span> <span class="tok-s2">&quot;map&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">val</span><span class="tok-o">]</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">external map : 'a array -&gt; 'b array -&gt; ('a -&gt; 'b -&gt; 'c [@bs]) -&gt; 'c array
+= "map" [@@bs.val]</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -1927,9 +1865,9 @@ unknown.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">f</span> <span class="tok-o">:</span> <span class="tok-k">&#39;</span><span class="tok-n">a0</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">a1</span> <span class="tok-o">-&gt;</span> <span class="tok-o">..</span> <span class="tok-k">&#39;</span><span class="tok-n">b0</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">]</span> <span class="tok-o">=</span>
-  <span class="tok-k">fun</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">]</span> <span class="tok-n">a0</span> <span class="tok-n">a1</span> <span class="tok-o">..</span> <span class="tok-n">aN</span> <span class="tok-o">-&gt;</span> <span class="tok-n">b0</span>
-<span class="tok-k">let</span> <span class="tok-n">b</span> <span class="tok-o">:</span> <span class="tok-k">&#39;</span><span class="tok-n">b0</span> <span class="tok-o">=</span> <span class="tok-n">f</span> <span class="tok-n">a0</span> <span class="tok-n">a1</span> <span class="tok-n">a2</span> <span class="tok-o">..</span> <span class="tok-n">aN</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">]</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">let f : 'a0 -&gt; 'a1 -&gt; .. 'b0 [@bs] =
+  fun [@bs] a0 a1 .. aN -&gt; b0
+let b : 'b0 = f a0 a1 a2 .. aN [@bs]</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -1937,8 +1875,8 @@ unknown.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">f</span> <span class="tok-o">:</span> <span class="tok-kt">unit</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">b0</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">]</span> <span class="tok-o">=</span> <span class="tok-k">fun</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">]</span> <span class="tok-bp">()</span> <span class="tok-o">-&gt;</span> <span class="tok-n">b0</span>
-<span class="tok-k">let</span> <span class="tok-n">b</span> <span class="tok-o">:</span> <span class="tok-k">&#39;</span><span class="tok-n">b0</span> <span class="tok-o">=</span> <span class="tok-n">f</span> <span class="tok-bp">()</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">]</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">let f : unit -&gt; 'b0 [@bs] = fun [@bs] () -&gt; b0
+let b : 'b0 = f () [@bs]</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -1952,10 +1890,10 @@ will complain.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">type</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-n">return</span> <span class="tok-o">=</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">]</span>
-<span class="tok-k">type</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-n">u0</span> <span class="tok-o">=</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">string</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-n">return</span>  <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">]</span> <b class="conum">(1)</b>
-<span class="tok-k">type</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-n">u1</span> <span class="tok-o">=</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">string</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">]</span> <b class="conum">(2)</b>
-<span class="tok-k">type</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-n">u2</span> <span class="tok-o">=</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">string</span> <span class="tok-o">-&gt;</span> <span class="tok-o">(</span><span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">])</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">]</span> <b class="conum">(3)</b></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">type 'a return = int -&gt; 'a [@bs]
+type 'a u0 = int -&gt; string -&gt; 'a return  [@bs] <b class="conum">(1)</b>
+type 'a u1 = int -&gt; string -&gt; int -&gt; 'a [@bs] <b class="conum">(2)</b>
+type 'a u2 = int -&gt; string -&gt; (int -&gt; 'a [@bs]) [@bs] <b class="conum">(3)</b></code></pre>
 </div>
 </div>
 <div class="colist arabic">
@@ -1986,9 +1924,9 @@ the native compilation is very slow and expensive for all functions.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">f</span> <span class="tok-n">x</span> <span class="tok-n">y</span> <span class="tok-n">z</span> <span class="tok-o">=</span> <span class="tok-n">x</span> <span class="tok-o">+</span> <span class="tok-n">y</span> <span class="tok-o">+</span> <span class="tok-n">z</span>
-<span class="tok-k">let</span> <span class="tok-n">a</span> <span class="tok-o">=</span> <span class="tok-n">f</span> <span class="tok-mi">1</span> <span class="tok-mi">2</span> <span class="tok-mi">3</span>
-<span class="tok-k">let</span> <span class="tok-n">b</span> <span class="tok-o">=</span> <span class="tok-n">f</span> <span class="tok-mi">1</span> <span class="tok-mi">2</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">let f x y z = x + y + z
+let a = f 1 2 3
+let b = f 1 2</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -1996,15 +1934,15 @@ the native compilation is very slow and expensive for all functions.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-kd">function</span> <span class="tok-nx">f</span><span class="tok-p">(</span><span class="tok-nx">x</span><span class="tok-p">){</span>
-  <span class="tok-k">return</span> <span class="tok-kd">function</span> <span class="tok-p">(</span><span class="tok-nx">y</span><span class="tok-p">){</span>
-    <span class="tok-k">return</span> <span class="tok-kd">function</span> <span class="tok-p">(</span><span class="tok-nx">z</span><span class="tok-p">){</span>
-      <span class="tok-k">return</span> <span class="tok-nx">x</span> <span class="tok-o">+</span> <span class="tok-nx">y</span> <span class="tok-o">+</span> <span class="tok-nx">z</span>
-    <span class="tok-p">}</span>
-  <span class="tok-p">}</span>
-<span class="tok-p">}</span>
-<span class="tok-kd">var</span> <span class="tok-nx">a</span> <span class="tok-o">=</span> <span class="tok-nx">f</span> <span class="tok-p">(</span><span class="tok-mi">1</span><span class="tok-p">)</span> <span class="tok-p">(</span><span class="tok-mi">2</span><span class="tok-p">)</span> <span class="tok-p">(</span><span class="tok-mi">3</span><span class="tok-p">)</span>
-<span class="tok-kd">var</span> <span class="tok-nx">b</span> <span class="tok-o">=</span> <span class="tok-nx">f</span> <span class="tok-p">(</span><span class="tok-mi">1</span><span class="tok-p">)</span> <span class="tok-p">(</span><span class="tok-mi">2</span><span class="tok-p">)</span></code></pre>
+<pre class="pygments highlight"><code data-lang="js">function f(x){
+  return function (y){
+    return function (z){
+      return x + y + z
+    }
+  }
+}
+var a = f (1) (2) (3)
+var b = f (1) (2)</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -2013,9 +1951,9 @@ already <em>saw the source definition</em> of <code>f</code>, it can be optimize
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-kd">function</span> <span class="tok-nx">f</span><span class="tok-p">(</span><span class="tok-nx">x</span><span class="tok-p">,</span><span class="tok-nx">y</span><span class="tok-p">,</span><span class="tok-nx">z</span><span class="tok-p">)</span> <span class="tok-p">{</span><span class="tok-k">return</span> <span class="tok-nx">x</span> <span class="tok-o">+</span> <span class="tok-nx">y</span> <span class="tok-o">+</span> <span class="tok-nx">z</span><span class="tok-p">}</span>
-<span class="tok-kd">var</span> <span class="tok-nx">a</span> <span class="tok-o">=</span> <span class="tok-nx">f</span><span class="tok-p">(</span><span class="tok-mi">1</span><span class="tok-p">,</span><span class="tok-mi">2</span><span class="tok-p">,</span><span class="tok-mi">3</span><span class="tok-p">)</span>
-<span class="tok-kd">var</span> <span class="tok-nx">b</span> <span class="tok-o">=</span> <span class="tok-kd">function</span><span class="tok-p">(</span><span class="tok-nx">z</span><span class="tok-p">){</span><span class="tok-k">return</span> <span class="tok-nx">f</span><span class="tok-p">(</span><span class="tok-mi">1</span><span class="tok-p">,</span><span class="tok-mi">2</span><span class="tok-p">,</span><span class="tok-nx">z</span><span class="tok-p">)}</span></code></pre>
+<pre class="pygments highlight"><code data-lang="js">function f(x,y,z) {return x + y + z}
+var a = f(1,2,3)
+var b = function(z){return f(1,2,z)}</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -2033,7 +1971,7 @@ i.e, callbacks.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">app</span> <span class="tok-n">f</span> <span class="tok-n">x</span> <span class="tok-o">=</span> <span class="tok-n">f</span> <span class="tok-n">x</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">let app f x = f x</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -2043,9 +1981,9 @@ have to generate code as below:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-kd">function</span> <span class="tok-nx">app</span><span class="tok-p">(</span><span class="tok-nx">f</span><span class="tok-p">,</span><span class="tok-nx">x</span><span class="tok-p">){</span>
-  <span class="tok-k">return</span> <span class="tok-nx">Curry</span><span class="tok-p">.</span><span class="tok-nx">_1</span><span class="tok-p">(</span><span class="tok-nx">f</span><span class="tok-p">,</span><span class="tok-nx">x</span><span class="tok-p">);</span>
-<span class="tok-p">}</span></code></pre>
+<pre class="pygments highlight"><code data-lang="js">function app(f,x){
+  return Curry._1(f,x);
+}</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -2058,7 +1996,7 @@ as below</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">app</span> <span class="tok-n">f</span> <span class="tok-n">x</span> <span class="tok-o">=</span> <span class="tok-n">f</span> <span class="tok-n">x</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">]</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">let app f x = f x [@bs]</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -2067,9 +2005,9 @@ as below</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-kd">function</span> <span class="tok-nx">app</span><span class="tok-p">(</span><span class="tok-nx">f</span><span class="tok-p">,</span><span class="tok-nx">x</span><span class="tok-p">){</span>
-  <span class="tok-k">return</span> <span class="tok-nx">f</span><span class="tok-p">(</span><span class="tok-nx">x</span><span class="tok-p">)</span>
-<span class="tok-p">}</span></code></pre>
+<pre class="pygments highlight"><code data-lang="js">function app(f,x){
+  return f(x)
+}</code></pre>
 </div>
 </div>
 <div class="admonitionblock note">
@@ -2099,9 +2037,9 @@ example:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-nx">x</span><span class="tok-p">.</span><span class="tok-nx">onload</span> <span class="tok-o">=</span> <span class="tok-kd">function</span><span class="tok-p">(</span><span class="tok-nx">v</span><span class="tok-p">){</span>
-  <span class="tok-nx">console</span><span class="tok-p">.</span><span class="tok-nx">log</span><span class="tok-p">(</span><span class="tok-k">this</span><span class="tok-p">.</span><span class="tok-nx">response</span> <span class="tok-o">+</span> <span class="tok-nx">v</span> <span class="tok-p">)</span>
-<span class="tok-p">}</span></code></pre>
+<pre class="pygments highlight"><code data-lang="js">x.onload = function(v){
+  console.log(this.response + v )
+}</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -2113,12 +2051,12 @@ Instead, we introduced a special attribute
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">type</span> <span class="tok-n">x</span>
-<span class="tok-k">external</span> <span class="tok-n">set_onload</span> <span class="tok-o">:</span> <span class="tok-n">x</span> <span class="tok-o">-&gt;</span> <span class="tok-o">(</span><span class="tok-n">x</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">unit</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">this</span><span class="tok-o">])</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">unit</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;onload&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">set</span><span class="tok-o">]</span>
-<span class="tok-k">external</span> <span class="tok-n">resp</span> <span class="tok-o">:</span> <span class="tok-n">x</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;response&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">get</span><span class="tok-o">]</span>
-<span class="tok-n">set_onload</span> <span class="tok-n">x</span> <span class="tok-k">begin</span> <span class="tok-k">fun</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">this</span><span class="tok-o">]</span> <span class="tok-n">o</span> <span class="tok-n">v</span> <span class="tok-o">-&gt;</span>
-  <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">log</span><span class="tok-o">(</span><span class="tok-n">resp</span> <span class="tok-n">o</span> <span class="tok-o">+</span> <span class="tok-n">v</span> <span class="tok-o">)</span>
-<span class="tok-k">end</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">type x
+external set_onload : x -&gt; (x -&gt; int -&gt; unit [@bs.this]) -&gt; unit = "onload" [@@bs.set]
+external resp : x -&gt; int = "response" [@@bs.get]
+set_onload x begin fun [@bs.this] o v -&gt;
+  Js.log(resp o + v )
+end</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -2126,10 +2064,10 @@ Instead, we introduced a special attribute
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-nx">x</span><span class="tok-p">.</span><span class="tok-nx">onload</span> <span class="tok-o">=</span> <span class="tok-kd">function</span><span class="tok-p">(</span><span class="tok-nx">v</span><span class="tok-p">){</span>
-  <span class="tok-kd">var</span> <span class="tok-nx">o</span> <span class="tok-o">=</span> <span class="tok-k">this</span> <span class="tok-p">;</span> <b class="conum">(1)</b>
-  <span class="tok-nx">console</span><span class="tok-p">.</span><span class="tok-nx">log</span><span class="tok-p">(</span><span class="tok-nx">o</span><span class="tok-p">.</span><span class="tok-nx">response</span> <span class="tok-o">+</span> <span class="tok-nx">v</span><span class="tok-p">);</span>
-<span class="tok-p">}</span></code></pre>
+<pre class="pygments highlight"><code data-lang="js">x.onload = function(v){
+  var o = this ; <b class="conum">(1)</b>
+  console.log(o.response + v);
+}</code></pre>
 </div>
 </div>
 <div class="colist arabic">
@@ -2145,10 +2083,10 @@ reserved for <code>this</code> and for arity of 0, there is no need for a redund
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">f</span> <span class="tok-o">:</span> <span class="tok-k">&#39;</span><span class="tok-n">obj</span> <span class="tok-o">-&gt;</span> <span class="tok-sc">&#39;b&#39;</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">this</span><span class="tok-o">]</span> <span class="tok-o">=</span>
-  <span class="tok-k">fun</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">this</span><span class="tok-o">]</span> <span class="tok-n">obj</span> <span class="tok-o">-&gt;</span> <span class="tok-o">....</span>
-<span class="tok-k">let</span> <span class="tok-n">f1</span> <span class="tok-o">:</span> <span class="tok-k">&#39;</span><span class="tok-n">obj</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">a0</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">b</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">this</span><span class="tok-o">]</span> <span class="tok-o">=</span>
-  <span class="tok-k">fun</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">this</span><span class="tok-o">]</span> <span class="tok-n">obj</span> <span class="tok-n">a</span> <span class="tok-o">-&gt;</span> <span class="tok-o">...</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">let f : 'obj -&gt; 'b' [@bs.this] =
+  fun [@bs.this] obj -&gt; ....
+let f1 : 'obj -&gt; 'a0 -&gt; 'b [@bs.this] =
+  fun [@bs.this] obj a -&gt; ...</code></pre>
 </div>
 </div>
 <div class="admonitionblock note">
@@ -2203,8 +2141,8 @@ which exports two properties: <code>height</code> and <code>width</code>:</p>
 <div class="listingblock">
 <div class="title">demo.js</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-nx">exports</span><span class="tok-p">.</span><span class="tok-nx">height</span> <span class="tok-o">=</span> <span class="tok-mi">3</span>
-<span class="tok-nx">exports</span><span class="tok-p">.</span><span class="tok-nx">width</span>  <span class="tok-o">=</span> <span class="tok-mi">3</span></code></pre>
+<pre class="pygments highlight"><code data-lang="js">exports.height = 3
+exports.width  = 3</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -2213,7 +2151,7 @@ here we use OCaml objects to model module <code>demo</code></p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">external</span> <span class="tok-n">demo</span> <span class="tok-o">:</span> <span class="tok-o">&lt;</span> <span class="tok-n">height</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">;</span> <span class="tok-n">width</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">&gt;</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">t</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">module</span><span class="tok-o">]</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">external demo : &lt; height : int ; width : int &gt; Js.t = "" [@@bs.module]</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -2225,10 +2163,10 @@ here we use OCaml objects to model module <code>demo</code></p>
 <p>normal type</p>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-o">&lt;</span> <span class="tok-n">label</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">&gt;</span>
-<span class="tok-o">&lt;</span> <span class="tok-n">label</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">&gt;</span>
-<span class="tok-o">&lt;</span> <span class="tok-n">label</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">]&gt;</span>
-<span class="tok-o">&lt;</span> <span class="tok-n">label</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">this</span><span class="tok-o">]&gt;</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">&lt; label : int &gt;
+&lt; label : int -&gt; int &gt;
+&lt; label : int -&gt; int [@bs]&gt;
+&lt; label : int -&gt; int [@bs.this]&gt;</code></pre>
 </div>
 </div>
 </li>
@@ -2236,7 +2174,7 @@ here we use OCaml objects to model module <code>demo</code></p>
 <p>method</p>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-o">&lt;</span> <span class="tok-n">label</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">meth</span><span class="tok-o">]</span> <span class="tok-o">&gt;</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">&lt; label : int -&gt; int [@bs.meth] &gt;</code></pre>
 </div>
 </div>
 </li>
@@ -2251,14 +2189,14 @@ its arguments all at the same time, since its semantics depends on <code>this</c
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">test</span> <span class="tok-n">f</span> <span class="tok-o">=</span>
-  <span class="tok-n">f</span><span class="tok-o">##</span><span class="tok-n">hi</span> <span class="tok-mi">1</span> <b class="conum">(1)</b>
-<span class="tok-k">let</span> <span class="tok-n">test2</span> <span class="tok-n">f</span>   <span class="tok-o">=</span>
-  <span class="tok-k">let</span> <span class="tok-n">u</span> <span class="tok-o">=</span> <span class="tok-n">f</span><span class="tok-o">##</span><span class="tok-n">hi</span> <span class="tok-k">in</span>
-  <span class="tok-n">u</span> <span class="tok-mi">1</span>
-<span class="tok-k">let</span> <span class="tok-n">test3</span> <span class="tok-n">f</span> <span class="tok-o">=</span>
-  <span class="tok-k">let</span> <span class="tok-n">u</span> <span class="tok-o">=</span> <span class="tok-n">f</span><span class="tok-o">##</span><span class="tok-n">hi</span> <span class="tok-k">in</span>
-  <span class="tok-n">u</span> <span class="tok-mi">1</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">]</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">let test f =
+  f##hi 1 <b class="conum">(1)</b>
+let test2 f   =
+  let u = f##hi in
+  u 1
+let test3 f =
+  let u = f##hi in
+  u 1 [@bs]</code></pre>
 </div>
 </div>
 <div class="colist arabic">
@@ -2273,9 +2211,9 @@ its arguments all at the same time, since its semantics depends on <code>this</c
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">val</span> <span class="tok-n">test</span> <span class="tok-o">:</span> <span class="tok-o">&lt;</span> <span class="tok-n">hi</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">meth</span><span class="tok-o">];</span> <span class="tok-o">..</span> <span class="tok-o">&gt;</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <b class="conum">(1)</b>
-<span class="tok-k">val</span> <span class="tok-n">test2</span> <span class="tok-o">:</span> <span class="tok-o">&lt;</span> <span class="tok-n">hi</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-o">;</span> <span class="tok-o">..</span> <span class="tok-o">&gt;</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span>
-<span class="tok-k">val</span> <span class="tok-n">test3</span> <span class="tok-o">:</span> <span class="tok-o">&lt;</span> <span class="tok-n">hi</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">];</span> <span class="tok-o">..</span> <span class="tok-o">&gt;</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">val test : &lt; hi : int -&gt; 'a [@bs.meth]; .. &gt; -&gt; 'a <b class="conum">(1)</b>
+val test2 : &lt; hi : int -&gt; 'a ; .. &gt; -&gt; 'a
+val test3 : &lt; hi : int -&gt; 'a [@bs]; .. &gt;</code></pre>
 </div>
 </div>
 <div class="colist arabic">
@@ -2293,12 +2231,12 @@ its arguments all at the same time, since its semantics depends on <code>this</c
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">class</span> <span class="tok-k">type</span> <span class="tok-o">_</span><span class="tok-n">rect</span> <span class="tok-o">=</span> <span class="tok-k">object</span>
-  <span class="tok-k">method</span> <span class="tok-n">height</span> <span class="tok-o">:</span> <span class="tok-kt">int</span>
-  <span class="tok-k">method</span> <span class="tok-n">width</span> <span class="tok-o">:</span> <span class="tok-kt">int</span>
-  <span class="tok-k">method</span> <span class="tok-n">draw</span> <span class="tok-o">:</span> <span class="tok-kt">unit</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">unit</span>
-<span class="tok-k">end</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">]</span> <b class="conum">(1)</b>
-<span class="tok-k">type</span> <span class="tok-n">rect</span> <span class="tok-o">=</span> <span class="tok-o">_</span><span class="tok-n">rect</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">t</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">class type _rect = object
+  method height : int
+  method width : int
+  method draw : unit -&gt; unit
+end [@bs] <b class="conum">(1)</b>
+type rect = _rect Js.t</code></pre>
 </div>
 </div>
 <div class="colist arabic">
@@ -2320,7 +2258,7 @@ are treated as properties.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">type</span> <span class="tok-n">rect</span> <span class="tok-o">=</span> <span class="tok-o">&lt;</span> <span class="tok-n">height</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">;</span> <span class="tok-n">wdith</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">;</span> <span class="tok-n">draw</span> <span class="tok-o">:</span> <span class="tok-kt">unit</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">unit</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">meth</span><span class="tok-o">]</span> <span class="tok-o">&gt;</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">t</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">type rect = &lt; height : int ; wdith : int ; draw : unit -&gt; unit [@bs.meth] &gt; Js.t</code></pre>
 </div>
 </div>
 </div>
@@ -2331,9 +2269,9 @@ are treated as properties.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-n">f</span><span class="tok-o">##</span><span class="tok-n">property</span> <b class="conum">(1)</b>
-<span class="tok-n">f</span><span class="tok-o">##</span><span class="tok-n">property</span><span class="tok-o">#=</span> <span class="tok-n">v</span>
-<span class="tok-n">f</span><span class="tok-o">##</span><span class="tok-n">js_method</span> <span class="tok-n">args0</span> <span class="tok-n">args1</span> <span class="tok-n">args2</span> <b class="conum">(2)</b></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">f##property <b class="conum">(1)</b>
+f##property#= v
+f##js_method args0 args1 args2 <b class="conum">(2)</b></code></pre>
 </div>
 </div>
 <div class="colist arabic">
@@ -2359,9 +2297,9 @@ be guaranteed by OCaml&#8217;s type checker, a classic example shown below:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-nx">console</span><span class="tok-p">.</span><span class="tok-nx">log</span><span class="tok-p">(</span><span class="tok-s1">&#39;fine&#39;</span><span class="tok-p">)</span>
-<span class="tok-kd">var</span> <span class="tok-nx">log</span> <span class="tok-o">=</span> <span class="tok-nx">console</span><span class="tok-p">.</span><span class="tok-nx">log</span><span class="tok-p">;</span>
-<span class="tok-nx">log</span><span class="tok-p">(</span><span class="tok-s1">&#39;fine&#39;</span><span class="tok-p">)</span> <b class="conum">(1)</b></code></pre>
+<pre class="pygments highlight"><code data-lang="js">console.log('fine')
+var log = console.log;
+log('fine') <b class="conum">(1)</b></code></pre>
 </div>
 </div>
 <div class="colist arabic">
@@ -2380,9 +2318,9 @@ be guaranteed by OCaml&#8217;s type checker, a classic example shown below:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">fn</span> <span class="tok-o">=</span> <span class="tok-n">f0</span><span class="tok-o">##</span><span class="tok-n">f</span> <span class="tok-k">in</span>
-<span class="tok-k">let</span> <span class="tok-n">a</span> <span class="tok-o">=</span> <span class="tok-n">fn</span> <span class="tok-mi">1</span> <span class="tok-mi">2</span>
-<span class="tok-c">(* f##field a b would think `field` as a method *)</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">let fn = f0##f in
+let a = fn 1 2
+(* f##field a b would think `field` as a method *)</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -2390,7 +2328,7 @@ be guaranteed by OCaml&#8217;s type checker, a classic example shown below:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">b</span> <span class="tok-o">=</span> <span class="tok-n">f1</span><span class="tok-o">##</span><span class="tok-n">f</span> <span class="tok-mi">1</span> <span class="tok-mi">2</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">let b = f1##f 1 2</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -2398,8 +2336,8 @@ be guaranteed by OCaml&#8217;s type checker, a classic example shown below:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">val</span> <span class="tok-n">f0</span> <span class="tok-o">:</span> <span class="tok-o">&lt;</span> <span class="tok-n">f</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span>  <span class="tok-o">&gt;</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">t</span>
-<span class="tok-k">val</span> <span class="tok-n">f1</span> <span class="tok-o">:</span> <span class="tok-o">&lt;</span> <span class="tok-n">f</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">meth</span><span class="tok-o">]</span> <span class="tok-o">&gt;</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">t</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">val f0 : &lt; f : int -&gt; int -&gt; int  &gt; Js.t
+val f1 : &lt; f : int -&gt; int -&gt; int [@bs.meth] &gt; Js.t</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -2407,9 +2345,9 @@ be guaranteed by OCaml&#8217;s type checker, a classic example shown below:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-n">console</span><span class="tok-o">##</span><span class="tok-n">log</span> <span class="tok-s2">&quot;fine&quot;</span>
-<span class="tok-k">let</span> <span class="tok-n">u</span> <span class="tok-o">=</span> <span class="tok-n">console</span><span class="tok-o">##</span><span class="tok-n">log</span>
-<span class="tok-k">let</span> <span class="tok-bp">()</span> <span class="tok-o">=</span> <span class="tok-n">u</span> <span class="tok-s2">&quot;fine&quot;</span> <b class="conum">(1)</b></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">console##log "fine"
+let u = console##log
+let () = u "fine" <b class="conum">(1)</b></code></pre>
 </div>
 </div>
 <div class="colist arabic">
@@ -2444,21 +2382,21 @@ them as property getters/setters.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">type</span> <span class="tok-n">y</span>  <span class="tok-o">=</span> <span class="tok-o">&lt;</span>
- <span class="tok-n">height</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">set</span> <span class="tok-o">{</span><span class="tok-n">no_get</span><span class="tok-o">}]</span> <b class="conum">(1)</b>
-<span class="tok-o">&gt;</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">t</span>
-<span class="tok-k">type</span> <span class="tok-n">y0</span> <span class="tok-o">=</span> <span class="tok-o">&lt;</span>
- <span class="tok-n">height</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">set</span><span class="tok-o">]</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">get</span> <span class="tok-o">{</span><span class="tok-n">null</span><span class="tok-o">}]</span> <b class="conum">(2)</b>
-<span class="tok-o">&gt;</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">t</span>
-<span class="tok-k">type</span> <span class="tok-n">y1</span> <span class="tok-o">=</span> <span class="tok-o">&lt;</span>
-  <span class="tok-n">height</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">set</span><span class="tok-o">]</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">get</span> <span class="tok-o">{</span><span class="tok-n">undefined</span><span class="tok-o">}]</span> <b class="conum">(3)</b>
-<span class="tok-o">&gt;</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">t</span>
-<span class="tok-k">type</span> <span class="tok-n">y2</span> <span class="tok-o">=</span> <span class="tok-o">&lt;</span>
-  <span class="tok-n">height</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">set</span><span class="tok-o">]</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">get</span> <span class="tok-o">{</span><span class="tok-n">undefined</span><span class="tok-o">;</span> <span class="tok-n">null</span><span class="tok-o">}]</span> <b class="conum">(4)</b>
-<span class="tok-o">&gt;</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">t</span>
-<span class="tok-k">type</span> <span class="tok-n">y3</span> <span class="tok-o">=</span> <span class="tok-o">&lt;</span>
-  <span class="tok-n">height</span> <span class="tok-o">:</span> <span class="tok-kt">int</span>  <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">get</span> <span class="tok-o">{</span><span class="tok-n">undefined</span> <span class="tok-o">;</span> <span class="tok-n">null</span><span class="tok-o">}]</span> <b class="conum">(5)</b>
-<span class="tok-o">&gt;</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">t</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">type y  = &lt;
+ height : int [@@bs.set {no_get}] <b class="conum">(1)</b>
+&gt; Js.t
+type y0 = &lt;
+ height : int [@@bs.set] [@@bs.get {null}] <b class="conum">(2)</b>
+&gt; Js.t
+type y1 = &lt;
+  height : int [@@bs.set] [@@bs.get {undefined}] <b class="conum">(3)</b>
+&gt; Js.t
+type y2 = &lt;
+  height : int [@@bs.set] [@@bs.get {undefined; null}] <b class="conum">(4)</b>
+&gt; Js.t
+type y3 = &lt;
+  height : int  [@@bs.get {undefined ; null}] <b class="conum">(5)</b>
+&gt; Js.t</code></pre>
 </div>
 </div>
 <div class="colist arabic">
@@ -2502,7 +2440,7 @@ create JS objects in a type safe way in OCaml side:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">u</span> <span class="tok-o">=</span> <span class="tok-o">[%</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">obj</span> <span class="tok-o">{</span> <span class="tok-n">x</span> <span class="tok-o">=</span> <span class="tok-o">{</span> <span class="tok-n">y</span> <span class="tok-o">=</span> <span class="tok-o">{</span> <span class="tok-n">z</span> <span class="tok-o">=</span> <span class="tok-mi">3</span><span class="tok-o">}}}</span> <span class="tok-o">]</span> <b class="conum">(1)</b></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">let u = [%bs.obj { x = { y = { z = 3}}} ] <b class="conum">(1)</b></code></pre>
 </div>
 </div>
 <div class="colist arabic">
@@ -2517,7 +2455,7 @@ create JS objects in a type safe way in OCaml side:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-kd">var</span> <span class="tok-nx">u</span> <span class="tok-o">=</span> <span class="tok-p">{</span> <span class="tok-nx">x</span> <span class="tok-o">:</span> <span class="tok-p">{</span> <span class="tok-nx">y</span> <span class="tok-o">:</span> <span class="tok-p">{</span> <span class="tok-nx">z</span> <span class="tok-o">:</span> <span class="tok-mi">3</span> <span class="tok-p">}}}}</span></code></pre>
+<pre class="pygments highlight"><code data-lang="js">var u = { x : { y : { z : 3 }}}}</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -2525,7 +2463,7 @@ create JS objects in a type safe way in OCaml side:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">val</span> <span class="tok-n">u</span> <span class="tok-o">:</span> <span class="tok-o">&lt;</span> <span class="tok-n">x</span> <span class="tok-o">:</span>  <span class="tok-o">&lt;</span> <span class="tok-n">y</span> <span class="tok-o">:</span> <span class="tok-o">&lt;</span> <span class="tok-n">z</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">&gt;</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">t</span> <span class="tok-o">&gt;</span>  <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">t</span> <span class="tok-o">&gt;</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">t</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">val u : &lt; x :  &lt; y : &lt; z : int &gt; Js.t &gt;  Js.t &gt; Js.t</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -2534,7 +2472,7 @@ into the type level, so you can write</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">val</span> <span class="tok-n">u</span> <span class="tok-o">:</span> <span class="tok-o">[%</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">obj</span><span class="tok-o">:</span> <span class="tok-o">&lt;</span> <span class="tok-n">x</span> <span class="tok-o">:</span> <span class="tok-o">&lt;</span> <span class="tok-n">y</span> <span class="tok-o">&lt;</span> <span class="tok-n">z</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">&gt;</span> <span class="tok-o">&gt;</span> <span class="tok-o">&gt;</span> <span class="tok-o">]</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">val u : [%bs.obj: &lt; x : &lt; y &lt; z : int &gt; &gt; &gt; ]</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -2542,7 +2480,7 @@ into the type level, so you can write</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">u</span> <span class="tok-o">=</span> <span class="tok-o">[%</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">obj</span> <span class="tok-o">(</span> <span class="tok-o">{</span> <span class="tok-n">x</span> <span class="tok-o">=</span> <span class="tok-o">{</span> <span class="tok-n">y</span> <span class="tok-o">=</span> <span class="tok-o">{</span> <span class="tok-n">z</span> <span class="tok-o">=</span> <span class="tok-mi">3</span> <span class="tok-o">}}}</span> <span class="tok-o">:</span> <span class="tok-o">&lt;</span> <span class="tok-n">x</span> <span class="tok-o">:</span> <span class="tok-o">&lt;</span> <span class="tok-n">y</span> <span class="tok-o">:</span> <span class="tok-o">&lt;</span> <span class="tok-n">z</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">&gt;</span> <span class="tok-o">&gt;</span> <span class="tok-o">&gt;</span> <span class="tok-o">]</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">let u = [%bs.obj ( { x = { y = { z = 3 }}} : &lt; x : &lt; y : &lt; z : int &gt; &gt; &gt; ]</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -2550,8 +2488,8 @@ into the type level, so you can write</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">xs</span> <span class="tok-o">=</span> <span class="tok-o">[%</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">obj</span> <span class="tok-o">[|</span> <span class="tok-o">{</span> <span class="tok-n">x</span> <span class="tok-o">=</span> <span class="tok-mi">3</span> <span class="tok-o">}</span> <span class="tok-o">;</span> <span class="tok-o">{</span><span class="tok-n">x</span> <span class="tok-o">=</span> <span class="tok-mi">3</span> <span class="tok-o">}</span> <span class="tok-o">|]</span> <span class="tok-o">:</span> <span class="tok-o">&lt;</span> <span class="tok-n">x</span> <span class="tok-o">:</span> <span class="tok-kt">int</span>  <span class="tok-o">&gt;</span> <span class="tok-kt">array</span>  <span class="tok-o">]</span>
-<span class="tok-k">let</span> <span class="tok-n">ys</span> <span class="tok-o">=</span> <span class="tok-o">[%</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">obj</span> <span class="tok-o">[|</span> <span class="tok-o">{</span> <span class="tok-n">x</span> <span class="tok-o">=</span> <span class="tok-mi">3</span><span class="tok-o">}</span> <span class="tok-o">:</span> <span class="tok-o">{</span> <span class="tok-n">x</span> <span class="tok-o">=</span> <span class="tok-mi">4</span> <span class="tok-o">}</span> <span class="tok-o">|]</span> <span class="tok-o">]</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">let xs = [%bs.obj [| { x = 3 } ; {x = 3 } |] : &lt; x : int  &gt; array  ]
+let ys = [%bs.obj [| { x = 3} : { x = 4 } |] ]</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -2559,8 +2497,8 @@ into the type level, so you can write</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-kd">var</span> <span class="tok-nx">xs</span> <span class="tok-o">=</span> <span class="tok-p">[</span> <span class="tok-p">{</span> <span class="tok-nx">x</span> <span class="tok-o">:</span> <span class="tok-mi">3</span> <span class="tok-p">}</span> <span class="tok-p">,</span> <span class="tok-p">{</span> <span class="tok-nx">x</span> <span class="tok-o">:</span> <span class="tok-mi">3</span> <span class="tok-p">}]</span>
-<span class="tok-kd">var</span> <span class="tok-nx">ys</span> <span class="tok-o">=</span> <span class="tok-p">[</span> <span class="tok-p">{</span> <span class="tok-nx">x</span> <span class="tok-o">:</span> <span class="tok-mi">3</span> <span class="tok-p">},</span>  <span class="tok-p">{</span><span class="tok-nx">x</span> <span class="tok-o">:</span> <span class="tok-mi">4</span> <span class="tok-p">}</span> <span class="tok-p">]</span></code></pre>
+<pre class="pygments highlight"><code data-lang="js">var xs = [ { x : 3 } , { x : 3 }]
+var ys = [ { x : 3 },  {x : 4 } ]</code></pre>
 </div>
 </div>
 </div>
@@ -2571,8 +2509,8 @@ into the type level, so you can write</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">external</span> <span class="tok-n">make_config</span> <span class="tok-o">:</span> <span class="tok-n">hi</span><span class="tok-o">:</span><span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-n">lo</span><span class="tok-o">:</span><span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">unit</span> <span class="tok-o">-&gt;</span> <span class="tok-n">t</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">obj</span><span class="tok-o">]</span>
-<span class="tok-k">let</span> <span class="tok-n">v</span> <span class="tok-o">=</span> <span class="tok-n">make_config</span> <span class="tok-o">~</span><span class="tok-n">hi</span><span class="tok-o">:</span><span class="tok-mi">2</span> <span class="tok-o">~</span><span class="tok-n">lo</span><span class="tok-o">:</span><span class="tok-mi">3</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">external make_config : hi:int -&gt; lo:int -&gt; unit -&gt; t = "" [@@bs.obj]
+let v = make_config ~hi:2 ~lo:3</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -2580,7 +2518,7 @@ into the type level, so you can write</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-kd">var</span> <span class="tok-nx">v</span> <span class="tok-o">=</span> <span class="tok-p">{</span> <span class="tok-nx">hi</span><span class="tok-o">:</span><span class="tok-mi">2</span><span class="tok-p">,</span> <span class="tok-nx">lo</span><span class="tok-o">:</span><span class="tok-mi">3</span><span class="tok-p">}</span></code></pre>
+<pre class="pygments highlight"><code data-lang="js">var v = { hi:2, lo:3}</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -2588,9 +2526,9 @@ into the type level, so you can write</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">external</span> <span class="tok-n">make_config</span> <span class="tok-o">:</span> <span class="tok-n">hi</span><span class="tok-o">:</span><span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-o">?</span><span class="tok-n">lo</span><span class="tok-o">:</span><span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">unit</span> <span class="tok-o">-&gt;</span> <span class="tok-n">t</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">obj</span><span class="tok-o">]</span> <b class="conum">(1)</b>
-<span class="tok-k">let</span> <span class="tok-n">u</span> <span class="tok-o">=</span> <span class="tok-n">make_config</span> <span class="tok-o">~</span><span class="tok-n">hi</span><span class="tok-o">:</span><span class="tok-mi">3</span> <span class="tok-bp">()</span>
-<span class="tok-k">let</span> <span class="tok-n">v</span> <span class="tok-o">=</span> <span class="tok-n">make_config</span> <span class="tok-o">~</span><span class="tok-n">lo</span><span class="tok-o">:</span><span class="tok-mi">2</span> <span class="tok-o">~</span><span class="tok-n">hi</span><span class="tok-o">:</span><span class="tok-mi">3</span>  <span class="tok-bp">()</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">external make_config : hi:int -&gt; ?lo:int -&gt; unit -&gt; t = "" [@@bs.obj] <b class="conum">(1)</b>
+let u = make_config ~hi:3 ()
+let v = make_config ~lo:2 ~hi:3  ()</code></pre>
 </div>
 </div>
 <div class="colist arabic">
@@ -2607,8 +2545,8 @@ are full-filled (including optional arguments), it is common to have a <code>uni
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-kd">var</span> <span class="tok-nx">u</span> <span class="tok-o">=</span> <span class="tok-p">{</span><span class="tok-nx">hi</span> <span class="tok-o">:</span> <span class="tok-mi">3</span><span class="tok-p">}</span>
-<span class="tok-kd">var</span> <span class="tok-nx">v</span> <span class="tok-o">=</span> <span class="tok-p">{</span><span class="tok-nx">hi</span> <span class="tok-o">:</span> <span class="tok-mi">3</span> <span class="tok-p">,</span> <span class="tok-nx">lo</span><span class="tok-o">:</span> <span class="tok-mi">2</span><span class="tok-p">}</span></code></pre>
+<pre class="pygments highlight"><code data-lang="js">var u = {hi : 3}
+var v = {hi : 3 , lo: 2}</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -2616,13 +2554,13 @@ are full-filled (including optional arguments), it is common to have a <code>uni
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">u</span> <span class="tok-o">=</span> <span class="tok-o">[%</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">obj</span> <span class="tok-o">{</span>
-  <span class="tok-n">x</span> <span class="tok-o">=</span> <span class="tok-o">{</span> <span class="tok-n">y</span> <span class="tok-o">=</span> <span class="tok-o">{</span> <span class="tok-n">z</span> <span class="tok-o">=</span> <span class="tok-mi">3</span> <span class="tok-o">}</span> <span class="tok-o">};</span>
-  <span class="tok-n">fn</span> <span class="tok-o">=</span> <span class="tok-k">fun</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">]</span> <span class="tok-n">u</span> <span class="tok-n">v</span> <span class="tok-o">-&gt;</span> <span class="tok-n">u</span> <span class="tok-o">+</span> <span class="tok-n">v</span> <b class="conum">(1)</b>
-  <span class="tok-o">}</span> <span class="tok-o">]</span>
-<span class="tok-k">let</span> <span class="tok-n">h</span> <span class="tok-o">=</span> <span class="tok-n">u</span><span class="tok-o">##</span><span class="tok-n">x</span><span class="tok-o">##</span><span class="tok-n">y</span><span class="tok-o">##</span><span class="tok-n">z</span>
-<span class="tok-k">let</span> <span class="tok-n">a</span> <span class="tok-o">=</span> <span class="tok-n">h</span><span class="tok-o">##</span><span class="tok-n">fn</span>
-<span class="tok-k">let</span> <span class="tok-n">b</span> <span class="tok-o">=</span> <span class="tok-n">a</span> <span class="tok-mi">1</span> <span class="tok-mi">2</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">]</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">let u = [%bs.obj {
+  x = { y = { z = 3 } };
+  fn = fun [@bs] u v -&gt; u + v <b class="conum">(1)</b>
+  } ]
+let h = u##x##y##z
+let a = h##fn
+let b = a 1 2 [@bs]</code></pre>
 </div>
 </div>
 <div class="colist arabic">
@@ -2638,10 +2576,10 @@ we will show how to create JS method in OCaml later.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-kd">var</span> <span class="tok-nx">u</span> <span class="tok-o">=</span> <span class="tok-p">{</span> <span class="tok-nx">x</span> <span class="tok-o">:</span> <span class="tok-p">{</span> <span class="tok-nx">y</span> <span class="tok-o">:</span> <span class="tok-p">{</span><span class="tok-nx">z</span> <span class="tok-o">:</span> <span class="tok-mi">3</span><span class="tok-p">}},</span> <span class="tok-nx">fn</span> <span class="tok-o">:</span> <span class="tok-kd">function</span> <span class="tok-p">(</span><span class="tok-nx">u</span><span class="tok-p">,</span><span class="tok-nx">v</span><span class="tok-p">)</span> <span class="tok-p">{</span><span class="tok-k">return</span> <span class="tok-nx">u</span> <span class="tok-o">+</span> <span class="tok-nx">v</span><span class="tok-p">}}</span>
-<span class="tok-kd">var</span> <span class="tok-nx">h</span> <span class="tok-o">=</span> <span class="tok-nx">u</span><span class="tok-p">.</span><span class="tok-nx">x</span><span class="tok-p">.</span><span class="tok-nx">y</span><span class="tok-p">.</span><span class="tok-nx">z</span>
-<span class="tok-kd">var</span> <span class="tok-nx">a</span> <span class="tok-o">=</span> <span class="tok-nx">h</span><span class="tok-p">.</span><span class="tok-nx">fn</span>
-<span class="tok-kd">var</span> <span class="tok-nx">b</span> <span class="tok-o">=</span> <span class="tok-nx">a</span><span class="tok-p">(</span><span class="tok-mi">1</span><span class="tok-p">,</span><span class="tok-mi">2</span><span class="tok-p">)</span></code></pre>
+<pre class="pygments highlight"><code data-lang="js">var u = { x : { y : {z : 3}}, fn : function (u,v) {return u + v}}
+var h = u.x.y.z
+var a = h.fn
+var b = a(1,2)</code></pre>
 </div>
 </div>
 <div class="admonitionblock note">
@@ -2657,14 +2595,14 @@ is available:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">b</span> <span class="tok-n">x</span> <span class="tok-n">y</span> <span class="tok-n">h</span> <span class="tok-o">=</span> <span class="tok-n">h</span><span class="tok-o">#@</span><span class="tok-n">fn</span> <span class="tok-n">x</span> <span class="tok-n">y</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">let b x y h = h#@fn x y</code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-kd">function</span> <span class="tok-nx">b</span> <span class="tok-p">(</span><span class="tok-nx">x</span><span class="tok-p">,</span><span class="tok-nx">y</span><span class="tok-p">,</span><span class="tok-nx">h</span><span class="tok-p">){</span>
-  <span class="tok-k">return</span> <span class="tok-nx">h</span><span class="tok-p">.</span><span class="tok-nx">fn</span><span class="tok-p">(</span><span class="tok-nx">x</span><span class="tok-p">,</span><span class="tok-nx">y</span><span class="tok-p">)</span>
-<span class="tok-p">}</span></code></pre>
+<pre class="pygments highlight"><code data-lang="js">function b (x,y,h){
+  return h.fn(x,y)
+}</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -2672,7 +2610,7 @@ is available:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">val</span> <span class="tok-n">b</span> <span class="tok-o">:</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">b</span> <span class="tok-o">-&gt;</span>  <span class="tok-o">&lt;</span> <span class="tok-n">fn</span> <span class="tok-o">:</span>  <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">b</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">c</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">]</span> <span class="tok-o">&gt;</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">t</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">c</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">val b : 'a -&gt; 'b -&gt;  &lt; fn :  'a -&gt; 'b -&gt; 'c [@bs] &gt; Js.t -&gt; 'c</code></pre>
 </div>
 </div>
 </td>
@@ -2688,13 +2626,13 @@ BuckleScript too.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">v2</span>  <span class="tok-o">=</span>
-  <span class="tok-k">let</span> <span class="tok-n">x</span> <span class="tok-o">=</span> <span class="tok-mi">3</span><span class="tok-o">.</span> <span class="tok-k">in</span>
-  <span class="tok-k">object</span> <span class="tok-o">(</span><span class="tok-n">self</span><span class="tok-o">)</span> <b class="conum">(1)</b>
-    <span class="tok-k">method</span> <span class="tok-n">hi</span> <span class="tok-n">x</span>  <span class="tok-n">y</span> <span class="tok-o">=</span> <span class="tok-n">self</span><span class="tok-o">##</span><span class="tok-n">say</span> <span class="tok-n">x</span> <span class="tok-o">+.</span> <span class="tok-n">y</span>
-    <span class="tok-k">method</span> <span class="tok-n">say</span> <span class="tok-n">x</span> <span class="tok-o">=</span>  <span class="tok-n">x</span> <span class="tok-o">*.</span> <span class="tok-n">self</span><span class="tok-o">##</span> <span class="tok-n">x</span> <span class="tok-bp">()</span>
-    <span class="tok-k">method</span> <span class="tok-n">x</span> <span class="tok-bp">()</span> <span class="tok-o">=</span> <span class="tok-n">x</span>
-  <span class="tok-k">end</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">]</span> <b class="conum">(2)</b></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">let v2  =
+  let x = 3. in
+  object (self) <b class="conum">(1)</b>
+    method hi x  y = self##say x +. y
+    method say x =  x *. self## x ()
+    method x () = x
+  end [@bs] <b class="conum">(2)</b></code></pre>
 </div>
 </div>
 <div class="colist arabic">
@@ -2712,19 +2650,19 @@ BuckleScript too.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-kd">var</span> <span class="tok-nx">v2</span> <span class="tok-o">=</span> <span class="tok-p">{</span>
-  <span class="tok-nx">hi</span><span class="tok-o">:</span> <span class="tok-kd">function</span> <span class="tok-p">(</span><span class="tok-nx">x</span><span class="tok-p">,</span> <span class="tok-nx">y</span><span class="tok-p">)</span> <span class="tok-p">{</span>
-    <span class="tok-kd">var</span> <span class="tok-nx">self</span> <span class="tok-o">=</span> <span class="tok-k">this</span> <span class="tok-p">;</span>
-    <span class="tok-k">return</span> <span class="tok-nx">self</span><span class="tok-p">.</span><span class="tok-nx">say</span><span class="tok-p">(</span><span class="tok-nx">x</span><span class="tok-p">)</span> <span class="tok-o">+</span> <span class="tok-nx">y</span><span class="tok-p">;</span>
-  <span class="tok-p">},</span>
-  <span class="tok-nx">say</span><span class="tok-o">:</span> <span class="tok-kd">function</span> <span class="tok-p">(</span><span class="tok-nx">x</span><span class="tok-p">)</span> <span class="tok-p">{</span>
-    <span class="tok-kd">var</span> <span class="tok-nx">self</span> <span class="tok-o">=</span> <span class="tok-k">this</span> <span class="tok-p">;</span>
-    <span class="tok-k">return</span> <span class="tok-nx">x</span> <span class="tok-o">*</span> <span class="tok-nx">self</span><span class="tok-p">.</span><span class="tok-nx">x</span><span class="tok-p">();</span>
-  <span class="tok-p">},</span>
-  <span class="tok-nx">x</span><span class="tok-o">:</span> <span class="tok-kd">function</span> <span class="tok-p">()</span> <span class="tok-p">{</span>
-    <span class="tok-k">return</span> <span class="tok-mi">3</span><span class="tok-p">;</span>
-  <span class="tok-p">}</span>
-<span class="tok-p">};</span></code></pre>
+<pre class="pygments highlight"><code data-lang="js">var v2 = {
+  hi: function (x, y) {
+    var self = this ;
+    return self.say(x) + y;
+  },
+  say: function (x) {
+    var self = this ;
+    return x * self.x();
+  },
+  x: function () {
+    return 3;
+  }
+};</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -2732,11 +2670,11 @@ BuckleScript too.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">val</span> <span class="tok-n">v2</span> <span class="tok-o">:</span> <span class="tok-k">object</span>
-  <span class="tok-k">method</span> <span class="tok-n">hi</span> <span class="tok-o">:</span> <span class="tok-kt">float</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">float</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">float</span>
-  <span class="tok-k">method</span> <span class="tok-n">say</span> <span class="tok-o">:</span> <span class="tok-kt">float</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">float</span>
-  <span class="tok-k">method</span> <span class="tok-n">x</span> <span class="tok-o">:</span> <span class="tok-kt">unit</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">float</span>
-<span class="tok-k">end</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">]</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">val v2 : object
+  method hi : float -&gt; float -&gt; float
+  method say : float -&gt; float
+  method x : unit -&gt; float
+end [@bs]</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -2744,15 +2682,15 @@ BuckleScript too.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">f</span> <span class="tok-o">(</span><span class="tok-n">u</span> <span class="tok-o">:</span> <span class="tok-n">rect</span><span class="tok-o">)</span> <span class="tok-o">=</span>
-  <span class="tok-c">(* the type annotation is un-necessary,</span>
-<span class="tok-c">     but it gives better error message</span>
-<span class="tok-c">  *)</span>
-   <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">log</span> <span class="tok-n">u</span><span class="tok-o">##</span><span class="tok-n">height</span> <span class="tok-o">;</span>
-   <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">log</span> <span class="tok-n">u</span><span class="tok-o">##</span><span class="tok-n">width</span> <span class="tok-o">;</span>
-   <span class="tok-n">u</span><span class="tok-o">##</span><span class="tok-n">width</span> <span class="tok-o">#=</span> <span class="tok-mi">30</span><span class="tok-o">;</span>
-   <span class="tok-n">u</span><span class="tok-o">##</span><span class="tok-n">height</span> <span class="tok-o">#=</span> <span class="tok-mi">30</span><span class="tok-o">;</span>
-   <span class="tok-n">u</span><span class="tok-o">##</span><span class="tok-n">draw</span> <span class="tok-bp">()</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">let f (u : rect) =
+  (* the type annotation is un-necessary,
+     but it gives better error message
+  *)
+   Js.log u##height ;
+   Js.log u##width ;
+   u##width #= 30;
+   u##height #= 30;
+   u##draw ()</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -2760,23 +2698,23 @@ BuckleScript too.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-kd">function</span> <span class="tok-nx">f</span><span class="tok-p">(</span><span class="tok-nx">u</span><span class="tok-p">){</span>
-  <span class="tok-nx">console</span><span class="tok-p">.</span><span class="tok-nx">log</span><span class="tok-p">(</span><span class="tok-nx">u</span><span class="tok-p">.</span><span class="tok-nx">height</span><span class="tok-p">);</span>
-  <span class="tok-nx">console</span><span class="tok-p">.</span><span class="tok-nx">log</span><span class="tok-p">(</span><span class="tok-nx">u</span><span class="tok-p">.</span><span class="tok-nx">width</span><span class="tok-p">);</span>
-  <span class="tok-nx">u</span><span class="tok-p">.</span><span class="tok-nx">width</span> <span class="tok-o">=</span> <span class="tok-mi">30</span><span class="tok-p">;</span>
-  <span class="tok-nx">u</span><span class="tok-p">.</span><span class="tok-nx">height</span> <span class="tok-o">=</span> <span class="tok-mi">30</span><span class="tok-p">;</span>
-  <span class="tok-k">return</span> <span class="tok-nx">u</span><span class="tok-p">.</span><span class="tok-nx">draw</span><span class="tok-p">()</span>
-<span class="tok-p">}</span></code></pre>
+<pre class="pygments highlight"><code data-lang="js">function f(u){
+  console.log(u.height);
+  console.log(u.width);
+  u.width = 30;
+  u.height = 30;
+  return u.draw()
+}</code></pre>
 </div>
 </div>
 <div class="sect4">
 <h5 id="_method_chaining"><a class="anchor" href="#_method_chaining"></a>Method chaining</h5>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-n">f</span>
-<span class="tok-o">##(</span><span class="tok-n">meth0</span> <span class="tok-bp">()</span><span class="tok-o">)</span>
-<span class="tok-o">##(</span><span class="tok-n">meth1</span> <span class="tok-n">a</span><span class="tok-o">)</span>
-<span class="tok-o">##(</span><span class="tok-n">meth2</span> <span class="tok-n">a</span> <span class="tok-n">b</span><span class="tok-o">)</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">f
+##(meth0 ())
+##(meth1 a)
+##(meth2 a b)</code></pre>
 </div>
 </div>
 </div>
@@ -2805,8 +2743,8 @@ get the job done.</p>
 <h4 id="_embedding_raw_js_code_as_an_expression"><a class="anchor" href="#_embedding_raw_js_code_as_an_expression"></a>Embedding raw JS code as an expression</h4>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">keys</span> <span class="tok-o">:</span> <span class="tok-n">t</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">string</span> <span class="tok-kt">array</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">]</span> <span class="tok-o">=</span> <span class="tok-o">[%</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">raw</span> <span class="tok-s2">&quot;Object.keys&quot;</span> <span class="tok-o">]</span>
-<span class="tok-k">let</span> <span class="tok-n">unsafe_lt</span> <span class="tok-o">:</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-o">-&gt;</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">boolean</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">]</span> <span class="tok-o">=</span> <span class="tok-o">[%</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">raw</span><span class="tok-o">{|</span><span class="tok-k">function</span><span class="tok-o">(</span><span class="tok-n">x</span><span class="tok-o">,</span><span class="tok-n">y</span><span class="tok-o">){</span><span class="tok-n">return</span> <span class="tok-n">x</span> <span class="tok-o">&lt;</span> <span class="tok-n">y</span><span class="tok-o">}|}]</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">let keys : t -&gt; string array [@bs] = [%bs.raw "Object.keys" ]
+let unsafe_lt : 'a -&gt; 'a -&gt; Js.boolean [@bs] = [%bs.raw{|function(x,y){return x &lt; y}|}]</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -2819,9 +2757,9 @@ refer to external OCaml symbols in raw JS code.</p>
 <h4 id="_embedding_raw_js_code_as_statements"><a class="anchor" href="#_embedding_raw_js_code_as_statements"></a>Embedding raw JS code as statements</h4>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-p">[</span><span class="tok-o">%%</span><span class="tok-nx">bs</span><span class="tok-p">.</span><span class="tok-nx">raw</span><span class="tok-p">{</span><span class="tok-o">|</span>
-  <span class="tok-nx">console</span><span class="tok-p">.</span><span class="tok-nx">log</span> <span class="tok-p">(</span><span class="tok-s2">&quot;hey&quot;</span><span class="tok-p">);</span>
-<span class="tok-o">|</span><span class="tok-p">}]</span></code></pre>
+<pre class="pygments highlight"><code data-lang="js">[%%bs.raw{|
+  console.log ("hey");
+|}]</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -2829,7 +2767,7 @@ refer to external OCaml symbols in raw JS code.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">x</span>  <span class="tok-o">:</span> <span class="tok-kt">string</span> <span class="tok-o">=</span> <span class="tok-o">[%</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">raw</span><span class="tok-o">{|</span><span class="tok-s2">&quot;</span><span class="tok-se">\x01\x02</span><span class="tok-s2">&quot;</span><span class="tok-o">|}]</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">let x  : string = [%bs.raw{|"\x01\x02"|}]</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -2837,7 +2775,7 @@ refer to external OCaml symbols in raw JS code.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-kd">var</span> <span class="tok-nx">x</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;\x01\x02&quot;</span></code></pre>
+<pre class="pygments highlight"><code data-lang="js">var x = "\x01\x02"</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -2845,12 +2783,12 @@ refer to external OCaml symbols in raw JS code.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml">   <span class="tok-o">[%%</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">raw</span><span class="tok-o">{|</span>
-   <span class="tok-o">//</span> <span class="tok-nn">Math</span><span class="tok-p">.</span><span class="tok-n">imul</span> <span class="tok-n">polyfill</span>
-   <span class="tok-k">if</span> <span class="tok-o">(!</span><span class="tok-nn">Math</span><span class="tok-p">.</span><span class="tok-n">imul</span><span class="tok-o">){</span>
-       <span class="tok-nn">Math</span><span class="tok-p">.</span><span class="tok-n">imul</span> <span class="tok-o">=</span> <span class="tok-k">function</span> <span class="tok-o">(..)</span> <span class="tok-o">{..}</span>
-    <span class="tok-o">}</span>
-   <span class="tok-o">|}]</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">   [%%bs.raw{|
+   // Math.imul polyfill
+   if (!Math.imul){
+       Math.imul = function (..) {..}
+    }
+   |}]</code></pre>
 </div>
 </div>
 <div class="admonitionblock warning">
@@ -2885,9 +2823,9 @@ that the order is correct.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml">  <span class="tok-k">let</span> <span class="tok-n">f</span> <span class="tok-n">x</span> <span class="tok-n">y</span> <span class="tok-o">=</span>
-    <span class="tok-o">[%</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">debugger</span><span class="tok-o">];</span>
-    <span class="tok-n">x</span> <span class="tok-o">+</span> <span class="tok-n">y</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">  let f x y =
+    [%bs.debugger];
+    x + y</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -2895,10 +2833,10 @@ that the order is correct.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js">  <span class="tok-kd">function</span> <span class="tok-nx">f</span> <span class="tok-p">(</span><span class="tok-nx">x</span><span class="tok-p">,</span><span class="tok-nx">y</span><span class="tok-p">)</span> <span class="tok-p">{</span>
-     <span class="tok-kr">debugger</span><span class="tok-p">;</span> <span class="tok-c1">// JavaScript developer tools will set an breakpoint and stop here</span>
-     <span class="tok-nx">x</span> <span class="tok-o">+</span> <span class="tok-nx">y</span><span class="tok-p">;</span>
-  <span class="tok-p">}</span></code></pre>
+<pre class="pygments highlight"><code data-lang="js">  function f (x,y) {
+     debugger; // JavaScript developer tools will set an breakpoint and stop here
+     x + y;
+  }</code></pre>
 </div>
 </div>
 </div>
@@ -2909,7 +2847,7 @@ that the order is correct.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">f</span>  <span class="tok-o">=</span> <span class="tok-o">[%</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">re</span> <span class="tok-s2">&quot;/b/g&quot;</span><span class="tok-o">]</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">let f  = [%bs.re "/b/g"]</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -2950,8 +2888,8 @@ more examples, please visit
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">external</span> <span class="tok-n">describe</span> <span class="tok-o">:</span> <span class="tok-kt">string</span> <span class="tok-o">-&gt;</span> <span class="tok-o">(</span><span class="tok-kt">unit</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">unit</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">])</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">unit</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">val</span><span class="tok-o">]</span>
-<span class="tok-k">external</span> <span class="tok-n">it</span> <span class="tok-o">:</span> <span class="tok-kt">string</span> <span class="tok-o">-&gt;</span> <span class="tok-o">(</span><span class="tok-kt">unit</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">unit</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">])</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">unit</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">val</span><span class="tok-o">]</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">external describe : string -&gt; (unit -&gt; unit [@bs]) -&gt; unit = "" [@@bs.val]
+external it : string -&gt; (unit -&gt; unit [@bs]) -&gt; unit = "" [@@bs.val]</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -2961,7 +2899,7 @@ more examples, please visit
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">external</span> <span class="tok-n">eq</span> <span class="tok-o">:</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">unit</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;deepEqual&quot;</span>  <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">module</span> <span class="tok-s2">&quot;assert&quot;</span><span class="tok-o">]</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">external eq : 'a -&gt; 'a -&gt; unit = "deepEqual"  [@@bs.module "assert"]</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -2969,11 +2907,11 @@ more examples, please visit
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">assert_equal</span> <span class="tok-o">=</span> <span class="tok-n">eq</span>
-<span class="tok-k">let</span> <span class="tok-n">from_suites</span> <span class="tok-n">name</span> <span class="tok-n">suite</span>  <span class="tok-o">=</span>
-    <span class="tok-n">describe</span> <span class="tok-n">name</span> <span class="tok-o">(</span><span class="tok-k">fun</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">]</span> <span class="tok-bp">()</span> <span class="tok-o">-&gt;</span>
-         <span class="tok-nn">List</span><span class="tok-p">.</span><span class="tok-n">iter</span> <span class="tok-o">(</span><span class="tok-k">fun</span> <span class="tok-o">(</span><span class="tok-n">name</span><span class="tok-o">,</span> <span class="tok-n">code</span><span class="tok-o">)</span> <span class="tok-o">-&gt;</span> <span class="tok-n">it</span> <span class="tok-n">name</span> <span class="tok-n">code</span><span class="tok-o">)</span> <span class="tok-n">suite</span>
-         <span class="tok-o">)</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">let assert_equal = eq
+let from_suites name suite  =
+    describe name (fun [@bs] () -&gt;
+         List.iter (fun (name, code) -&gt; it name code) suite
+         )</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -2981,20 +2919,20 @@ more examples, please visit
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"> <span class="tok-kd">var</span> <span class="tok-nx">Assert</span> <span class="tok-o">=</span> <span class="tok-nx">require</span><span class="tok-p">(</span><span class="tok-s2">&quot;assert&quot;</span><span class="tok-p">);</span>
- <span class="tok-kd">var</span> <span class="tok-nx">List</span> <span class="tok-o">=</span> <span class="tok-nx">require</span><span class="tok-p">(</span><span class="tok-s2">&quot;bs-platform/lib/js/list&quot;</span><span class="tok-p">);</span>
+<pre class="pygments highlight"><code data-lang="js"> var Assert = require("assert");
+ var List = require("bs-platform/lib/js/list");
 
-<span class="tok-kd">function</span> <span class="tok-nx">assert_equal</span><span class="tok-p">(</span><span class="tok-nx">prim</span><span class="tok-p">,</span> <span class="tok-nx">prim$1</span><span class="tok-p">)</span> <span class="tok-p">{</span>
- <span class="tok-k">return</span> <span class="tok-nx">Assert</span><span class="tok-p">.</span><span class="tok-nx">deepEqual</span><span class="tok-p">(</span><span class="tok-nx">prim</span><span class="tok-p">,</span> <span class="tok-nx">prim$1</span><span class="tok-p">);</span>
- <span class="tok-p">}</span>
+function assert_equal(prim, prim$1) {
+ return Assert.deepEqual(prim, prim$1);
+ }
 
-<span class="tok-kd">function</span> <span class="tok-nx">from_suites</span><span class="tok-p">(</span><span class="tok-nx">name</span><span class="tok-p">,</span> <span class="tok-nx">suite</span><span class="tok-p">)</span> <span class="tok-p">{</span>
- <span class="tok-k">return</span> <span class="tok-nx">describe</span><span class="tok-p">(</span><span class="tok-nx">name</span><span class="tok-p">,</span> <span class="tok-kd">function</span> <span class="tok-p">()</span> <span class="tok-p">{</span>
-   <span class="tok-k">return</span> <span class="tok-nx">List</span><span class="tok-p">.</span><span class="tok-nx">iter</span><span class="tok-p">(</span><span class="tok-kd">function</span> <span class="tok-p">(</span><span class="tok-nx">param</span><span class="tok-p">)</span> <span class="tok-p">{</span>
-    <span class="tok-k">return</span> <span class="tok-nx">it</span><span class="tok-p">(</span><span class="tok-nx">param</span><span class="tok-p">[</span><span class="tok-mi">0</span><span class="tok-p">],</span> <span class="tok-nx">param</span><span class="tok-p">[</span><span class="tok-mi">1</span><span class="tok-p">]);</span>
-      <span class="tok-p">},</span> <span class="tok-nx">suite</span><span class="tok-p">);</span>
-  <span class="tok-p">});</span>
- <span class="tok-p">}</span></code></pre>
+function from_suites(name, suite) {
+ return describe(name, function () {
+   return List.iter(function (param) {
+    return it(param[0], param[1]);
+      }, suite);
+  });
+ }</code></pre>
 </div>
 </div>
 </div>
@@ -3010,27 +2948,13 @@ more examples, please visit
 <div class="listingblock">
 <div class="title">Js Public types</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">type</span> <span class="tok-o">+</span><span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-n">t</span>
-<span class="tok-c">(** Js object type *)</span>
-<span class="tok-k">type</span> <span class="tok-o">+</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-n">null</span>
-<span class="tok-c">(** nullable, value of this type can be either [null] or [&#39;a]</span>
-<span class="tok-c">    this type is the same as {!Js.Null.t}  *)</span>
-<span class="tok-k">type</span> <span class="tok-o">+</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-n">undefined</span>
-<span class="tok-c">(** value of this type can be either [undefined] or [&#39;a]</span>
-<span class="tok-c">    this type is the same as {!Js.Undefined.t}  *)</span>
-<span class="tok-k">type</span> <span class="tok-o">+</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-n">null_undefined</span>
-<span class="tok-c">(** value of this type can be [undefined], [null] or [&#39;a]</span>
-<span class="tok-c">    this type is the same as {!Js.Null_undefined.t}*)</span>
-<span class="tok-k">type</span> <span class="tok-n">boolean</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"></code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="title">Js Nested modules</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-c">(** {3 nested modules}*)</span>
-<span class="tok-k">module</span> <span class="tok-nc">Null</span> <span class="tok-o">=</span> <span class="tok-nc">Js_null</span>
-<span class="tok-k">module</span> <span class="tok-nc">Undefined</span> <span class="tok-o">=</span> <span class="tok-nc">Js_undefined</span>
-<span class="tok-k">module</span> <span class="tok-nc">Null_undefined</span> <span class="tok-o">=</span> <span class="tok-nc">Js_null_undefined</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"></code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -3039,43 +2963,19 @@ more examples, please visit
 <div class="listingblock">
 <div class="title">Js.Null module</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">type</span> <span class="tok-o">+</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-n">t</span> <span class="tok-o">=</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">null</span>
-<span class="tok-k">external</span> <span class="tok-n">to_opt</span> <span class="tok-o">:</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-n">t</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-n">option</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;js_from_nullable&quot;</span>
-<span class="tok-k">external</span> <span class="tok-n">return</span> <span class="tok-o">:</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-n">t</span>  <span class="tok-o">=</span> <span class="tok-s2">&quot;%identity&quot;</span>
-<span class="tok-k">external</span> <span class="tok-n">test</span> <span class="tok-o">:</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-n">t</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">bool</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;js_is_nil&quot;</span>
-<span class="tok-k">external</span> <span class="tok-n">empty</span> <span class="tok-o">:</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-n">t</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;null&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">val</span><span class="tok-o">]</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"></code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="title">Js Utility functions</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">external</span> <span class="tok-n">to_bool</span> <span class="tok-o">:</span> <span class="tok-n">boolean</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">bool</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;js_boolean_to_bool&quot;</span>
-<span class="tok-c">(** convert Js boolean to OCaml bool *)</span>
-<span class="tok-k">external</span> <span class="tok-n">typeof</span> <span class="tok-o">:</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">string</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;js_typeof&quot;</span>
-<span class="tok-c">(** [typeof x] will be compiled as [typeof x] in JS *)</span>
-<span class="tok-k">external</span> <span class="tok-n">log</span> <span class="tok-o">:</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">unit</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;js_dump&quot;</span>
-<span class="tok-c">(** A convenience function to log *)</span>
-
-<span class="tok-c">(** {4 operators }*)</span>
-<span class="tok-k">external</span> <span class="tok-n">unsafe_lt</span> <span class="tok-o">:</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-o">-&gt;</span> <span class="tok-n">boolean</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;js_unsafe_lt&quot;</span>
-<span class="tok-c">(**  [unsafe_lt a b] will be compiled as [a &lt; b] *)</span>
-<span class="tok-k">external</span> <span class="tok-n">unsafe_le</span> <span class="tok-o">:</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-o">-&gt;</span> <span class="tok-n">boolean</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;js_unsafe_le&quot;</span>
-<span class="tok-c">(**  [unsafe_le a b] will be compiled as [a &lt;= b] *)</span>
-<span class="tok-k">external</span> <span class="tok-n">unsafe_gt</span> <span class="tok-o">:</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-o">-&gt;</span> <span class="tok-n">boolean</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;js_unsafe_gt&quot;</span>
-<span class="tok-c">(**  [unsafe_gt a b] will be compiled as [a &gt; b] *)</span>
-<span class="tok-k">external</span> <span class="tok-n">unsafe_ge</span> <span class="tok-o">:</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-o">-&gt;</span> <span class="tok-n">boolean</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;js_unsafe_ge&quot;</span>
-<span class="tok-c">(**  [unsafe_ge a b] will be compiled as [a &gt;= b] *)</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"></code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="title">Js Predefined JS values</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">external</span> <span class="tok-bp">true</span><span class="tok-o">_</span> <span class="tok-o">:</span> <span class="tok-n">boolean</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;true&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">val</span><span class="tok-o">]</span>
-<span class="tok-k">external</span> <span class="tok-bp">false</span><span class="tok-o">_</span> <span class="tok-o">:</span> <span class="tok-n">boolean</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;false&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">val</span><span class="tok-o">]</span>
-<span class="tok-k">external</span> <span class="tok-n">null</span> <span class="tok-o">:</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-n">null</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;&quot;</span>
-<span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">val</span><span class="tok-o">]</span> <span class="tok-c">(* The same as {!Js.Null.empty} will be compiled as [null]*)</span>
-<span class="tok-k">external</span> <span class="tok-n">undefined</span> <span class="tok-o">:</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-n">undefined</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;&quot;</span>
-<span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">val</span><span class="tok-o">]</span> <span class="tok-c">(* The same as  {!Js.Undefined.empty} will be compiled as [undefined]*)</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"></code></pre>
 </div>
 </div>
 </div>
@@ -3199,7 +3099,7 @@ Another use case is that users can use <code>-ppx</code> explicitly as below:</p
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-n">bsc</span> <span class="tok-o">-</span><span class="tok-n">c</span> <span class="tok-o">-</span><span class="tok-n">ppx</span> <span class="tok-n">bsppx</span> <span class="tok-o">-</span><span class="tok-n">bs</span><span class="tok-o">-</span><span class="tok-n">no</span><span class="tok-o">-</span><span class="tok-n">builtin</span><span class="tok-o">-</span><span class="tok-n">ppx</span><span class="tok-o">-</span><span class="tok-n">ml</span> <span class="tok-n">c</span><span class="tok-o">.</span><span class="tok-n">ml</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">bsc -c -ppx bsppx -bs-no-builtin-ppx-ml c.ml</code></pre>
 </div>
 </div>
 </div>
@@ -3346,21 +3246,21 @@ inlining, arity inference and other information.</p>
 <div class="listingblock">
 <div class="title">Makefile</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="make"><span class="tok-nv">OCAMLC</span><span class="tok-o">=</span>bsc <b class="conum">(1)</b>
-<span class="tok-nv">OCAMLDEP</span><span class="tok-o">=</span>ocamldep <b class="conum">(2)</b>
-<span class="tok-nv">SOURCE_LIST</span> <span class="tok-o">:=</span> src_a src_b
-<span class="tok-nv">SOURCE_MLI</span>  <span class="tok-o">=</span> <span class="tok-k">$(</span>addsuffix .mli, <span class="tok-k">$(</span>SOURCE_LIST<span class="tok-k">))</span>
-<span class="tok-nv">SOURCE_ML</span>   <span class="tok-o">=</span> <span class="tok-k">$(</span>addsuffix .ml, <span class="tok-k">$(</span>SOURCE_LIST<span class="tok-k">))</span>
-<span class="tok-nv">TARGETS</span> <span class="tok-o">:=</span> <span class="tok-k">$(</span>addsuffix .cmj, <span class="tok-k">$(</span>SOURCE_LIST<span class="tok-k">))</span>
-<span class="tok-nv">INCLUDES</span><span class="tok-o">=</span>
-<span class="tok-nf">all</span><span class="tok-o">:</span> <span class="tok-k">$(</span><span class="tok-nv">TARGETS</span><span class="tok-k">)</span>
-<span class="tok-nf">%.cmi</span><span class="tok-o">:</span> %.<span class="tok-n">mli</span>
-        <span class="tok-k">$(</span>OCAMLC<span class="tok-k">)</span> <span class="tok-k">$(</span>INCLUDES<span class="tok-k">)</span> <span class="tok-k">$(</span>COMPFLAGS<span class="tok-k">)</span>  -c <span class="tok-nv">$&lt;</span>
-<span class="tok-nf">%.ml</span><span class="tok-o">:</span> %.<span class="tok-n">cmj</span>:
-        <span class="tok-k">$(</span>OCAMLC<span class="tok-k">)</span> <span class="tok-k">$(</span>INCLUDES<span class="tok-k">)</span> <span class="tok-k">$(</span>COMPFLAGS<span class="tok-k">)</span>  -c <span class="tok-nv">$&lt;</span>
-<span class="tok-cp">-include .depend</span>
-<span class="tok-nf">depend</span><span class="tok-o">:</span>
-        <span class="tok-k">$(</span>OCAMLDEP<span class="tok-k">)</span> <span class="tok-k">$(</span>INCLUDES<span class="tok-k">)</span> <span class="tok-k">$(</span>SOURCE_ML<span class="tok-k">)</span> <span class="tok-k">$(</span>SOURCE_MLI<span class="tok-k">)</span> <span class="tok-p">|</span> sed -e <span class="tok-s1">&#39;s/\.cmx/.cmj/g&#39;</span> &gt; .depend</code></pre>
+<pre class="pygments highlight"><code data-lang="make">OCAMLC=bsc <b class="conum">(1)</b>
+OCAMLDEP=ocamldep <b class="conum">(2)</b>
+SOURCE_LIST := src_a src_b
+SOURCE_MLI  = $(addsuffix .mli, $(SOURCE_LIST))
+SOURCE_ML   = $(addsuffix .ml, $(SOURCE_LIST))
+TARGETS := $(addsuffix .cmj, $(SOURCE_LIST))
+INCLUDES=
+all: $(TARGETS)
+%.cmi: %.mli
+        $(OCAMLC) $(INCLUDES) $(COMPFLAGS)  -c $&lt;
+%.ml: %.cmj:
+        $(OCAMLC) $(INCLUDES) $(COMPFLAGS)  -c $&lt;
+-include .depend
+depend:
+        $(OCAMLDEP) $(INCLUDES) $(SOURCE_ML) $(SOURCE_MLI) | sed -e 's/\.cmx/.cmj/g' &gt; .depend</code></pre>
 </div>
 </div>
 <div class="colist arabic">
@@ -3684,8 +3584,8 @@ We might encode it as buffer  in NodeJS.
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">type</span> <span class="tok-n">t</span> <span class="tok-o">=</span> <span class="tok-o">{</span> <span class="tok-n">x</span> <span class="tok-o">:</span> <span class="tok-kt">int</span><span class="tok-o">;</span> <span class="tok-n">y</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">}</span>
-<span class="tok-k">let</span> <span class="tok-n">v</span> <span class="tok-o">=</span> <span class="tok-o">{</span><span class="tok-n">x</span> <span class="tok-o">=</span> <span class="tok-mi">1</span><span class="tok-o">;</span>  <span class="tok-n">y</span> <span class="tok-o">=</span> <span class="tok-mi">2</span><span class="tok-o">}</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">type t = { x : int; y : int }
+let v = {x = 1;  y = 2}</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -3693,7 +3593,7 @@ We might encode it as buffer  in NodeJS.
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-kd">var</span> <span class="tok-nx">v</span> <span class="tok-o">=</span> <span class="tok-p">[</span><span class="tok-mi">1</span><span class="tok-p">,</span><span class="tok-mi">2</span><span class="tok-p">]</span></code></pre>
+<pre class="pygments highlight"><code data-lang="js">var v = [1,2]</code></pre>
 </div>
 </div></div></td>
 </tr>
@@ -3792,7 +3692,7 @@ We might encode it as buffer  in NodeJS.
 <div class="listingblock">
 <div class="title">Js module</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">val</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">to_bool</span><span class="tok-o">:</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">boolean</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">bool</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">val Js.to_bool: Js.boolean -&gt; bool</code></pre>
 </div>
 </div></div></td>
 </tr>
@@ -3804,11 +3704,11 @@ We might encode it as buffer  in NodeJS.
 <div class="listingblock">
 <div class="title">Js.Null module</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">val</span> <span class="tok-n">to_opt</span> <span class="tok-o">:</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-n">t</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-n">option</span>
+<pre class="pygments highlight"><code data-lang="ocaml">val to_opt : 'a t -&gt; 'a option
 
-<span class="tok-k">val</span> <span class="tok-n">return</span> <span class="tok-o">:</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-n">t</span>
+val return : 'a -&gt; 'a t
 
-<span class="tok-k">val</span> <span class="tok-n">test</span> <span class="tok-o">:</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-n">t</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">bool</span></code></pre>
+val test : 'a t -&gt; bool</code></pre>
 </div>
 </div></div></td>
 </tr>
@@ -3820,9 +3720,9 @@ We might encode it as buffer  in NodeJS.
 <div class="listingblock">
 <div class="title">Js.Undefined</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">val</span> <span class="tok-n">to_opt</span> <span class="tok-o">:</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-n">t</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-n">option</span>
-<span class="tok-k">val</span> <span class="tok-n">return</span> <span class="tok-o">:</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-n">t</span>
-<span class="tok-k">val</span> <span class="tok-n">test</span> <span class="tok-o">:</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-n">t</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">bool</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">val to_opt : 'a t -&gt; 'a option
+val return : 'a -&gt; 'a t
+val test : 'a t -&gt; bool</code></pre>
 </div>
 </div></div></td>
 </tr>
@@ -3866,11 +3766,11 @@ We are working to provide a ppx extension as below:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">type</span> <span class="tok-n">t</span> <span class="tok-o">=</span>
-  <span class="tok-o">|</span> <span class="tok-nc">A</span>
-  <span class="tok-o">|</span> <span class="tok-nc">B</span> <span class="tok-k">of</span> <span class="tok-kt">int</span> <span class="tok-o">*</span> <span class="tok-kt">int</span>
-  <span class="tok-o">|</span> <span class="tok-nc">C</span> <span class="tok-k">of</span> <span class="tok-kt">int</span> <span class="tok-o">*</span> <span class="tok-kt">int</span>
-  <span class="tok-o">|</span> <span class="tok-nc">D</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">deriving</span><span class="tok-o">{</span><span class="tok-n">export</span><span class="tok-o">}]</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">type t =
+  | A
+  | B of int * int
+  | C of int * int
+  | D [@@bs.deriving{export}]</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -3879,15 +3779,15 @@ We are working to provide a ppx extension as below:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">val</span> <span class="tok-n">a</span> <span class="tok-o">:</span> <span class="tok-n">t</span>
-<span class="tok-k">val</span> <span class="tok-n">b</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-n">t</span>
-<span class="tok-k">val</span> <span class="tok-n">c</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-n">t</span>
-<span class="tok-k">val</span> <span class="tok-n">d</span> <span class="tok-o">:</span> <span class="tok-kt">int</span>
+<pre class="pygments highlight"><code data-lang="ocaml">val a : t
+val b : int -&gt; int -&gt; t
+val c : int -&gt; int -&gt; t
+val d : int
 
-<span class="tok-k">val</span> <span class="tok-n">a_of_t</span> <span class="tok-o">:</span> <span class="tok-n">t</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">bool</span>
-<span class="tok-k">val</span> <span class="tok-n">d_of_t</span> <span class="tok-o">:</span> <span class="tok-n">t</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">bool</span>
-<span class="tok-k">val</span> <span class="tok-n">b_of_t</span> <span class="tok-o">:</span> <span class="tok-n">t</span> <span class="tok-o">-&gt;</span> <span class="tok-o">(</span><span class="tok-kt">int</span> <span class="tok-o">*</span> <span class="tok-kt">int</span> <span class="tok-o">)</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-nn">Null</span><span class="tok-p">.</span><span class="tok-n">t</span>
-<span class="tok-k">val</span> <span class="tok-n">c_of_t</span> <span class="tok-o">:</span> <span class="tok-n">t</span> <span class="tok-o">-&gt;</span> <span class="tok-o">(</span><span class="tok-kt">int</span> <span class="tok-o">*</span> <span class="tok-kt">int</span> <span class="tok-o">)</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-nn">Null</span><span class="tok-p">.</span><span class="tok-n">t</span></code></pre>
+val a_of_t : t -&gt; bool
+val d_of_t : t -&gt; bool
+val b_of_t : t -&gt; (int * int ) Js.Null.t
+val c_of_t : t -&gt; (int * int ) Js.Null.t</code></pre>
 </div>
 </div>
 </div>
@@ -3947,7 +3847,7 @@ following:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="sh"><span class="tok-nb">cd </span>jscomp/
+<pre class="pygments highlight"><code data-lang="sh">cd jscomp/
 ./build.sh</code></pre>
 </div>
 </div>
@@ -3956,7 +3856,7 @@ following:</p>
 <h3 id="_build_the_runtime"><a class="anchor" href="#_build_the_runtime"></a>Build the runtime</h3>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="sh"><span class="tok-nb">cd</span> ./runtime<span class="tok-p">;</span> make all</code></pre>
+<pre class="pygments highlight"><code data-lang="sh">cd ./runtime; make all</code></pre>
 </div>
 </div>
 </div>
@@ -3964,7 +3864,7 @@ following:</p>
 <h3 id="_build_the_stdlib"><a class="anchor" href="#_build_the_stdlib"></a>Build the stdlib</h3>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="sh"><span class="tok-nb">cd</span> ./stdlib<span class="tok-p">;</span> make all</code></pre>
+<pre class="pygments highlight"><code data-lang="sh">cd ./stdlib; make all</code></pre>
 </div>
 </div>
 </div>
@@ -4005,13 +3905,13 @@ the compiler you modified.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">suites</span> <span class="tok-o">:</span> <span class="tok-o">_</span> <span class="tok-nn">Mt</span><span class="tok-p">.</span><span class="tok-n">pair_suites</span> <span class="tok-o">=</span>
-   <span class="tok-o">[</span><span class="tok-s2">&quot;hey&quot;</span><span class="tok-o">,</span> <span class="tok-o">(</span><span class="tok-k">fun</span> <span class="tok-o">_</span> <span class="tok-o">-&gt;</span> <span class="tok-nc">Eq</span><span class="tok-o">(</span><span class="tok-bp">true</span><span class="tok-o">,</span> <span class="tok-mi">3</span> <span class="tok-o">&gt;</span> <span class="tok-mi">2</span><span class="tok-o">));</span>
-       <span class="tok-s2">&quot;hi&quot;</span><span class="tok-o">,</span> <span class="tok-o">(</span><span class="tok-k">fun</span> <span class="tok-o">_</span> <span class="tok-o">-&gt;</span>  <span class="tok-nc">Neq</span><span class="tok-o">(</span><span class="tok-mi">2</span><span class="tok-o">,</span><span class="tok-mi">3</span><span class="tok-o">));</span>
-       <span class="tok-s2">&quot;hello&quot;</span><span class="tok-o">,</span> <span class="tok-o">(</span><span class="tok-k">fun</span> <span class="tok-o">_</span> <span class="tok-o">-&gt;</span> <span class="tok-nc">Approx</span><span class="tok-o">(</span><span class="tok-mi">3</span><span class="tok-o">.</span><span class="tok-mi">0</span><span class="tok-o">,</span> <span class="tok-mi">3</span><span class="tok-o">.</span><span class="tok-mi">0</span><span class="tok-o">));</span>
-       <span class="tok-s2">&quot;throw&quot;</span><span class="tok-o">,</span> <span class="tok-o">(</span><span class="tok-k">fun</span> <span class="tok-o">_</span> <span class="tok-o">-&gt;</span> <span class="tok-nc">ThrowAny</span><span class="tok-o">(</span><span class="tok-k">fun</span> <span class="tok-o">_</span> <span class="tok-o">-&gt;</span> <span class="tok-k">raise</span> <span class="tok-mi">3</span><span class="tok-o">))</span>
-       <span class="tok-o">]</span>
-<span class="tok-k">let</span> <span class="tok-bp">()</span> <span class="tok-o">=</span> <span class="tok-nn">Mt</span><span class="tok-p">.</span><span class="tok-n">from_pair_suites</span> <span class="tok-o">__</span><span class="tok-n">FILE__</span> <span class="tok-n">suites</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">let suites : _ Mt.pair_suites =
+   ["hey", (fun _ -&gt; Eq(true, 3 &gt; 2));
+       "hi", (fun _ -&gt;  Neq(2,3));
+       "hello", (fun _ -&gt; Approx(3.0, 3.0));
+       "throw", (fun _ -&gt; ThrowAny(fun _ -&gt; raise 3))
+       ]
+let () = Mt.from_pair_suites __FILE__ suites</code></pre>
 </div>
 </div>
 <div class="ulist">

--- a/site/docsource/Get_started.adoc
+++ b/site/docsource/Get_started.adoc
@@ -10,7 +10,7 @@
 ----
 {
     "dependencies": {
-        "bs-platform": "0.9.3" // <1>
+        "bs-platform": "1.0.1" // <1>
     },
     "scripts" : {
         "build" : "bsc -c  main_entry.ml"
@@ -39,7 +39,7 @@ Now you should see a file called `main_entry.js` generated as below:
 [source,js]
 .main_entry.js
 ----
-// GENERATED CODE BY BUCKLESCRIPT VERSION 0.9.3 , PLEASE EDIT WITH CARE
+// GENERATED CODE BY BUCKLESCRIPT VERSION 1.0.1 , PLEASE EDIT WITH CARE
 'use strict';
 
 
@@ -65,7 +65,7 @@ will call `fib`.
 ----------
 {
     "dependencies": {
-        "bs-platform": "0.9.4"
+        "bs-platform": "1.0.1"
     },
     "scripts" : {
         "build" : "bsc -c -bs-main main_entry.ml" // <1>


### PR DESCRIPTION
Neither `0.9.3` nor `0.9.4` included `bs.send.pipe`, the installed version has to be the latest to make the example work.