### PR TITLE
add an option -bs-sort-imports to get a more stable js output

### DIFF
--- a/jscomp/bin/bs_ppx.ml
+++ b/jscomp/bin/bs_ppx.ml
@@ -1293,6 +1293,9 @@ val ref_pop : 'a t -> 'a
 
 val rev_except_last : 'a list -> 'a list * 'a
 
+val sort_via_array :
+  ('a -> 'a -> int) -> 'a list -> 'a list
+
 end = struct
 #1 "ext_list.ml"
 (* Copyright (C) 2015-2016 Bloomberg Finance L.P.
@@ -1643,6 +1646,11 @@ let rev_except_last xs =
     | [ x ] -> acc ,x
     | x :: xs -> aux (x::acc) xs in
   aux [] xs   
+
+let sort_via_array cmp lst =
+  let arr = Array.of_list lst  in
+  Array.sort cmp arr;
+  Array.to_list arr
 
 end
 module Ast_comb : sig 
@@ -3530,6 +3538,7 @@ val tool_name : string
 val is_windows : bool 
 
 val better_errors : bool ref
+val sort_imports : bool ref 
 
 end = struct
 #1 "js_config.ml"
@@ -3760,6 +3769,7 @@ let set_no_any_assert () = no_any_assert := true
 let get_no_any_assert () = !no_any_assert
 
 let better_errors = ref false
+let sort_imports = ref false
     
 let is_windows = 
   match Sys.os_type with 

--- a/jscomp/common/js_config.ml
+++ b/jscomp/common/js_config.ml
@@ -225,6 +225,7 @@ let set_no_any_assert () = no_any_assert := true
 let get_no_any_assert () = !no_any_assert
 
 let better_errors = ref false
+let sort_imports = ref false
     
 let is_windows = 
   match Sys.os_type with 

--- a/jscomp/common/js_config.mli
+++ b/jscomp/common/js_config.mli
@@ -159,3 +159,4 @@ val tool_name : string
 val is_windows : bool 
 
 val better_errors : bool ref
+val sort_imports : bool ref 

--- a/jscomp/ext/ext_list.ml
+++ b/jscomp/ext/ext_list.ml
@@ -346,3 +346,8 @@ let rev_except_last xs =
     | [ x ] -> acc ,x
     | x :: xs -> aux (x::acc) xs in
   aux [] xs   
+
+let sort_via_array cmp lst =
+  let arr = Array.of_list lst  in
+  Array.sort cmp arr;
+  Array.to_list arr

--- a/jscomp/ext/ext_list.mli
+++ b/jscomp/ext/ext_list.mli
@@ -113,3 +113,6 @@ val ref_push : 'a -> 'a t -> unit
 val ref_pop : 'a t -> 'a
 
 val rev_except_last : 'a list -> 'a list * 'a
+
+val sort_via_array :
+  ('a -> 'a -> int) -> 'a list -> 'a list

--- a/jscomp/js_main.ml
+++ b/jscomp/js_main.ml
@@ -94,6 +94,12 @@ let set_noassert () =
 
 
 let buckle_script_flags =
+  (
+    "-bs-sort-imports",
+    Arg.Set Js_config.sort_imports,
+    " Sort the imports by lexical order so the output will be more stable"
+  )
+  ::
   ("-bs-better-errors",
    Arg.Set Js_config.better_errors,
    " Better error message combined with other tools "

--- a/jscomp/lam_compile_group.ml
+++ b/jscomp/lam_compile_group.ml
@@ -394,8 +394,18 @@ let compile  ~filename output_prefix no_export env _sigs
                 meta.env
                 meta.required_modules  
                 (Js_fold_basic.calculate_hard_dependencies js.block)
+              |>
+              (fun x ->
+                 if !Js_config.sort_imports then
+                   Ext_list.sort_via_array
+                     (fun (id1 : Lam_module_ident.t) (id2 : Lam_module_ident.t) ->
+                       String.compare (Lam_module_ident.name id1) (Lam_module_ident.name id2)
+                     ) x
+                 else
+                   x
+              )
             in
-            (* Exporting ... *)
+
             let v = 
               Lam_stats_export.export_to_cmj meta  maybe_pure external_module_ids
                 (if no_export then Ident_map.empty else export_map) 

--- a/jscomp/test/ext_list.js
+++ b/jscomp/test/ext_list.js
@@ -925,6 +925,12 @@ function rev_except_last(xs) {
   };
 }
 
+function sort_via_array(cmp, lst) {
+  var arr = $$Array.of_list(lst);
+  $$Array.sort(cmp, arr);
+  return $$Array.to_list(arr);
+}
+
 exports.filter_map         = filter_map;
 exports.excludes           = excludes;
 exports.exclude_with_fact  = exclude_with_fact;
@@ -964,4 +970,5 @@ exports.ref_empty          = ref_empty;
 exports.ref_push           = ref_push;
 exports.ref_pop            = ref_pop;
 exports.rev_except_last    = rev_except_last;
+exports.sort_via_array     = sort_via_array;
 /* No side effect */


### PR DESCRIPTION
```
bsc -bs-sort-imports xx.ml
```
will sort the name by lexical order, cc @chenglou 