### PR TITLE
provide -bs-syntax-only

### DIFF
--- a/jscomp/bin/bsdep.ml
+++ b/jscomp/bin/bsdep.ml
@@ -1259,6 +1259,7 @@ val is_windows : bool
 val better_errors : bool ref
 val sort_imports : bool ref 
 val dump_js : bool ref
+val syntax_only  : bool ref
 
 end = struct
 #1 "js_config.ml"
@@ -1461,7 +1462,7 @@ let int32 = "Caml_int32"
 let block = "Block"
 let js_primitive = "Js_primitive"
 let module_ = "Caml_module"
-let version = "1.1.2"
+let version = "1.1.2+dev"
 let current_file = ref ""
 let debug_file = ref ""
 
@@ -1498,6 +1499,8 @@ let is_windows =
   | "Win32"
   | "Cygwin"-> true
   | _ -> false
+
+let syntax_only = ref false
 
 end
 module Terminfo : sig 

--- a/jscomp/bin/bsppx.ml
+++ b/jscomp/bin/bsppx.ml
@@ -7568,6 +7568,7 @@ val is_windows : bool
 val better_errors : bool ref
 val sort_imports : bool ref 
 val dump_js : bool ref
+val syntax_only  : bool ref
 
 end = struct
 #1 "js_config.ml"
@@ -7770,7 +7771,7 @@ let int32 = "Caml_int32"
 let block = "Block"
 let js_primitive = "Js_primitive"
 let module_ = "Caml_module"
-let version = "1.1.2"
+let version = "1.1.2+dev"
 let current_file = ref ""
 let debug_file = ref ""
 
@@ -7807,6 +7808,8 @@ let is_windows =
   | "Win32"
   | "Cygwin"-> true
   | _ -> false
+
+let syntax_only = ref false
 
 end
 module Bs_warnings : sig 

--- a/jscomp/bin/compiler.ml
+++ b/jscomp/bin/compiler.ml
@@ -3700,6 +3700,7 @@ val is_windows : bool
 val better_errors : bool ref
 val sort_imports : bool ref 
 val dump_js : bool ref
+val syntax_only  : bool ref
 
 end = struct
 #1 "js_config.ml"
@@ -3902,7 +3903,7 @@ let int32 = "Caml_int32"
 let block = "Block"
 let js_primitive = "Js_primitive"
 let module_ = "Caml_module"
-let version = "1.1.2"
+let version = "1.1.2+dev"
 let current_file = ref ""
 let debug_file = ref ""
 
@@ -3939,6 +3940,8 @@ let is_windows =
   | "Win32"
   | "Cygwin"-> true
   | _ -> false
+
+let syntax_only = ref false
 
 end
 module Bs_warnings : sig 
@@ -34072,29 +34075,31 @@ let print_if ppf flag printer arg =
   arg
 
 let after_parsing_sig ppf sourcefile outputprefix ast  =
-  if not @@ !Js_config.no_warn_unused_bs_attribute then 
-    Bs_ast_invariant.emit_external_warnings.signature Bs_ast_invariant.emit_external_warnings ast ;
-  if Js_config.get_diagnose () then
-    Format.fprintf Format.err_formatter "Building %s@." sourcefile;    
-  let modulename = module_of_filename ppf sourcefile outputprefix in
-  let initial_env = Compmisc.initial_env () in
-  Env.set_unit_name modulename;
-  let tsg = Typemod.type_interface initial_env ast in
-  if !Clflags.dump_typedtree then fprintf ppf "%a@." Printtyped.interface tsg;
-  let sg = tsg.sig_type in
-  if !Clflags.print_types then
-    Printtyp.wrap_printing_env initial_env (fun () ->
-        fprintf std_formatter "%a@."
-          Printtyp.signature (Typemod.simplify_signature sg));
-  ignore (Includemod.signatures initial_env sg sg);
-  Typecore.force_delayed_checks ();
-  Warnings.check_fatal ();
-  if not !Clflags.print_types then begin
-    let sg = Env.save_signature sg modulename (outputprefix ^ ".cmi") in
-    Typemod.save_signature modulename tsg outputprefix sourcefile
-      initial_env sg ;
-  end
-
+  if !Js_config.syntax_only then () else 
+    begin 
+      if not @@ !Js_config.no_warn_unused_bs_attribute then 
+        Bs_ast_invariant.emit_external_warnings.signature Bs_ast_invariant.emit_external_warnings ast ;
+      if Js_config.get_diagnose () then
+        Format.fprintf Format.err_formatter "Building %s@." sourcefile;    
+      let modulename = module_of_filename ppf sourcefile outputprefix in
+      let initial_env = Compmisc.initial_env () in
+      Env.set_unit_name modulename;
+      let tsg = Typemod.type_interface initial_env ast in
+      if !Clflags.dump_typedtree then fprintf ppf "%a@." Printtyped.interface tsg;
+      let sg = tsg.sig_type in
+      if !Clflags.print_types then
+        Printtyp.wrap_printing_env initial_env (fun () ->
+            fprintf std_formatter "%a@."
+              Printtyp.signature (Typemod.simplify_signature sg));
+      ignore (Includemod.signatures initial_env sg sg);
+      Typecore.force_delayed_checks ();
+      Warnings.check_fatal ();
+      if not !Clflags.print_types then begin
+        let sg = Env.save_signature sg modulename (outputprefix ^ ".cmi") in
+        Typemod.save_signature modulename tsg outputprefix sourcefile
+          initial_env sg ;
+      end
+    end
 let interface ppf sourcefile outputprefix =
   Compmisc.init_path false;
   Ocaml_parse.parse_interface ppf sourcefile
@@ -34103,52 +34108,54 @@ let interface ppf sourcefile outputprefix =
   |> after_parsing_sig ppf sourcefile outputprefix 
 
 let after_parsing_impl ppf sourcefile outputprefix ast =
-  if not @@ !Js_config.no_warn_unused_bs_attribute then 
-    Bs_ast_invariant.emit_external_warnings.structure Bs_ast_invariant.emit_external_warnings ast ;
-  if Js_config.get_diagnose () then
-    Format.fprintf Format.err_formatter "Building %s@." sourcefile;      
-  let modulename = Compenv.module_of_filename ppf sourcefile outputprefix in
-  let env = Compmisc.initial_env() in
-  Env.set_unit_name modulename;
-  try
-    let (typedtree, coercion, finalenv, current_signature) =
-      ast 
-      |> Typemod.type_implementation_more sourcefile outputprefix modulename env 
-      |> print_if ppf Clflags.dump_typedtree
-        (fun fmt (ty,co,_,_) -> Printtyped.implementation_with_coercion fmt  (ty,co))
-    in
-    if !Clflags.print_types then begin
-      Warnings.check_fatal ();
-    end else begin
-      (typedtree, coercion)
-      |> Translmod.transl_implementation modulename
-      |> print_if ppf Clflags.dump_rawlambda Printlambda.lambda
-      |> (fun lambda -> 
-          match           
-            Lam_compile_group.lambda_as_module
-              finalenv current_signature 
-              sourcefile  outputprefix lambda  with
-          | e -> e 
-          | exception e -> 
-            (* Save to a file instead so that it will not scare user *)
-            if Js_config.get_diagnose () then
-              begin              
-                let file = "bsc.dump" in
-                Ext_pervasives.with_file_as_chan file
-                  (fun ch -> output_string ch @@             
-                    Printexc.raw_backtrace_to_string (Printexc.get_raw_backtrace ()));
-                Ext_log.err __LOC__
-                  "Compilation fatal error, stacktrace saved into %s when compiling %s"
-                  file sourcefile;
-              end;            
-            raise e             
-        );
-    end;
-    Stypes.dump (Some (outputprefix ^ ".annot"));
-  with x ->
-    Stypes.dump (Some (outputprefix ^ ".annot"));
-    raise x
-
+  if !Js_config.syntax_only then () else 
+    begin
+      if not @@ !Js_config.no_warn_unused_bs_attribute then 
+        Bs_ast_invariant.emit_external_warnings.structure Bs_ast_invariant.emit_external_warnings ast ;
+      if Js_config.get_diagnose () then
+        Format.fprintf Format.err_formatter "Building %s@." sourcefile;      
+      let modulename = Compenv.module_of_filename ppf sourcefile outputprefix in
+      let env = Compmisc.initial_env() in
+      Env.set_unit_name modulename;
+      try
+        let (typedtree, coercion, finalenv, current_signature) =
+          ast 
+          |> Typemod.type_implementation_more sourcefile outputprefix modulename env 
+          |> print_if ppf Clflags.dump_typedtree
+            (fun fmt (ty,co,_,_) -> Printtyped.implementation_with_coercion fmt  (ty,co))
+        in
+        if !Clflags.print_types then begin
+          Warnings.check_fatal ();
+        end else begin
+          (typedtree, coercion)
+          |> Translmod.transl_implementation modulename
+          |> print_if ppf Clflags.dump_rawlambda Printlambda.lambda
+          |> (fun lambda -> 
+              match           
+                Lam_compile_group.lambda_as_module
+                  finalenv current_signature 
+                  sourcefile  outputprefix lambda  with
+              | e -> e 
+              | exception e -> 
+                (* Save to a file instead so that it will not scare user *)
+                if Js_config.get_diagnose () then
+                  begin              
+                    let file = "bsc.dump" in
+                    Ext_pervasives.with_file_as_chan file
+                      (fun ch -> output_string ch @@             
+                        Printexc.raw_backtrace_to_string (Printexc.get_raw_backtrace ()));
+                    Ext_log.err __LOC__
+                      "Compilation fatal error, stacktrace saved into %s when compiling %s"
+                      file sourcefile;
+                  end;            
+                raise e             
+            );
+        end;
+        Stypes.dump (Some (outputprefix ^ ".annot"));
+      with x ->
+        Stypes.dump (Some (outputprefix ^ ".annot"));
+        raise x
+    end
 let implementation ppf sourcefile outputprefix =
   Compmisc.init_path false;
   Ocaml_parse.parse_implementation ppf sourcefile
@@ -34833,6 +34840,11 @@ let set_noassert () =
 
 
 let buckle_script_flags =
+  ("-bs-syntax-only", 
+   Arg.Set Js_config.syntax_only,
+   " only check syntax"
+  )
+  ::
   ("-bs-eval", 
    Arg.String set_eval_string, 
    " (experimental) Set the string to be evaluated, note this flag will be conflicted with -bs-main"

--- a/jscomp/bin/whole_compiler.ml
+++ b/jscomp/bin/whole_compiler.ml
@@ -1259,6 +1259,7 @@ val is_windows : bool
 val better_errors : bool ref
 val sort_imports : bool ref 
 val dump_js : bool ref
+val syntax_only  : bool ref
 
 end = struct
 #1 "js_config.ml"
@@ -1461,7 +1462,7 @@ let int32 = "Caml_int32"
 let block = "Block"
 let js_primitive = "Js_primitive"
 let module_ = "Caml_module"
-let version = "1.1.2"
+let version = "1.1.2+dev"
 let current_file = ref ""
 let debug_file = ref ""
 
@@ -1498,6 +1499,8 @@ let is_windows =
   | "Win32"
   | "Cygwin"-> true
   | _ -> false
+
+let syntax_only = ref false
 
 end
 module Terminfo : sig 
@@ -96937,29 +96940,31 @@ let print_if ppf flag printer arg =
   arg
 
 let after_parsing_sig ppf sourcefile outputprefix ast  =
-  if not @@ !Js_config.no_warn_unused_bs_attribute then 
-    Bs_ast_invariant.emit_external_warnings.signature Bs_ast_invariant.emit_external_warnings ast ;
-  if Js_config.get_diagnose () then
-    Format.fprintf Format.err_formatter "Building %s@." sourcefile;    
-  let modulename = module_of_filename ppf sourcefile outputprefix in
-  let initial_env = Compmisc.initial_env () in
-  Env.set_unit_name modulename;
-  let tsg = Typemod.type_interface initial_env ast in
-  if !Clflags.dump_typedtree then fprintf ppf "%a@." Printtyped.interface tsg;
-  let sg = tsg.sig_type in
-  if !Clflags.print_types then
-    Printtyp.wrap_printing_env initial_env (fun () ->
-        fprintf std_formatter "%a@."
-          Printtyp.signature (Typemod.simplify_signature sg));
-  ignore (Includemod.signatures initial_env sg sg);
-  Typecore.force_delayed_checks ();
-  Warnings.check_fatal ();
-  if not !Clflags.print_types then begin
-    let sg = Env.save_signature sg modulename (outputprefix ^ ".cmi") in
-    Typemod.save_signature modulename tsg outputprefix sourcefile
-      initial_env sg ;
-  end
-
+  if !Js_config.syntax_only then () else 
+    begin 
+      if not @@ !Js_config.no_warn_unused_bs_attribute then 
+        Bs_ast_invariant.emit_external_warnings.signature Bs_ast_invariant.emit_external_warnings ast ;
+      if Js_config.get_diagnose () then
+        Format.fprintf Format.err_formatter "Building %s@." sourcefile;    
+      let modulename = module_of_filename ppf sourcefile outputprefix in
+      let initial_env = Compmisc.initial_env () in
+      Env.set_unit_name modulename;
+      let tsg = Typemod.type_interface initial_env ast in
+      if !Clflags.dump_typedtree then fprintf ppf "%a@." Printtyped.interface tsg;
+      let sg = tsg.sig_type in
+      if !Clflags.print_types then
+        Printtyp.wrap_printing_env initial_env (fun () ->
+            fprintf std_formatter "%a@."
+              Printtyp.signature (Typemod.simplify_signature sg));
+      ignore (Includemod.signatures initial_env sg sg);
+      Typecore.force_delayed_checks ();
+      Warnings.check_fatal ();
+      if not !Clflags.print_types then begin
+        let sg = Env.save_signature sg modulename (outputprefix ^ ".cmi") in
+        Typemod.save_signature modulename tsg outputprefix sourcefile
+          initial_env sg ;
+      end
+    end
 let interface ppf sourcefile outputprefix =
   Compmisc.init_path false;
   Ocaml_parse.parse_interface ppf sourcefile
@@ -96968,52 +96973,54 @@ let interface ppf sourcefile outputprefix =
   |> after_parsing_sig ppf sourcefile outputprefix 
 
 let after_parsing_impl ppf sourcefile outputprefix ast =
-  if not @@ !Js_config.no_warn_unused_bs_attribute then 
-    Bs_ast_invariant.emit_external_warnings.structure Bs_ast_invariant.emit_external_warnings ast ;
-  if Js_config.get_diagnose () then
-    Format.fprintf Format.err_formatter "Building %s@." sourcefile;      
-  let modulename = Compenv.module_of_filename ppf sourcefile outputprefix in
-  let env = Compmisc.initial_env() in
-  Env.set_unit_name modulename;
-  try
-    let (typedtree, coercion, finalenv, current_signature) =
-      ast 
-      |> Typemod.type_implementation_more sourcefile outputprefix modulename env 
-      |> print_if ppf Clflags.dump_typedtree
-        (fun fmt (ty,co,_,_) -> Printtyped.implementation_with_coercion fmt  (ty,co))
-    in
-    if !Clflags.print_types then begin
-      Warnings.check_fatal ();
-    end else begin
-      (typedtree, coercion)
-      |> Translmod.transl_implementation modulename
-      |> print_if ppf Clflags.dump_rawlambda Printlambda.lambda
-      |> (fun lambda -> 
-          match           
-            Lam_compile_group.lambda_as_module
-              finalenv current_signature 
-              sourcefile  outputprefix lambda  with
-          | e -> e 
-          | exception e -> 
-            (* Save to a file instead so that it will not scare user *)
-            if Js_config.get_diagnose () then
-              begin              
-                let file = "bsc.dump" in
-                Ext_pervasives.with_file_as_chan file
-                  (fun ch -> output_string ch @@             
-                    Printexc.raw_backtrace_to_string (Printexc.get_raw_backtrace ()));
-                Ext_log.err __LOC__
-                  "Compilation fatal error, stacktrace saved into %s when compiling %s"
-                  file sourcefile;
-              end;            
-            raise e             
-        );
-    end;
-    Stypes.dump (Some (outputprefix ^ ".annot"));
-  with x ->
-    Stypes.dump (Some (outputprefix ^ ".annot"));
-    raise x
-
+  if !Js_config.syntax_only then () else 
+    begin
+      if not @@ !Js_config.no_warn_unused_bs_attribute then 
+        Bs_ast_invariant.emit_external_warnings.structure Bs_ast_invariant.emit_external_warnings ast ;
+      if Js_config.get_diagnose () then
+        Format.fprintf Format.err_formatter "Building %s@." sourcefile;      
+      let modulename = Compenv.module_of_filename ppf sourcefile outputprefix in
+      let env = Compmisc.initial_env() in
+      Env.set_unit_name modulename;
+      try
+        let (typedtree, coercion, finalenv, current_signature) =
+          ast 
+          |> Typemod.type_implementation_more sourcefile outputprefix modulename env 
+          |> print_if ppf Clflags.dump_typedtree
+            (fun fmt (ty,co,_,_) -> Printtyped.implementation_with_coercion fmt  (ty,co))
+        in
+        if !Clflags.print_types then begin
+          Warnings.check_fatal ();
+        end else begin
+          (typedtree, coercion)
+          |> Translmod.transl_implementation modulename
+          |> print_if ppf Clflags.dump_rawlambda Printlambda.lambda
+          |> (fun lambda -> 
+              match           
+                Lam_compile_group.lambda_as_module
+                  finalenv current_signature 
+                  sourcefile  outputprefix lambda  with
+              | e -> e 
+              | exception e -> 
+                (* Save to a file instead so that it will not scare user *)
+                if Js_config.get_diagnose () then
+                  begin              
+                    let file = "bsc.dump" in
+                    Ext_pervasives.with_file_as_chan file
+                      (fun ch -> output_string ch @@             
+                        Printexc.raw_backtrace_to_string (Printexc.get_raw_backtrace ()));
+                    Ext_log.err __LOC__
+                      "Compilation fatal error, stacktrace saved into %s when compiling %s"
+                      file sourcefile;
+                  end;            
+                raise e             
+            );
+        end;
+        Stypes.dump (Some (outputprefix ^ ".annot"));
+      with x ->
+        Stypes.dump (Some (outputprefix ^ ".annot"));
+        raise x
+    end
 let implementation ppf sourcefile outputprefix =
   Compmisc.init_path false;
   Ocaml_parse.parse_implementation ppf sourcefile
@@ -98545,6 +98552,11 @@ let set_noassert () =
 
 
 let buckle_script_flags =
+  ("-bs-syntax-only", 
+   Arg.Set Js_config.syntax_only,
+   " only check syntax"
+  )
+  ::
   ("-bs-eval", 
    Arg.String set_eval_string, 
    " (experimental) Set the string to be evaluated, note this flag will be conflicted with -bs-main"

--- a/jscomp/common/js_config.ml
+++ b/jscomp/common/js_config.ml
@@ -197,7 +197,7 @@ let int32 = "Caml_int32"
 let block = "Block"
 let js_primitive = "Js_primitive"
 let module_ = "Caml_module"
-let version = "1.1.2"
+let version = "1.1.2+dev"
 let current_file = ref ""
 let debug_file = ref ""
 
@@ -234,3 +234,5 @@ let is_windows =
   | "Win32"
   | "Cygwin"-> true
   | _ -> false
+
+let syntax_only = ref false

--- a/jscomp/common/js_config.mli
+++ b/jscomp/common/js_config.mli
@@ -163,3 +163,4 @@ val is_windows : bool
 val better_errors : bool ref
 val sort_imports : bool ref 
 val dump_js : bool ref
+val syntax_only  : bool ref

--- a/jscomp/js_implementation.ml
+++ b/jscomp/js_implementation.ml
@@ -27,29 +27,31 @@ let print_if ppf flag printer arg =
   arg
 
 let after_parsing_sig ppf sourcefile outputprefix ast  =
-  if not @@ !Js_config.no_warn_unused_bs_attribute then 
-    Bs_ast_invariant.emit_external_warnings.signature Bs_ast_invariant.emit_external_warnings ast ;
-  if Js_config.get_diagnose () then
-    Format.fprintf Format.err_formatter "Building %s@." sourcefile;    
-  let modulename = module_of_filename ppf sourcefile outputprefix in
-  let initial_env = Compmisc.initial_env () in
-  Env.set_unit_name modulename;
-  let tsg = Typemod.type_interface initial_env ast in
-  if !Clflags.dump_typedtree then fprintf ppf "%a@." Printtyped.interface tsg;
-  let sg = tsg.sig_type in
-  if !Clflags.print_types then
-    Printtyp.wrap_printing_env initial_env (fun () ->
-        fprintf std_formatter "%a@."
-          Printtyp.signature (Typemod.simplify_signature sg));
-  ignore (Includemod.signatures initial_env sg sg);
-  Typecore.force_delayed_checks ();
-  Warnings.check_fatal ();
-  if not !Clflags.print_types then begin
-    let sg = Env.save_signature sg modulename (outputprefix ^ ".cmi") in
-    Typemod.save_signature modulename tsg outputprefix sourcefile
-      initial_env sg ;
-  end
-
+  if !Js_config.syntax_only then () else 
+    begin 
+      if not @@ !Js_config.no_warn_unused_bs_attribute then 
+        Bs_ast_invariant.emit_external_warnings.signature Bs_ast_invariant.emit_external_warnings ast ;
+      if Js_config.get_diagnose () then
+        Format.fprintf Format.err_formatter "Building %s@." sourcefile;    
+      let modulename = module_of_filename ppf sourcefile outputprefix in
+      let initial_env = Compmisc.initial_env () in
+      Env.set_unit_name modulename;
+      let tsg = Typemod.type_interface initial_env ast in
+      if !Clflags.dump_typedtree then fprintf ppf "%a@." Printtyped.interface tsg;
+      let sg = tsg.sig_type in
+      if !Clflags.print_types then
+        Printtyp.wrap_printing_env initial_env (fun () ->
+            fprintf std_formatter "%a@."
+              Printtyp.signature (Typemod.simplify_signature sg));
+      ignore (Includemod.signatures initial_env sg sg);
+      Typecore.force_delayed_checks ();
+      Warnings.check_fatal ();
+      if not !Clflags.print_types then begin
+        let sg = Env.save_signature sg modulename (outputprefix ^ ".cmi") in
+        Typemod.save_signature modulename tsg outputprefix sourcefile
+          initial_env sg ;
+      end
+    end
 let interface ppf sourcefile outputprefix =
   Compmisc.init_path false;
   Ocaml_parse.parse_interface ppf sourcefile
@@ -58,52 +60,54 @@ let interface ppf sourcefile outputprefix =
   |> after_parsing_sig ppf sourcefile outputprefix 
 
 let after_parsing_impl ppf sourcefile outputprefix ast =
-  if not @@ !Js_config.no_warn_unused_bs_attribute then 
-    Bs_ast_invariant.emit_external_warnings.structure Bs_ast_invariant.emit_external_warnings ast ;
-  if Js_config.get_diagnose () then
-    Format.fprintf Format.err_formatter "Building %s@." sourcefile;      
-  let modulename = Compenv.module_of_filename ppf sourcefile outputprefix in
-  let env = Compmisc.initial_env() in
-  Env.set_unit_name modulename;
-  try
-    let (typedtree, coercion, finalenv, current_signature) =
-      ast 
-      |> Typemod.type_implementation_more sourcefile outputprefix modulename env 
-      |> print_if ppf Clflags.dump_typedtree
-        (fun fmt (ty,co,_,_) -> Printtyped.implementation_with_coercion fmt  (ty,co))
-    in
-    if !Clflags.print_types then begin
-      Warnings.check_fatal ();
-    end else begin
-      (typedtree, coercion)
-      |> Translmod.transl_implementation modulename
-      |> print_if ppf Clflags.dump_rawlambda Printlambda.lambda
-      |> (fun lambda -> 
-          match           
-            Lam_compile_group.lambda_as_module
-              finalenv current_signature 
-              sourcefile  outputprefix lambda  with
-          | e -> e 
-          | exception e -> 
-            (* Save to a file instead so that it will not scare user *)
-            if Js_config.get_diagnose () then
-              begin              
-                let file = "bsc.dump" in
-                Ext_pervasives.with_file_as_chan file
-                  (fun ch -> output_string ch @@             
-                    Printexc.raw_backtrace_to_string (Printexc.get_raw_backtrace ()));
-                Ext_log.err __LOC__
-                  "Compilation fatal error, stacktrace saved into %s when compiling %s"
-                  file sourcefile;
-              end;            
-            raise e             
-        );
-    end;
-    Stypes.dump (Some (outputprefix ^ ".annot"));
-  with x ->
-    Stypes.dump (Some (outputprefix ^ ".annot"));
-    raise x
-
+  if !Js_config.syntax_only then () else 
+    begin
+      if not @@ !Js_config.no_warn_unused_bs_attribute then 
+        Bs_ast_invariant.emit_external_warnings.structure Bs_ast_invariant.emit_external_warnings ast ;
+      if Js_config.get_diagnose () then
+        Format.fprintf Format.err_formatter "Building %s@." sourcefile;      
+      let modulename = Compenv.module_of_filename ppf sourcefile outputprefix in
+      let env = Compmisc.initial_env() in
+      Env.set_unit_name modulename;
+      try
+        let (typedtree, coercion, finalenv, current_signature) =
+          ast 
+          |> Typemod.type_implementation_more sourcefile outputprefix modulename env 
+          |> print_if ppf Clflags.dump_typedtree
+            (fun fmt (ty,co,_,_) -> Printtyped.implementation_with_coercion fmt  (ty,co))
+        in
+        if !Clflags.print_types then begin
+          Warnings.check_fatal ();
+        end else begin
+          (typedtree, coercion)
+          |> Translmod.transl_implementation modulename
+          |> print_if ppf Clflags.dump_rawlambda Printlambda.lambda
+          |> (fun lambda -> 
+              match           
+                Lam_compile_group.lambda_as_module
+                  finalenv current_signature 
+                  sourcefile  outputprefix lambda  with
+              | e -> e 
+              | exception e -> 
+                (* Save to a file instead so that it will not scare user *)
+                if Js_config.get_diagnose () then
+                  begin              
+                    let file = "bsc.dump" in
+                    Ext_pervasives.with_file_as_chan file
+                      (fun ch -> output_string ch @@             
+                        Printexc.raw_backtrace_to_string (Printexc.get_raw_backtrace ()));
+                    Ext_log.err __LOC__
+                      "Compilation fatal error, stacktrace saved into %s when compiling %s"
+                      file sourcefile;
+                  end;            
+                raise e             
+            );
+        end;
+        Stypes.dump (Some (outputprefix ^ ".annot"));
+      with x ->
+        Stypes.dump (Some (outputprefix ^ ".annot"));
+        raise x
+    end
 let implementation ppf sourcefile outputprefix =
   Compmisc.init_path false;
   Ocaml_parse.parse_implementation ppf sourcefile

--- a/jscomp/js_main.ml
+++ b/jscomp/js_main.ml
@@ -103,6 +103,11 @@ let set_noassert () =
 
 
 let buckle_script_flags =
+  ("-bs-syntax-only", 
+   Arg.Set Js_config.syntax_only,
+   " only check syntax"
+  )
+  ::
   ("-bs-eval", 
    Arg.String set_eval_string, 
    " (experimental) Set the string to be evaluated, note this flag will be conflicted with -bs-main"

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "postinstall": "node scripts/config.js"
   },
   "name": "bs-platform",
-  "version": "1.1.2",
+  "version": "1.1.2+dev",
   "description": "bucklescript compiler, ocaml standard libary by bucklescript and its required runtime support",
   "repository": {
     "type": "git",


### PR DESCRIPTION
jscomp>bsc.exe -bs-syntax-only -dparsetree -bs-eval 'let a = 3'
[
  structure_item (//toplevel//[1,0+0]..[1,0+9])
    Pstr_value Nonrec
    [
     	<def>
        pattern (//toplevel//[1,0+4]..[1,0+5])
          Ppat_var "a" (//toplevel//[1,0+4]..[1,0+5])
        expression (//toplevel//[1,0+8]..[1,0+9])
          Pexp_constant Const_int 3
    ]
]
