### PR TITLE
fix  outprefix problem -o _build/xxx.cmj 

### DIFF
--- a/jscomp/bin/compiler.ml
+++ b/jscomp/bin/compiler.ml
@@ -19390,7 +19390,8 @@ val decorate_deps :
   string option ->
   J.program -> J.deps_program
 
-val string_of_module_id : 
+val string_of_module_id :
+  output_prefix:string ->
   Lam_module_ident.system -> Lam_module_ident.t -> string
 
 end = struct
@@ -19465,7 +19466,7 @@ module S = Js_stmt_make
 
 let (//) = Filename.concat 
 
-let string_of_module_id 
+let string_of_module_id ~output_prefix
     (module_system : Lam_module_ident.system)
     (x : Lam_module_ident.t) : string =
 
@@ -19477,7 +19478,7 @@ let string_of_module_id
         let file = Printf.sprintf "%s.js" id.name in
         let modulename = String.uncapitalize id.name in
         let current_unit_dir =
-          (`Dir (Js_config.get_output_dir module_system !Location.input_name)) in
+          `Dir (Js_config.get_output_dir module_system output_prefix) in
         let rebase dep =
           Ext_filename.node_relative_path  current_unit_dir dep 
         in 
@@ -19601,10 +19602,12 @@ module Js_dump : sig
 
 
 
-val pp_deps_program : 
+val pp_deps_program :
+  output_prefix:string ->
   Lam_module_ident.system -> J.deps_program -> Ext_pp.t -> unit
 
-val dump_deps_program : 
+val dump_deps_program :
+  output_prefix:string ->
   Lam_module_ident.system  -> J.deps_program -> out_channel -> unit
 
 (** 2 functions Only used for debugging *)
@@ -21210,7 +21213,7 @@ let program f cxt   ( x : J.program ) =
   let () = P.force_newline f in
   exports cxt f x.exports
 
-let goog_program f goog_package (x : J.deps_program)  = 
+let goog_program ~output_prefix f goog_package (x : J.deps_program)  = 
   P.newline f ;
   P.string f L.goog_module;
   P.string f "(";
@@ -21224,12 +21227,14 @@ let goog_program f goog_package (x : J.deps_program)  =
       f 
       (List.map 
          (fun x -> 
-            Lam_module_ident.id x, Js_program_loader.string_of_module_id `Goog x)
+            Lam_module_ident.id x,
+            Js_program_loader.string_of_module_id
+              ~output_prefix `Goog x)
          x.modules) 
   in
   program f cxt x.program  
 
-let node_program f ( x : J.deps_program) = 
+let node_program ~output_prefix f ( x : J.deps_program) = 
   let cxt = 
     requires 
       L.require
@@ -21237,15 +21242,16 @@ let node_program f ( x : J.deps_program) =
       f
       (List.map 
          (fun x -> 
-            Lam_module_ident.id x, Js_program_loader.string_of_module_id `NodeJS x)
+            Lam_module_ident.id x,
+            Js_program_loader.string_of_module_id
+              ~output_prefix
+              `NodeJS x)
          x.modules)
   in
   program f cxt x.program  
 
 
-let amd_program f 
-    (  x : J.deps_program)
-  = 
+let amd_program ~output_prefix f (  x : J.deps_program) = 
   P.newline f ; 
   let cxt = Ext_pp_scope.empty in
   P.vgroup f 1 @@ fun _ -> 
@@ -21254,7 +21260,7 @@ let amd_program f
   P.string f (Printf.sprintf "%S" L.exports);
 
   List.iter (fun x ->
-      let s = Js_program_loader.string_of_module_id `AmdJS x in
+      let s = Js_program_loader.string_of_module_id ~output_prefix `AmdJS x in
       P.string f L.comma ;
       P.space f; 
       pp_string f ~utf:true ~quote:(best_string_quote s) s;
@@ -21293,7 +21299,8 @@ let bs_header =
   Js_config.version ^
   " , PLEASE EDIT WITH CARE"
 
-let pp_deps_program 
+let pp_deps_program
+    ~output_prefix
     (kind : Lam_module_ident.system )
     (program  : J.deps_program) (f : Ext_pp.t) = 
   begin
@@ -21306,16 +21313,9 @@ let pp_deps_program
     P.newline f ;    
     ignore (match kind with 
      | `AmdJS -> 
-       amd_program f program
-     (* | `Browser -> *)
-     (*    browser_program f program *)
+       amd_program ~output_prefix f program
      | `NodeJS -> 
-       begin match Sys.getenv "OCAML_AMD_MODULE" with 
-         | exception Not_found -> 
-           node_program f program
-           (* amd_program f program *)
-         | _ -> amd_program f program
-       end 
+       node_program ~output_prefix f program
      | `Goog  -> 
        let goog_package = 
          let v = Js_config.get_module_name () in
@@ -21324,7 +21324,7 @@ let pp_deps_program
            -> v 
          | Some x -> x ^ "." ^ v 
        in 
-       goog_program f goog_package  program
+       goog_program ~output_prefix f goog_package  program
       ) ;
     P.newline f ;
     P.string f (
@@ -21338,11 +21338,12 @@ let pp_deps_program
 let dump_program (x : J.program) oc = 
   ignore (program (P.from_channel oc)  Ext_pp_scope.empty  x )
 
-let dump_deps_program 
+let dump_deps_program
+    ~output_prefix
     kind
     x 
     (oc : out_channel) = 
-  pp_deps_program kind x (P.from_channel oc)
+  pp_deps_program ~output_prefix  kind x (P.from_channel oc)
 
 let string_of_block  block  
   = 
@@ -33315,7 +33316,7 @@ let lambda_as_module
            Filename.dirname filename) // basename         
       in 
       let output_chan chan =         
-        Js_dump.dump_deps_program `NodeJS lambda_output chan in
+        Js_dump.dump_deps_program output_prefix `NodeJS lambda_output chan in
       (if !Js_config.dump_js then output_chan stdout);
       if not @@ !Clflags.dont_write_files then 
         Ext_pervasives.with_file_as_chan 
@@ -33330,12 +33331,12 @@ let lambda_as_module
           basename 
         in
         let output_chan chan  = 
-          Js_dump.dump_deps_program 
+          Js_dump.dump_deps_program ~output_prefix
             module_system 
             lambda_output
             chan in
         (if !Js_config.dump_js then 
-          output_chan stdout);
+          output_chan  stdout);
         if not @@ !Clflags.dont_write_files then 
           Ext_pervasives.with_file_as_chan output_filename output_chan
             

--- a/jscomp/js_dump.mli
+++ b/jscomp/js_dump.mli
@@ -26,10 +26,12 @@
 
 
 
-val pp_deps_program : 
+val pp_deps_program :
+  output_prefix:string ->
   Lam_module_ident.system -> J.deps_program -> Ext_pp.t -> unit
 
-val dump_deps_program : 
+val dump_deps_program :
+  output_prefix:string ->
   Lam_module_ident.system  -> J.deps_program -> out_channel -> unit
 
 (** 2 functions Only used for debugging *)

--- a/jscomp/js_program_loader.ml
+++ b/jscomp/js_program_loader.ml
@@ -68,7 +68,7 @@ module S = Js_stmt_make
 
 let (//) = Filename.concat 
 
-let string_of_module_id 
+let string_of_module_id ~output_prefix
     (module_system : Lam_module_ident.system)
     (x : Lam_module_ident.t) : string =
 #if BS_COMPILER_IN_BROWSER then   
@@ -85,7 +85,7 @@ let string_of_module_id
         let file = Printf.sprintf "%s.js" id.name in
         let modulename = String.uncapitalize id.name in
         let current_unit_dir =
-          (`Dir (Js_config.get_output_dir module_system !Location.input_name)) in
+          `Dir (Js_config.get_output_dir module_system output_prefix) in
         let rebase dep =
           Ext_filename.node_relative_path  current_unit_dir dep 
         in 

--- a/jscomp/js_program_loader.mli
+++ b/jscomp/js_program_loader.mli
@@ -46,5 +46,6 @@ val decorate_deps :
   string option ->
   J.program -> J.deps_program
 
-val string_of_module_id : 
+val string_of_module_id :
+  output_prefix:string ->
   Lam_module_ident.system -> Lam_module_ident.t -> string

--- a/jscomp/jsoo_main.ml
+++ b/jscomp/jsoo_main.ml
@@ -65,7 +65,9 @@ let implementation impl no_export ppf  str  =
   |>  Translmod.transl_implementation modulename
   |> (* Printlambda.lambda ppf *) (fun lam -> 
       let buffer = Buffer.create 1000 in 
-      let () = Js_dump.(pp_deps_program `NodeJS
+      let () = Js_dump.(pp_deps_program
+                          ~output_prefix:"" (* does not matter here *)
+                          `NodeJS
                           (Lam_compile_group.compile ~filename:"" "" no_export
                              !finalenv !types_signature lam)
                           (Ext_pp.from_buffer buffer)) in

--- a/jscomp/lam_compile_group.ml
+++ b/jscomp/lam_compile_group.ml
@@ -452,7 +452,7 @@ let lambda_as_module
            Filename.dirname filename) // basename         
       in 
       let output_chan chan =         
-        Js_dump.dump_deps_program `NodeJS lambda_output chan in
+        Js_dump.dump_deps_program output_prefix `NodeJS lambda_output chan in
       (if !Js_config.dump_js then output_chan stdout);
       if not @@ !Clflags.dont_write_files then 
         Ext_pervasives.with_file_as_chan 
@@ -467,12 +467,12 @@ let lambda_as_module
           basename 
         in
         let output_chan chan  = 
-          Js_dump.dump_deps_program 
+          Js_dump.dump_deps_program ~output_prefix
             module_system 
             lambda_output
             chan in
         (if !Js_config.dump_js then 
-          output_chan stdout);
+          output_chan  stdout);
         if not @@ !Clflags.dont_write_files then 
           Ext_pervasives.with_file_as_chan output_filename output_chan
             


### PR DESCRIPTION
when in script mode the relative js path should take outputprefix into account