### PR TITLE
quick fix for bsc, bsdep path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,6 +72,7 @@ ocaml_src
 .bs_dir_cache
 *.d
 .bsbuild
+build.ninja
 jscomp/bin/bsb
 jscomp/bin/bsc
 jscomp/bin/config_whole_compiler.ml

--- a/bsconfig.json
+++ b/bsconfig.json
@@ -17,12 +17,12 @@
 
         {
             "dir" : "jscomp/test/" ,
-            "resources" : 
-            [
-                "flow_parser_sample.js",
-                "joinClasses.js"
-            ]
-            ,
+            // "resources" : 
+            // [
+            //     "flow_parser_sample.js",
+            //     "joinClasses.js"
+            // ]
+            // ,
 
             "subdirs": [
                 {

--- a/jscomp/Makefile
+++ b/jscomp/Makefile
@@ -76,7 +76,7 @@ CORE_CMXS=$(addprefix core/, $(addsuffix .cmx, $(CORE_SRCS)))
 OTHER_CORE_SRCS= bsppx_main bspack_main jsoo_main  bspp_main js_cmi_datasets \
 		 js_main
 OTHER_CORE_CMXS= $(addprefix core/, $(addsuffix .cmx, $(OTHER_CORE_SRCS)))
-BSB_SRCS=bs_build_schemas bs_build_util bs_dep_infos bs_dir bs_json sexp_lexer sexp_eval  bs_ninja bs_build_ui
+BSB_SRCS= bsb_config bs_build_schemas bs_build_util bs_dep_infos bs_dir bs_json sexp_lexer sexp_eval  bs_ninja bs_build_ui
 
 BSB_CMXS=$(addprefix bsb/, $(addsuffix .cmx, $(BSB_SRCS)))
 MAIN_SRCS= jsgen_main jscmj_main bsb/bsb_main

--- a/jscomp/all.depend
+++ b/jscomp/all.depend
@@ -479,16 +479,17 @@ bsb/bs_build_ui.cmx : ext/string_set.cmx ext/string_map.cmx \
     bsb/bs_json.cmx bsb/bs_dir.cmx bsb/bs_build_schemas.cmx \
     common/binary_cache.cmx bsb/bs_build_ui.cmi
 bsb/bs_build_util.cmx : ext/ext_list.cmx ext/ext_filename.cmx \
-    bsb/bs_build_util.cmi
+    bsb/bsb_config.cmx bsb/bs_build_util.cmi
 bsb/bs_dep_infos.cmx : bsb/bs_dep_infos.cmi
 bsb/bs_dir.cmx : bsb/bs_dir.cmi
 bsb/bs_json.cmx : ext/string_map.cmx ext/ext_array.cmx bsb/bs_json.cmi
 bsb/bs_ninja.cmx : ext/string_set.cmx ext/string_map.cmx ext/literals.cmx \
-    ext/ext_list.cmx ext/ext_filename.cmx bsb/bs_build_util.cmx \
+    ext/ext_list.cmx ext/ext_filename.cmx bsb/bsb_config.cmx \
     bsb/bs_build_ui.cmx common/binary_cache.cmx bsb/bs_ninja.cmi
+bsb/bsb_config.cmx : ext/ext_filename.cmx bsb/bsb_config.cmi
 bsb/bsb_main.cmx : ext/string_map.cmx ext/literals.cmx ext/ext_list.cmx \
     ext/ext_filename.cmx ext/ext_file_pp.cmx ext/ext_array.cmx \
-    bsb/bs_ninja.cmx bsb/bs_json.cmx bsb/bs_dep_infos.cmx \
+    bsb/bsb_config.cmx bsb/bs_ninja.cmx bsb/bs_json.cmx bsb/bs_dep_infos.cmx \
     bsb/bs_build_util.cmx bsb/bs_build_ui.cmx bsb/bs_build_schemas.cmx \
     common/binary_cache.cmx bsb/bsb_main.cmi
 bsb/sexp_eval.cmx : bsb/sexp_lexer.cmx ext/ext_list.cmx
@@ -500,5 +501,6 @@ bsb/bs_dep_infos.cmi :
 bsb/bs_dir.cmi :
 bsb/bs_json.cmi : ext/string_map.cmi
 bsb/bs_ninja.cmi : bsb/bs_build_ui.cmi
+bsb/bsb_config.cmi :
 bsb/bsb_main.cmi :
 bsb/sexp_lexer.cmi :

--- a/jscomp/bin/bsb.d
+++ b/jscomp/bin/bsb.d
@@ -25,6 +25,8 @@ bin/bsb.ml : ext/string_set.ml
 bin/bsb.ml : ext/string_set.mli
 bin/bsb.ml : bsb/bs_build_ui.ml
 bin/bsb.ml : bsb/bs_build_ui.mli
+bin/bsb.ml : bsb/bsb_config.ml
+bin/bsb.ml : bsb/bsb_config.mli
 bin/bsb.ml : ext/ext_list.ml
 bin/bsb.ml : ext/ext_list.mli
 bin/bsb.ml : bsb/bs_build_util.ml

--- a/jscomp/bsb/bs_ninja.ml
+++ b/jscomp/bsb/bs_ninja.ml
@@ -243,8 +243,6 @@ let (++) (us : info) (vs : info) =
 
 
 
-let common_js_prefix =  "lib"//"js" 
-let ocaml_bin_install_prefix = "lib"// "ocaml"
                                
 let handle_file_group oc acc (group: Bs_build_ui.file_group) =
   let handle_module_info  oc  module_name
@@ -258,7 +256,7 @@ let handle_file_group oc acc (group: Bs_build_ui.file_group) =
       | Export_set set ->  String_set.mem module_name set in 
     let emit_build (kind : [`Ml | `Mll | `Re | `Mli | `Rei ])  input  = 
       let filename_sans_extension = Filename.chop_extension input in
-      let input = "$src_root_dir"// input in
+      let input = Bsb_config.proj_rel input in
       let output_file_sans_extension = filename_sans_extension in
       let output_ml = output_file_sans_extension ^ Literals.suffix_ml in 
       let output_mlast = output_file_sans_extension  ^ Literals.suffix_mlast in 
@@ -267,14 +265,14 @@ let handle_file_group oc acc (group: Bs_build_ui.file_group) =
       let output_mliastd = output_file_sans_extension ^ Literals.suffix_mliastd in
       let output_cmi = output_file_sans_extension ^ Literals.suffix_cmi in 
       let output_cmj =  output_file_sans_extension ^ Literals.suffix_cmj in 
-      let output_js = Bs_build_util.proj_rel common_js_prefix
-                      // output_file_sans_extension ^ Literals.suffix_js in
+      let output_js = Bsb_config.proj_rel @@ Bsb_config.common_js_prefix
+                       output_file_sans_extension ^ Literals.suffix_js in
 
       let shadows = 
         let package_flags = 
           [ "bs_package_flags",
             `Overwrite ("-bs-package-output commonjs:"^  
-                       common_js_prefix //Filename.dirname output_cmi)
+                       Bsb_config.common_js_prefix @@ Filename.dirname output_cmi)
             (* FIXME: assume that output is calculated correctly*)
           ]
         in
@@ -329,7 +327,8 @@ let handle_file_group oc acc (group: Bs_build_ui.file_group) =
                   (
                     fun x -> 
                       output_build oc 
-                        ~output:(Bs_build_util.proj_rel @@ "lib" // "ocaml"// Filename.basename x)
+                        ~output:(Bsb_config.proj_rel @@ 
+                                 Bsb_config.ocaml_bin_install_prefix @@ Filename.basename x)
                         ~input:x
                         ~rule:Rules.copy_resources
                   )
@@ -358,7 +357,9 @@ let handle_file_group oc acc (group: Bs_build_ui.file_group) =
           if installable then 
             begin 
               output_build oc 
-                ~output:(Bs_build_util.proj_rel @@ "lib" // "ocaml"// Filename.basename output_cmi)
+                ~output:(Bsb_config.proj_rel @@ 
+                         Bsb_config.ocaml_bin_install_prefix @@ 
+                         Filename.basename output_cmi)
                 ~input:output_cmi
                 ~rule:Rules.copy_resources
             end;

--- a/jscomp/bsb/bsb_config.ml
+++ b/jscomp/bsb/bsb_config.ml
@@ -21,16 +21,20 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
+let (//) = Ext_filename.combine 
 
-(** 
-Use:
-{[
-flag_concat "-ppx" [ppxs]
-]}
+let lib_js = "lib"//"js"
+let lib_ocaml = "lib"// "ocaml"
+let lib_bs = "lib" // "bs"
+let rev_lib_bs = ".."// ".."
+let rev_lib_bs_prefix p = rev_lib_bs // p 
+let common_js_prefix p  =  lib_js  // p 
+let ocaml_bin_install_prefix p = lib_ocaml // p
+
+let lazy_src_root_dir = "$src_root_dir" 
+let proj_rel path = lazy_src_root_dir // path
+                                 
+(** it may not be a bad idea to hard code the binary path 
+    of bsb in configuration time
 *)
-val flag_concat : string -> string list -> string
 
-val convert_path : string -> string
-val convert_file : string -> string
-val mkp : string -> unit
-val get_bsc_bsdep : unit -> string * string 

--- a/jscomp/bsb/bsb_config.mli
+++ b/jscomp/bsb/bsb_config.mli
@@ -22,15 +22,10 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
 
-(** 
-Use:
-{[
-flag_concat "-ppx" [ppxs]
-]}
-*)
-val flag_concat : string -> string list -> string
 
-val convert_path : string -> string
-val convert_file : string -> string
-val mkp : string -> unit
-val get_bsc_bsdep : unit -> string * string 
+val common_js_prefix : string -> string
+val ocaml_bin_install_prefix : string -> string
+val proj_rel : string -> string
+val lib_bs : string
+(* we need generate path relative to [lib/bs] directory in the opposite direction *)
+val rev_lib_bs_prefix : string -> string


### PR DESCRIPTION
Currently, `bsb.exe` assume that `bsc.exe` and `bsdep.exe` are sitting in the same directory as `bsb.exe`.

And it try to figure out the path of `bsc.exe` by using Sys.executable_name.
Note this is not nice that Sys.executable_name does not always return an absolute path, if it returns
a relative path(it can in theory change each time of invocation), we have to adjust it to the working dir `lib/bs`, the worse thing is that if we change the path of `bsb.exe`, it may impact the path, and ninja will recalculate all deps (the ninja behavior is correct)

A simple solution in the future would be just hard code the absolute path of `bsb.exe` during configuration, and we add a check if `bsb.exe`'s path has changed during each execution

Also allow people to configure `bsc.exe` and `bsdep.exe` seems to be a bad idea
@chenglou 
