### PR TITLE
use open_out_bin (open_out does not work with marshal on windows)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,5 @@ build.ninja
 jscomp/bin/bsb
 jscomp/bin/bsc
 jscomp/bin/config_whole_compiler.ml
+lib/bs
+lib/js/jscomp/test

--- a/jscomp/bin/bsb.ml
+++ b/jscomp/bin/bsb.ml
@@ -102,10 +102,10 @@ let finally v action f   =
   | e ->  action v ; e 
 
 let with_file_as_chan filename f = 
-  finally (open_out filename) close_out f 
+  finally (open_out_bin filename) close_out f 
 
 let with_file_as_pp filename f = 
-  finally (open_out filename) close_out
+  finally (open_out_bin filename) close_out
     (fun chan -> 
       let fmt = Format.formatter_of_out_channel chan in
       let v = f  fmt in
@@ -4597,7 +4597,7 @@ let output_ninja
     in  (* make sure -bs-package-name is before -bs-package-output *)
     String.concat " " ( bsc_flags @ init_flags)
   in
-  let oc = open_out (builddir // Literals.build_ninja) in 
+  let oc = open_out_bin (builddir // Literals.build_ninja) in 
   begin 
 
     let () = 

--- a/jscomp/bin/bsb.ml
+++ b/jscomp/bin/bsb.ml
@@ -1478,7 +1478,7 @@ let write_build_cache bsbuild (bs_files : module_info String_map.t)  =
   close_out oc 
 
 let read_build_cache bsbuild : module_info String_map.t = 
-  let ic = open_in bsbuild in 
+  let ic = open_in_bin bsbuild in 
   let buffer = really_input_string ic (String.length module_info_magic_number) in
   assert(buffer = module_info_magic_number); 
   let data : module_info String_map.t = input_value ic in 
@@ -2624,7 +2624,7 @@ let parse_json_from_chan in_chan =
   parse_json lexbuf 
 
 let parse_json_from_file s = 
-  let in_chan = open_in s in 
+  let in_chan = open_in_bin s in 
   let lexbuf = Lexing.from_channel in_chan in 
   match parse_json lexbuf with 
   | exception e -> close_in in_chan ; raise e
@@ -3911,7 +3911,7 @@ let write (fname : string)  (x : t) =
   close_out oc 
 
 let read (fname : string) : t = 
-  let ic = open_in fname in 
+  let ic = open_in_bin fname in  (* Windows binary mode*)
   let buffer = really_input_string ic (String.length magic_number) in
   assert (buffer = magic_number);
   let res : t = input_value ic  in 

--- a/jscomp/bin/bsdep.ml
+++ b/jscomp/bin/bsdep.ml
@@ -4274,7 +4274,7 @@ let write_build_cache bsbuild (bs_files : module_info String_map.t)  =
   close_out oc 
 
 let read_build_cache bsbuild : module_info String_map.t = 
-  let ic = open_in bsbuild in 
+  let ic = open_in_bin bsbuild in 
   let buffer = really_input_string ic (String.length module_info_magic_number) in
   assert(buffer = module_info_magic_number); 
   let data : module_info String_map.t = input_value ic in 

--- a/jscomp/bin/bsdep.ml
+++ b/jscomp/bin/bsdep.ml
@@ -2785,7 +2785,8 @@ let write_ast (type t) ~(fname : string) ~output (kind : t kind) ( pt : t) : uni
     match kind with 
     | Ml -> Config.ast_impl_magic_number
     | Mli -> Config.ast_intf_magic_number in
-  let oc = open_out output in 
+  let oc = open_out_bin output in 
+  (* FIX for windows: output_value: not a binary channel*)
   output_string oc magic ;
   output_value oc fname;
   output_value oc pt;
@@ -2897,10 +2898,10 @@ let finally v action f   =
   | e ->  action v ; e 
 
 let with_file_as_chan filename f = 
-  finally (open_out filename) close_out f 
+  finally (open_out_bin filename) close_out f 
 
 let with_file_as_pp filename f = 
-  finally (open_out filename) close_out
+  finally (open_out_bin filename) close_out
     (fun chan -> 
       let fmt = Format.formatter_of_out_channel chan in
       let v = f  fmt in

--- a/jscomp/bin/bspp.ml
+++ b/jscomp/bin/bspp.ml
@@ -4887,7 +4887,7 @@ let buffer_intervals (intervals : (int * int) list) buf ic oc =
   
 
 let preprocess fn oc = 
-  let ic = open_in fn in 
+  let ic = open_in_bin fn in 
   let lexbuf = Lexing.from_channel ic in 
   let buf = Buffer.create 4096 in 
   Location.init lexbuf fn;

--- a/jscomp/bin/bsppx.ml
+++ b/jscomp/bin/bsppx.ml
@@ -7358,10 +7358,10 @@ let finally v action f   =
   | e ->  action v ; e 
 
 let with_file_as_chan filename f = 
-  finally (open_out filename) close_out f 
+  finally (open_out_bin filename) close_out f 
 
 let with_file_as_pp filename f = 
-  finally (open_out filename) close_out
+  finally (open_out_bin filename) close_out
     (fun chan -> 
       let fmt = Format.formatter_of_out_channel chan in
       let v = f  fmt in

--- a/jscomp/bin/whole_compiler.ml
+++ b/jscomp/bin/whole_compiler.ml
@@ -20696,10 +20696,10 @@ let finally v action f   =
   | e ->  action v ; e 
 
 let with_file_as_chan filename f = 
-  finally (open_out filename) close_out f 
+  finally (open_out_bin filename) close_out f 
 
 let with_file_as_pp filename f = 
-  finally (open_out filename) close_out
+  finally (open_out_bin filename) close_out
     (fun chan -> 
       let fmt = Format.formatter_of_out_channel chan in
       let v = f  fmt in
@@ -22170,7 +22170,8 @@ let write_ast (type t) ~(fname : string) ~output (kind : t kind) ( pt : t) : uni
     match kind with 
     | Ml -> Config.ast_impl_magic_number
     | Mli -> Config.ast_intf_magic_number in
-  let oc = open_out output in 
+  let oc = open_out_bin output in 
+  (* FIX for windows: output_value: not a binary channel*)
   output_string oc magic ;
   output_value oc fname;
   output_value oc pt;

--- a/jscomp/bin/whole_compiler.ml
+++ b/jscomp/bin/whole_compiler.ml
@@ -97687,7 +97687,7 @@ let write_build_cache bsbuild (bs_files : module_info String_map.t)  =
   close_out oc 
 
 let read_build_cache bsbuild : module_info String_map.t = 
-  let ic = open_in bsbuild in 
+  let ic = open_in_bin bsbuild in 
   let buffer = really_input_string ic (String.length module_info_magic_number) in
   assert(buffer = module_info_magic_number); 
   let data : module_info String_map.t = input_value ic in 

--- a/jscomp/bsb/bs_dep_infos.ml
+++ b/jscomp/bsb/bs_dep_infos.ml
@@ -15,7 +15,7 @@ let write (fname : string)  (x : t) =
   close_out oc 
 
 let read (fname : string) : t = 
-  let ic = open_in fname in 
+  let ic = open_in_bin fname in  (* Windows binary mode*)
   let buffer = really_input_string ic (String.length magic_number) in
   assert (buffer = magic_number);
   let res : t = input_value ic  in 

--- a/jscomp/bsb/bs_json.ml
+++ b/jscomp/bsb/bs_json.ml
@@ -670,7 +670,7 @@ let parse_json_from_chan in_chan =
   parse_json lexbuf 
 
 let parse_json_from_file s = 
-  let in_chan = open_in s in 
+  let in_chan = open_in_bin s in 
   let lexbuf = Lexing.from_channel in_chan in 
   match parse_json lexbuf with 
   | exception e -> close_in in_chan ; raise e

--- a/jscomp/bsb/bsb_main.ml
+++ b/jscomp/bsb/bsb_main.ml
@@ -165,7 +165,7 @@ let output_ninja
     in  (* make sure -bs-package-name is before -bs-package-output *)
     String.concat " " ( bsc_flags @ init_flags)
   in
-  let oc = open_out (builddir // Literals.build_ninja) in 
+  let oc = open_out_bin (builddir // Literals.build_ninja) in 
   begin 
 
     let () = 

--- a/jscomp/common/binary_ast.ml
+++ b/jscomp/common/binary_ast.ml
@@ -52,7 +52,8 @@ let write_ast (type t) ~(fname : string) ~output (kind : t kind) ( pt : t) : uni
     match kind with 
     | Ml -> Config.ast_impl_magic_number
     | Mli -> Config.ast_intf_magic_number in
-  let oc = open_out output in 
+  let oc = open_out_bin output in 
+  (* FIX for windows: output_value: not a binary channel*)
   output_string oc magic ;
   output_value oc fname;
   output_value oc pt;

--- a/jscomp/common/binary_cache.ml
+++ b/jscomp/common/binary_cache.ml
@@ -53,7 +53,7 @@ let write_build_cache bsbuild (bs_files : module_info String_map.t)  =
   close_out oc 
 
 let read_build_cache bsbuild : module_info String_map.t = 
-  let ic = open_in bsbuild in 
+  let ic = open_in_bin bsbuild in 
   let buffer = really_input_string ic (String.length module_info_magic_number) in
   assert(buffer = module_info_magic_number); 
   let data : module_info String_map.t = input_value ic in 

--- a/jscomp/core/bspack_main.ml
+++ b/jscomp/core/bspack_main.ml
@@ -266,7 +266,7 @@ let () =
      let out_chan =
        lazy (match !output_file with
            | None -> stdout
-           | Some file -> open_out file)  in
+           | Some file -> open_out_bin file)  in
      let emit_header out_chan = 
        let local_time = Unix.(localtime (gettimeofday ())) in
        (if  !header_option 

--- a/jscomp/core/bspp_main.ml
+++ b/jscomp/core/bspp_main.ml
@@ -16,7 +16,7 @@ let buffer_intervals (intervals : (int * int) list) buf ic oc =
   
 
 let preprocess fn oc = 
-  let ic = open_in fn in 
+  let ic = open_in_bin fn in 
   let lexbuf = Lexing.from_channel ic in 
   let buf = Buffer.create 4096 in 
   Location.init lexbuf fn;

--- a/jscomp/ext/ext_io.ml
+++ b/jscomp/ext/ext_io.ml
@@ -25,7 +25,7 @@
 
 (** on 32 bit , there are 16M limitation *)
 let load_file f =
-  Ext_pervasives.finally (open_in f) close_in begin fun ic ->   
+  Ext_pervasives.finally (open_in_bin f) close_in begin fun ic ->   
     let n = in_channel_length ic in
     let s = Bytes.create n in
     really_input ic s 0 n;
@@ -34,7 +34,7 @@ let load_file f =
 
 
 let rev_lines_of_file file = 
-  Ext_pervasives.finally (open_in file) close_in begin fun chan -> 
+  Ext_pervasives.finally (open_in_bin file) close_in begin fun chan -> 
     let rec loop acc = 
       match input_line chan with
       | line -> loop (line :: acc)

--- a/jscomp/ext/ext_io.ml
+++ b/jscomp/ext/ext_io.ml
@@ -43,6 +43,6 @@ let rev_lines_of_file file =
   end
 
 let write_file f content = 
-  Ext_pervasives.finally (open_out f) close_out begin fun oc ->   
+  Ext_pervasives.finally (open_out_bin f) close_out begin fun oc ->   
     output_string oc content
   end

--- a/jscomp/ext/ext_pervasives.ml
+++ b/jscomp/ext/ext_pervasives.ml
@@ -37,10 +37,10 @@ let finally v action f   =
   | e ->  action v ; e 
 
 let with_file_as_chan filename f = 
-  finally (open_out filename) close_out f 
+  finally (open_out_bin filename) close_out f 
 
 let with_file_as_pp filename f = 
-  finally (open_out filename) close_out
+  finally (open_out_bin filename) close_out
     (fun chan -> 
       let fmt = Format.formatter_of_out_channel chan in
       let v = f  fmt in

--- a/jscomp/test/ext_pervasives.js
+++ b/jscomp/test/ext_pervasives.js
@@ -35,11 +35,11 @@ function $$finally(v, action, f) {
 }
 
 function with_file_as_chan(filename, f) {
-  return $$finally(Pervasives.open_out(filename), Pervasives.close_out, f);
+  return $$finally(Pervasives.open_out_bin(filename), Pervasives.close_out, f);
 }
 
 function with_file_as_pp(filename, f) {
-  return $$finally(Pervasives.open_out(filename), Pervasives.close_out, function (chan) {
+  return $$finally(Pervasives.open_out_bin(filename), Pervasives.close_out, function (chan) {
               var fmt = Format.formatter_of_out_channel(chan);
               var v = Curry._1(f, fmt);
               Format.pp_print_flush(fmt, /* () */0);

--- a/jscomp/test/qcc.js
+++ b/jscomp/test/qcc.js
@@ -1959,7 +1959,7 @@ function main() {
         };
     default:
       var oc = Pervasives.open_out("a.out");
-      inch[0] = Pervasives.open_in(f);
+      inch[0] = Pervasives.open_in_bin(f);
       top(/* () */0);
       elfgen(oc);
       Caml_io.caml_ml_flush(oc);

--- a/jscomp/test/qcc.ml
+++ b/jscomp/test/qcc.ml
@@ -721,7 +721,7 @@ let main () =
   | "-blk" -> doone (block (ref 0, 0)) []
   | f ->
     let oc = open_out "a.out" in
-    inch := open_in f;
+    inch := open_in_bin f;
     top (); elfgen oc;
     close_out oc
 

--- a/jscomp/test/sexpm.js
+++ b/jscomp/test/sexpm.js
@@ -19,7 +19,7 @@ var Format                  = require("../../lib/js/format");
 var Caml_string             = require("../../lib/js/caml_string");
 
 function _with_in(filename, f) {
-  var ic = Pervasives.open_in(filename);
+  var ic = Pervasives.open_in_bin(filename);
   try {
     var x = Curry._1(f, ic);
     (function () {

--- a/jscomp/test/sexpm.ml
+++ b/jscomp/test/sexpm.ml
@@ -14,7 +14,7 @@ type t = [
 type sexp = t
 
 let _with_in filename f =
-  let ic = open_in filename in
+  let ic = open_in_bin filename in
   try
     let x = f ic in
     close_in ic;


### PR DESCRIPTION
Note `output_value`, `input_value` requires channel to be opened in binary mode
https://caml.inria.fr/mantis/view.php?id=5639

TODO:
Reading directories from `sources`, we need convert linux path to platform dependent path,
however, we should only convert it into absolute path for once? (or it maybe not necessary since source files have to be in the project directory)