### PR TITLE
Fix not semantics (#904)

### DIFF
--- a/jscomp/bin/whole_compiler.ml
+++ b/jscomp/bin/whole_compiler.ml
@@ -66979,13 +66979,6 @@ and
     else action ()
   | Caml_not e ->
     expression_desc cxt l f (Bin (Minus, E.one_int_literal, e))
-    (* let action () =  *)
-    (*   P.string f "+!" ; (\* FIXME: priority*\) *)
-    (*   expression 13 cxt f e  *)
-    (* in *)
-    (* if l > 13  *)
-    (* then P.paren_group f 1 action  *)
-    (* else action () *)
 
   | Js_not e ->
     let action () = 

--- a/jscomp/bin/whole_compiler.ml
+++ b/jscomp/bin/whole_compiler.ml
@@ -57336,7 +57336,8 @@ and expression_desc =
      [typeof] is an operator     
   *)
   | Typeof of expression
-  | Not of expression (* !v *)
+  | Caml_not of expression (* 1 - v *)
+  | Js_not of expression (* !v *)
   | String_of_small_int_array of expression 
     (* String.fromCharCode.apply(null, args) *)
     (* Convert JS boolean into OCaml boolean 
@@ -59639,7 +59640,8 @@ class virtual fold =
                  (* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Operator_Precedence 
      [typeof] is an operator     
   *)
-                 (* !v *) (* String.fromCharCode.apply(null, args) *)
+                 (* 1 - v *) (* !v *)
+                 (* String.fromCharCode.apply(null, args) *)
                  (* Convert JS boolean into OCaml boolean 
        like [+true], note this ast talks using js
        terminnology unless explicity stated                       
@@ -59877,7 +59879,8 @@ class virtual fold =
       | Anything_to_number _x -> let o = o#expression _x in o
       | Bool _x -> let o = o#bool _x in o
       | Typeof _x -> let o = o#expression _x in o
-      | Not _x -> let o = o#expression _x in o
+      | Caml_not _x -> let o = o#expression _x in o
+      | Js_not _x -> let o = o#expression _x in o
       | String_of_small_int_array _x -> let o = o#expression _x in o
       | Json_stringify _x -> let o = o#expression _x in o
       | Anything_to_string _x -> let o = o#expression _x in o
@@ -60178,7 +60181,8 @@ let rec no_side_effect_expression_desc (x : J.expression_desc)  =
   (* | Tag_ml_obj _ *)
   | Int_of_boolean _ 
   | J.Anything_to_number _
-  | Not _ 
+  | Caml_not _ 
+  | Js_not _
   | String_of_small_int_array _ 
   | Json_stringify _ 
   | Anything_to_string _ 
@@ -61546,24 +61550,37 @@ let rec or_ ?comment (e1 : t) (e2 : t) =
      it is right that !(x > 3 ) -> x <= 3 *)
 let rec not ({expression_desc; comment} as e : t) : t =
   match expression_desc with 
-  | Bin(EqEqEq , e0,e1)
-    -> {expression_desc = Bin(NotEqEq, e0,e1); comment}
-  | Bin(NotEqEq , e0,e1) -> {expression_desc = Bin(EqEqEq, e0,e1); comment}
-
-  (* Note here the compiled js use primtive comparison only 
-     for *primitive types*, so it is safe to do such optimization,
-     for generic comparison, this does not hold        
-  *)
-  | Bin(Lt, a, b) -> {e with expression_desc = Bin (Ge,a,b)}
-  | Bin(Ge,a,b) -> {e with expression_desc = Bin (Lt,a,b)}          
-  | Bin(Le,a,b) -> {e with expression_desc = Bin (Gt,a,b)}
-  | Bin(Gt,a,b) -> {e with expression_desc = Bin (Le,a,b)}
-
   | Number (Int {i; _}) -> 
     if i <> 0l then caml_false else caml_true
-  | Int_of_boolean  e -> not e
-  | Not e -> e 
-  | x -> {expression_desc = Not e ; comment = None}
+  | Int_of_boolean  x -> js_not  x  e
+  | Caml_not e -> e
+  | Js_not e -> e 
+  (* match expression_desc with  *)
+  (* can still hapen after some optimizations *)
+  | Bin(EqEqEq , e0,e1) 
+    -> {expression_desc = Bin(NotEqEq, e0,e1); comment}
+  | Bin(NotEqEq , e0,e1) -> {expression_desc = Bin(EqEqEq, e0,e1); comment}
+  | Bin(Lt, a, b) -> {e with expression_desc = Bin (Ge,a,b)}
+  | Bin(Ge,a,b) -> {e with expression_desc = Bin (Lt,a,b)}
+  | Bin(Le,a,b) -> {e with expression_desc = Bin (Gt,a,b)}
+  | Bin(Gt,a,b) -> {e with expression_desc = Bin (Le,a,b)}
+  | x -> {expression_desc = Caml_not e ; comment = None}
+and js_not ({expression_desc; comment} as e : t) origin : t =
+  match expression_desc with 
+  | Bin(EqEqEq , e0,e1) 
+    -> 
+    to_ocaml_boolean {expression_desc = Bin(NotEqEq, e0,e1); comment}
+  | Bin(NotEqEq , e0,e1) -> 
+    to_ocaml_boolean {expression_desc = Bin(EqEqEq, e0,e1); comment}
+  | Bin(Lt, a, b) -> 
+    to_ocaml_boolean {e with expression_desc = Bin (Ge,a,b)}
+  | Bin(Ge,a,b) -> 
+    to_ocaml_boolean {e with expression_desc = Bin (Lt,a,b)}
+  | Bin(Le,a,b) -> 
+    to_ocaml_boolean {e with expression_desc = Bin (Gt,a,b)}
+  | Bin(Gt,a,b) -> 
+    to_ocaml_boolean {e with expression_desc = Bin (Le,a,b)}
+  | _ -> {expression_desc = Caml_not origin; comment = None}
 
 let rec ocaml_boolean_under_condition (b : t) =
   match b.expression_desc with 
@@ -61579,11 +61596,15 @@ let rec ocaml_boolean_under_condition (b : t) =
     if x == x' && y == y' then b 
     else {b with expression_desc = Bin(Or,x',y')}
   (** TODO: settle down Not semantics *)
-  | Not u
+  | Caml_not u
+    -> 
+    let u' = ocaml_boolean_under_condition u in 
+    {b with expression_desc = Js_not u'}
+  | Js_not u 
     -> 
     let u' = ocaml_boolean_under_condition u in 
     if u' == u then b 
-    else {b with expression_desc = Not u'} 
+    else {b with expression_desc = Js_not u'} 
   | _ -> b 
   
 let rec econd ?comment (b : t) (t : t) (f : t) : t = 
@@ -61665,7 +61686,10 @@ let rec econd ?comment (b : t) (t : t) (f : t) : t =
     (* the same as above except we revert the [cond] expression *)      
     econd (or_ b (not p1')) t branch_code0
 
-  | Not e, _, _ -> econd ?comment e f t 
+  | Caml_not e, _, _ 
+  | Js_not e, _, _ 
+    ->
+    econd ?comment e f t 
   | Int_of_boolean  b, _, _  -> econd ?comment  b t f
   (* | Bin (And ,{expression_desc = Int_of_boolean b0},b1), _, _  -> *)
   (*   econd ?comment { b with expression_desc = Bin (And , b0,b1)} t f *)
@@ -65228,8 +65252,8 @@ let rec if_ ?comment  ?declaration ?else_ (e : J.expression) (then_ : J.block)  
       exp (E.econd e b a) :: acc 
     | _, [], []                                   
       -> exp e :: acc 
-
-    | Not e, _ , _ :: _
+    | Caml_not e, _ , _ :: _
+    | Js_not e, _ , _ :: _
       -> aux ?comment e else_ then_ acc
     | _, [], _
       ->
@@ -66953,8 +66977,17 @@ and
     if l > 12 
     then P.paren_group f 1 action 
     else action ()
+  | Caml_not e ->
+    expression_desc cxt l f (Bin (Minus, E.one_int_literal, e))
+    (* let action () =  *)
+    (*   P.string f "+!" ; (\* FIXME: priority*\) *)
+    (*   expression 13 cxt f e  *)
+    (* in *)
+    (* if l > 13  *)
+    (* then P.paren_group f 1 action  *)
+    (* else action () *)
 
-  | Not e ->
+  | Js_not e ->
     let action () = 
       P.string f "!" ;
       expression 13 cxt f e 
@@ -67440,7 +67473,8 @@ and statement_desc top cxt f (s : J.statement_desc) : Ext_pp_scope.t =
       | Typeof _
       | Bind _ 
       | Number _
-      | Not _ 
+      | Caml_not _ (* FIXME*)
+      | Js_not _ 
       | Bool _
       | New _ 
       | J.Anything_to_number _ 
@@ -68664,7 +68698,8 @@ class virtual map =
                  (* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Operator_Precedence 
      [typeof] is an operator     
   *)
-                 (* !v *) (* String.fromCharCode.apply(null, args) *)
+                 (* 1 - v *) (* !v *)
+                 (* String.fromCharCode.apply(null, args) *)
                  (* Convert JS boolean into OCaml boolean 
        like [+true], note this ast talks using js
        terminnology unless explicity stated                       
@@ -68917,7 +68952,8 @@ class virtual map =
           let _x = o#expression _x in Anything_to_number _x
       | Bool _x -> let _x = o#bool _x in Bool _x
       | Typeof _x -> let _x = o#expression _x in Typeof _x
-      | Not _x -> let _x = o#expression _x in Not _x
+      | Caml_not _x -> let _x = o#expression _x in Caml_not _x
+      | Js_not _x -> let _x = o#expression _x in Js_not _x
       | String_of_small_int_array _x ->
           let _x = o#expression _x in String_of_small_int_array _x
       | Json_stringify _x -> let _x = o#expression _x in Json_stringify _x

--- a/jscomp/core/Boolean.adoc
+++ b/jscomp/core/Boolean.adoc
@@ -26,7 +26,7 @@ JS operatons which could generate JS booleans
 - `not`
 - Equality comparison
 
-`and`, `or` is fine
+# `and`, `or` is fine
 In JS, `and`, `or` is untyped, but it is a superset of OCaml semantics:
 
 [source,js]
@@ -40,3 +40,7 @@ There is no coersion so `1&&0`, `1&&1`, `0&&1`, `0&&0` are all the same as JS ve
 Same for `or`
 
 but `not` is not the same as `!`, `!` will do the conversion to enforce its result is JS boolean  
+
+# It does not affect `if_then_else` compilation
+
+since JS if is more capable, there is no need do any coercion  

--- a/jscomp/core/j.ml
+++ b/jscomp/core/j.ml
@@ -119,7 +119,8 @@ and expression_desc =
      [typeof] is an operator     
   *)
   | Typeof of expression
-  | Not of expression (* !v *)
+  | Caml_not of expression (* 1 - v *)
+  | Js_not of expression (* !v *)
   | String_of_small_int_array of expression 
     (* String.fromCharCode.apply(null, args) *)
     (* Convert JS boolean into OCaml boolean 

--- a/jscomp/core/js_analyzer.ml
+++ b/jscomp/core/js_analyzer.ml
@@ -118,7 +118,8 @@ let rec no_side_effect_expression_desc (x : J.expression_desc)  =
   (* | Tag_ml_obj _ *)
   | Int_of_boolean _ 
   | J.Anything_to_number _
-  | Not _ 
+  | Caml_not _ 
+  | Js_not _
   | String_of_small_int_array _ 
   | Json_stringify _ 
   | Anything_to_string _ 

--- a/jscomp/core/js_dump.ml
+++ b/jscomp/core/js_dump.ml
@@ -743,13 +743,6 @@ and
     else action ()
   | Caml_not e ->
     expression_desc cxt l f (Bin (Minus, E.one_int_literal, e))
-    (* let action () =  *)
-    (*   P.string f "+!" ; (\* FIXME: priority*\) *)
-    (*   expression 13 cxt f e  *)
-    (* in *)
-    (* if l > 13  *)
-    (* then P.paren_group f 1 action  *)
-    (* else action () *)
 
   | Js_not e ->
     let action () = 

--- a/jscomp/core/js_dump.ml
+++ b/jscomp/core/js_dump.ml
@@ -741,8 +741,17 @@ and
     if l > 12 
     then P.paren_group f 1 action 
     else action ()
+  | Caml_not e ->
+    expression_desc cxt l f (Bin (Minus, E.one_int_literal, e))
+    (* let action () =  *)
+    (*   P.string f "+!" ; (\* FIXME: priority*\) *)
+    (*   expression 13 cxt f e  *)
+    (* in *)
+    (* if l > 13  *)
+    (* then P.paren_group f 1 action  *)
+    (* else action () *)
 
-  | Not e ->
+  | Js_not e ->
     let action () = 
       P.string f "!" ;
       expression 13 cxt f e 
@@ -1228,7 +1237,8 @@ and statement_desc top cxt f (s : J.statement_desc) : Ext_pp_scope.t =
       | Typeof _
       | Bind _ 
       | Number _
-      | Not _ 
+      | Caml_not _ (* FIXME*)
+      | Js_not _ 
       | Bool _
       | New _ 
       | J.Anything_to_number _ 

--- a/jscomp/core/js_fold.ml
+++ b/jscomp/core/js_fold.ml
@@ -134,7 +134,8 @@ class virtual fold =
                  (* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Operator_Precedence 
      [typeof] is an operator     
   *)
-                 (* !v *) (* String.fromCharCode.apply(null, args) *)
+                 (* 1 - v *) (* !v *)
+                 (* String.fromCharCode.apply(null, args) *)
                  (* Convert JS boolean into OCaml boolean 
        like [+true], note this ast talks using js
        terminnology unless explicity stated                       
@@ -372,7 +373,8 @@ class virtual fold =
       | Anything_to_number _x -> let o = o#expression _x in o
       | Bool _x -> let o = o#bool _x in o
       | Typeof _x -> let o = o#expression _x in o
-      | Not _x -> let o = o#expression _x in o
+      | Caml_not _x -> let o = o#expression _x in o
+      | Js_not _x -> let o = o#expression _x in o
       | String_of_small_int_array _x -> let o = o#expression _x in o
       | Json_stringify _x -> let o = o#expression _x in o
       | Anything_to_string _x -> let o = o#expression _x in o

--- a/jscomp/core/js_map.ml
+++ b/jscomp/core/js_map.ml
@@ -147,7 +147,8 @@ class virtual map =
                  (* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Operator_Precedence 
      [typeof] is an operator     
   *)
-                 (* !v *) (* String.fromCharCode.apply(null, args) *)
+                 (* 1 - v *) (* !v *)
+                 (* String.fromCharCode.apply(null, args) *)
                  (* Convert JS boolean into OCaml boolean 
        like [+true], note this ast talks using js
        terminnology unless explicity stated                       
@@ -400,7 +401,8 @@ class virtual map =
           let _x = o#expression _x in Anything_to_number _x
       | Bool _x -> let _x = o#bool _x in Bool _x
       | Typeof _x -> let _x = o#expression _x in Typeof _x
-      | Not _x -> let _x = o#expression _x in Not _x
+      | Caml_not _x -> let _x = o#expression _x in Caml_not _x
+      | Js_not _x -> let _x = o#expression _x in Js_not _x
       | String_of_small_int_array _x ->
           let _x = o#expression _x in String_of_small_int_array _x
       | Json_stringify _x -> let _x = o#expression _x in Json_stringify _x

--- a/jscomp/core/js_stmt_make.ml
+++ b/jscomp/core/js_stmt_make.ml
@@ -208,8 +208,8 @@ let rec if_ ?comment  ?declaration ?else_ (e : J.expression) (then_ : J.block)  
       exp (E.econd e b a) :: acc 
     | _, [], []                                   
       -> exp e :: acc 
-
-    | Not e, _ , _ :: _
+    | Caml_not e, _ , _ :: _
+    | Js_not e, _ , _ :: _
       -> aux ?comment e else_ then_ acc
     | _, [], _
       ->

--- a/jscomp/test/.depend
+++ b/jscomp/test/.depend
@@ -316,6 +316,8 @@ gpr_627_test.cmj : mt.cmi
 gpr_627_test.cmx : mt.cmx
 gpr_658.cmj : ../runtime/js.cmj
 gpr_658.cmx : ../runtime/js.cmx
+gpr_904_test.cmj : mt.cmi
+gpr_904_test.cmx : mt.cmx
 guide_for_ext.cmj :
 guide_for_ext.cmx :
 hamming_test.cmj : ../stdlib/printf.cmi mt.cmi ../stdlib/lazy.cmi \
@@ -386,8 +388,8 @@ js_date.cmj : ../runtime/js.cmj
 js_date.cmx : ../runtime/js.cmx
 js_date_test.cmj : mt.cmi js_date.cmj
 js_date_test.cmx : mt.cmx js_date.cmx
-js_json_test.cmj : ../runtime/js.cmj
-js_json_test.cmx : ../runtime/js.cmx
+js_json_test.cmj : mt.cmi ../runtime/js.cmj
+js_json_test.cmx : mt.cmx ../runtime/js.cmx
 js_obj_test.cmj : mt.cmi
 js_obj_test.cmx : mt.cmx
 js_string_test.cmj : mt.cmi ../runtime/js.cmj
@@ -1184,6 +1186,8 @@ gpr_627_test.cmo : mt.cmi
 gpr_627_test.cmj : mt.cmj
 gpr_658.cmo : ../runtime/js.cmo
 gpr_658.cmj : ../runtime/js.cmj
+gpr_904_test.cmo : mt.cmi
+gpr_904_test.cmj : mt.cmj
 guide_for_ext.cmo :
 guide_for_ext.cmj :
 hamming_test.cmo : ../stdlib/printf.cmi mt.cmi ../stdlib/lazy.cmi \
@@ -1254,8 +1258,8 @@ js_date.cmo : ../runtime/js.cmo
 js_date.cmj : ../runtime/js.cmj
 js_date_test.cmo : mt.cmi js_date.cmo
 js_date_test.cmj : mt.cmj js_date.cmj
-js_json_test.cmo : ../runtime/js.cmo
-js_json_test.cmj : ../runtime/js.cmj
+js_json_test.cmo : mt.cmi ../runtime/js.cmo
+js_json_test.cmj : mt.cmj ../runtime/js.cmj
 js_obj_test.cmo : mt.cmi
 js_obj_test.cmj : mt.cmj
 js_string_test.cmo : mt.cmi ../runtime/js.cmo

--- a/jscomp/test/Makefile
+++ b/jscomp/test/Makefile
@@ -68,7 +68,8 @@ OTHERS := literals a test_ari test_export2 test_internalOO test_obj_simple_ffi t
 	sexpm sexpm_test sexp js_json_test array_subtle_test  \
 	bytes_split_gpr_743_test module_splice_test hello.foo \
 	ffi_splice_test node_path_test js_string_test string_unicode_test node_fs_test\
-	flow_parser_reg_test	utf8_decode_test stream_parser_test condition_compilation_test semver_test update_record_test installation_test app_root_finder derive_projector_test
+	flow_parser_reg_test	utf8_decode_test stream_parser_test condition_compilation_test semver_test update_record_test installation_test app_root_finder derive_projector_test\
+	gpr_904_test
 
 
 

--- a/jscomp/test/flow_parser_reg_test.js
+++ b/jscomp/test/flow_parser_reg_test.js
@@ -7149,7 +7149,7 @@ function identifier_no_dupe_check(param, param$1) {
 
 function strict_post_check(env, strict, simple, id, params) {
   if (strict || !simple) {
-    var env$1 = strict ? with_strict(!env[/* in_strict_mode */5], env) : env;
+    var env$1 = strict ? with_strict(1 - env[/* in_strict_mode */5], env) : env;
     if (id) {
       var match = id[0];
       var name = match[1][/* name */0];
@@ -7692,7 +7692,7 @@ function assignment(env) {
         error$1(env$1, /* IllegalYield */24);
       }
       var delegate = maybe(env$1, /* T_MULT */97);
-      var has_argument = !(+(Curry._2(Parser_env_048[/* token */0], /* None */0, env$1) === /* T_SEMICOLON */7) || Curry._1(Parser_env_048[/* is_implicit_semicolon */6], env$1));
+      var has_argument = 1 - (+(Curry._2(Parser_env_048[/* token */0], /* None */0, env$1) === /* T_SEMICOLON */7) || Curry._1(Parser_env_048[/* is_implicit_semicolon */6], env$1));
       var argument = delegate || has_argument ? /* Some */[Curry._1(assignment, env$1)] : /* None */0;
       var end_loc;
       if (argument) {

--- a/jscomp/test/gpr_904_test.js
+++ b/jscomp/test/gpr_904_test.js
@@ -1,0 +1,68 @@
+'use strict';
+
+var Mt    = require("./mt");
+var Block = require("../../lib/js/block");
+
+var suites = [/* [] */0];
+
+var test_id = [0];
+
+function eq(loc, x, y) {
+  test_id[0] = test_id[0] + 1 | 0;
+  suites[0] = /* :: */[
+    /* tuple */[
+      loc + (" id " + test_id[0]),
+      function () {
+        return /* Eq */Block.__(0, [
+                  x,
+                  y
+                ]);
+      }
+    ],
+    suites[0]
+  ];
+  return /* () */0;
+}
+
+function check_healty(check) {
+  if (!check.a && !check.b) {
+    return 1 - check.c;
+  }
+  else {
+    return /* false */0;
+  }
+}
+
+function basic_not(x) {
+  return 1 - x;
+}
+
+function f(check) {
+  if (check.x) {
+    return check.y;
+  }
+  else {
+    return /* false */0;
+  }
+}
+
+eq('File "gpr_904_test.ml", line 23, characters 5-12', f({
+          x: /* true */1,
+          y: /* false */0
+        }), /* false */0);
+
+eq('File "gpr_904_test.ml", line 26, characters 5-12', check_healty({
+          a: /* false */0,
+          b: /* false */0,
+          c: /* true */1
+        }), /* false */0);
+
+Mt.from_pair_suites("gpr_904_test.ml", suites[0]);
+
+exports.suites       = suites;
+exports.test_id      = test_id;
+exports.eq           = eq;
+exports.check_healty = check_healty;
+exports.basic_not    = basic_not;
+exports.f            = f;
+/*  Not a pure module */

--- a/jscomp/test/gpr_904_test.ml
+++ b/jscomp/test/gpr_904_test.ml
@@ -1,0 +1,30 @@
+
+let suites :  Mt.pair_suites ref  = ref []
+let test_id = ref 0
+let eq loc x y = 
+  incr test_id ; 
+  suites := 
+    (loc ^" id " ^ (string_of_int !test_id), (fun _ -> Mt.Eq(x,y))) :: !suites
+
+let check_healty check =
+  not (check##a )&& not (check##b) && not (check##c)
+
+
+let basic_not x = 
+  not x 
+
+let f check = 
+  check##x && check##y 
+  (* [x && y] in OCaml can be translated to [x && y] in JS  *)
+
+
+let ()
+  = 
+  eq __LOC__ (f [%obj{x=true;y=false}]) false
+
+let () = 
+  eq __LOC__ (check_healty [%obj{a=false;b=false;c=true}]) false
+
+
+
+let () = Mt.from_pair_suites __FILE__ !suites

--- a/jscomp/test/js_json_test.js
+++ b/jscomp/test/js_json_test.js
@@ -1,7 +1,30 @@
 'use strict';
 
 var Caml_builtin_exceptions = require("../../lib/js/caml_builtin_exceptions");
+var Mt                      = require("./mt");
+var Block                   = require("../../lib/js/block");
 var Js_json                 = require("../../lib/js/js_json");
+
+var suites = [/* [] */0];
+
+var test_id = [0];
+
+function eq(loc, x, y) {
+  test_id[0] = test_id[0] + 1 | 0;
+  suites[0] = /* :: */[
+    /* tuple */[
+      loc + (" id " + test_id[0]),
+      function () {
+        return /* Eq */Block.__(0, [
+                  x,
+                  y
+                ]);
+      }
+    ],
+    suites[0]
+  ];
+  return /* () */0;
+}
 
 var v = JSON.parse(' { "x" : [1, 2, 3 ] } ');
 
@@ -12,7 +35,7 @@ if (match[0] !== 2) {
         Caml_builtin_exceptions.assert_failure,
         [
           "js_json_test.ml",
-          26,
+          33,
           9
         ]
       ];
@@ -26,7 +49,7 @@ else {
             Caml_builtin_exceptions.assert_failure,
             [
               "js_json_test.ml",
-              21,
+              28,
               13
             ]
           ];
@@ -39,7 +62,7 @@ else {
                     Caml_builtin_exceptions.assert_failure,
                     [
                       "js_json_test.ml",
-                      19,
+                      26,
                       19
                     ]
                   ];
@@ -56,14 +79,19 @@ else {
           Caml_builtin_exceptions.assert_failure,
           [
             "js_json_test.ml",
-            24,
+            31,
             6
           ]
         ];
   }
 }
 
-console.log(Js_json.test(v, /* Object */2));
+eq('File "js_json_test.ml", line 37, characters 5-12', Js_json.test(v, /* Object */2), /* true */1);
 
-exports.v = v;
+Mt.from_pair_suites("js_json_test.ml", suites[0]);
+
+exports.suites  = suites;
+exports.test_id = test_id;
+exports.eq      = eq;
+exports.v       = v;
 /* v Not a pure module */

--- a/jscomp/test/js_json_test.ml
+++ b/jscomp/test/js_json_test.ml
@@ -1,4 +1,11 @@
 
+let suites :  Mt.pair_suites ref  = ref []
+let test_id = ref 0
+let eq loc x y = 
+  incr test_id ; 
+  suites := 
+    (loc ^" id " ^ (string_of_int !test_id), (fun _ -> Mt.Eq(x,y))) :: !suites
+
 
 let v = Js.Json.parse {| { "x" : [1, 2, 3 ] } |}
 
@@ -27,4 +34,6 @@ let () =
 
 
 let () = 
-  Js.log (Js.Json.test v Object)
+  eq __LOC__  (Js.Json.test v Object) true
+
+let () = Mt.from_pair_suites __FILE__ !suites

--- a/jscomp/test/ocaml_proto_test.js
+++ b/jscomp/test/ocaml_proto_test.js
@@ -7272,7 +7272,7 @@ function compile(proto_definition) {
                                   var has_encoded = first ? Curry._3(f, /* None */0, type_, sc) : Curry._3(f, /* Some */[/* () */0], type_, sc);
                                   line$1(sc, "");
                                   if (first) {
-                                    return !has_encoded;
+                                    return 1 - has_encoded;
                                   }
                                   else {
                                     return /* false */0;

--- a/jscomp/test/stack_comp_test.js
+++ b/jscomp/test/stack_comp_test.js
@@ -304,12 +304,12 @@ assert_('File "stack_comp_test.ml", line 93, characters 10-17', +(s$4[/* c */0] 
 for(var i$4 = 1; i$4 <= 10; ++i$4){
   Stack.push(i$4, s$4);
   assert_('File "stack_comp_test.ml", line 96, characters 12-19', +(List.length(s$4[/* c */0]) === i$4));
-  assert_('File "stack_comp_test.ml", line 97, characters 12-19', s$4[/* c */0] !== /* [] */0);
+  assert_('File "stack_comp_test.ml", line 97, characters 12-19', +(s$4[/* c */0] !== /* [] */0));
 }
 
 for(var i$5 = 10; i$5 >= 1; --i$5){
   assert_('File "stack_comp_test.ml", line 100, characters 12-19', +(List.length(s$4[/* c */0]) === i$5));
-  assert_('File "stack_comp_test.ml", line 101, characters 12-19', s$4[/* c */0] !== /* [] */0);
+  assert_('File "stack_comp_test.ml", line 101, characters 12-19', +(s$4[/* c */0] !== /* [] */0));
   Stack.pop(s$4);
 }
 

--- a/lib/js/caml_int64.js
+++ b/lib/js/caml_int64.js
@@ -307,11 +307,11 @@ function ge(param, param$1) {
 }
 
 function neq(x, y) {
-  return !eq(x, y);
+  return 1 - eq(x, y);
 }
 
 function lt(x, y) {
-  return !ge(x, y);
+  return 1 - ge(x, y);
 }
 
 function gt(x, y) {
@@ -327,7 +327,7 @@ function gt(x, y) {
 }
 
 function le(x, y) {
-  return !gt(x, y);
+  return 1 - gt(x, y);
 }
 
 function to_float(param) {

--- a/lib/js/caml_obj.js
+++ b/lib/js/caml_obj.js
@@ -263,7 +263,7 @@ function caml_equal(_a, _b) {
 }
 
 function caml_notequal(a, b) {
-  return !caml_equal(a, b);
+  return 1 - caml_equal(a, b);
 }
 
 function caml_greaterequal(a, b) {

--- a/lib/js/caml_weak.js
+++ b/lib/js/caml_weak.js
@@ -38,7 +38,7 @@ function caml_weak_get_copy(xs, i) {
 }
 
 function caml_weak_check(xs, i) {
-  return xs[i] !== undefined;
+  return +(xs[i] !== undefined);
 }
 
 var caml_weak_blit = Caml_array.caml_array_blit;

--- a/lib/js/camlinternalFormat.js
+++ b/lib/js/camlinternalFormat.js
@@ -263,7 +263,7 @@ function bprint_char_set(buf, char_set) {
       var match_000 = Char.chr(c - 1 | 0);
       var match_001 = Char.chr(c + 1 | 0);
       if (is_in_char_set(set, c)) {
-        return !(is_in_char_set(set, match_000) && is_in_char_set(set, match_001));
+        return 1 - (is_in_char_set(set, match_000) && is_in_char_set(set, match_001));
       }
       else {
         return /* false */0;

--- a/lib/js/js_json.js
+++ b/lib/js/js_json.js
@@ -24,7 +24,7 @@ function test(x, v) {
         return +(typeof x === "number");
     case 2 : 
         if (x !== null && typeof x === "object") {
-          return !Array.isArray(x);
+          return 1 - +Array.isArray(x);
         }
         else {
           return /* false */0;


### PR DESCRIPTION
Note we still introduce `Js_not` and `Caml_not` since the optimization will introduce JS_not under conditional context