### PR TITLE
[bug fix]use function declaration instead of function expression

### DIFF
--- a/jscomp/bin/whole_compiler.ml
+++ b/jscomp/bin/whole_compiler.ml
@@ -66539,7 +66539,11 @@ type name =
   | No_name
   | Name_top  of Ident.t
   | Name_non_top of Ident.t
-(* TODO: refactoring *)
+
+
+(* TODO: refactoring 
+   Note that {!pp_function} could print both statement and expression when [No_name] is given 
+*)
 let rec pp_function method_
     cxt (f : P.t) ?(name=No_name)  return 
     (l : Ident.t list) (b : J.block) (env : Js_fun_env.t ) =  

--- a/jscomp/core/js_dump.ml
+++ b/jscomp/core/js_dump.ml
@@ -299,9 +299,17 @@ f/122 -->
              if in  use it 
              else check last bumped id, increase it and register
 *)
+type name =
+  | No_name
+  | Name_top  of Ident.t
+  | Name_non_top of Ident.t
 
+
+(* TODO: refactoring 
+   Note that {!pp_function} could print both statement and expression when [No_name] is given 
+*)
 let rec pp_function method_
-    cxt (f : P.t) ?name  return 
+    cxt (f : P.t) ?(name=No_name)  return 
     (l : Ident.t list) (b : J.block) (env : Js_fun_env.t ) =  
   match b, (name,  return)  with 
   | [ {statement_desc =
@@ -313,7 +321,7 @@ let rec pp_function method_
                             (* TODO: need a case to justify it*)
                             call_info = 
                               (Call_builtin_runtime | Call_ml )})}}}],
-    ((_, false) | (None, true))  
+    ((_, false) | (No_name, true))  
     when
       not method_ && 
       Ext_list.for_all2_no_exn (fun a b -> 
@@ -334,16 +342,17 @@ let rec pp_function method_
     in
     let len = List.length l in (* length *)           
     begin match name with 
-      | Some i -> 
+      | Name_top i | Name_non_top i  -> 
         P.string f L.var; 
         P.space f ; 
         let cxt = ident cxt f i in
         P.space f ;
         P.string f L.eq;
         P.space f ;
-
-        optimize len (arity = NA && len <= 8) cxt f v 
-      | None ->
+        let cxt = optimize len (arity = NA && len <= 8) cxt f v in 
+        semi f ;
+        cxt
+      | No_name ->
         if return then 
           begin 
             P.string f L.return ;
@@ -355,9 +364,9 @@ let rec pp_function method_
 
     let set_env : Ident_set.t = (** identifiers will be printed following*)
       match name with 
-      | None ->
+      | No_name ->
         Js_fun_env.get_unbounded env 
-      | Some id -> Ident_set.add id (Js_fun_env.get_unbounded env )
+      | Name_top id | Name_non_top id -> Ident_set.add id (Js_fun_env.get_unbounded env )
     in
     (* the context will be continued after this function *)
     let outer_cxt = Ext_pp_scope.merge set_env cxt in  
@@ -373,17 +382,7 @@ let rec pp_function method_
 
     (* (if not @@ Js_fun_env.is_empty env then *)
     (* pp_comment  f (Some (Js_fun_env.to_string env))) ; *)
-    let action return = 
-      if return then 
-        begin 
-          P.string f L.return ;
-          P.space f
-        end ;
-      P.string f L.function_;
-      P.space f ;
-      (match name with 
-      | None  -> () 
-      | Some x -> ignore (ident inner_cxt f x));
+    let param_body () = 
       if method_ then begin
         let cxt = P.paren_group f 1 (fun _ -> 
             formal_parameter_list inner_cxt  f method_ (List.tl l) env )
@@ -421,33 +420,98 @@ let rec pp_function method_
       end
     in
     let lexical = Js_fun_env.get_lexical_scope env in
+    let enclose  lexical  return = 
+        let handle lexical = 
+          if  Ident_set.is_empty lexical  
+          then
+            begin 
+              if return then 
+                begin 
+                  P.string f L.return ;
+                  P.space f
+                end ;
 
-    let enclose action lexical  return = 
-      if  Ident_set.is_empty lexical  
-      then 
-        action return 
-      else
-        (* print as 
-           {[(function(x,y){...} (x,y))]}           
-        *)
-        let lexical = Ident_set.elements lexical in
-        if return then
-          begin 
-            P.string f L.return ; 
-            P.space f
-          end ;
-        P.string f L.lparen;
-        P.string f L.function_; 
-        P.string f L.lparen;
-        ignore @@ comma_idents inner_cxt f lexical;
-        P.string f L.rparen;
-        P.brace_vgroup f 0  (fun _ -> action true);
-        P.string f L.lparen;
-        ignore @@ comma_idents inner_cxt f lexical;
-        P.string f L.rparen;
-        P.string f L.rparen
+              begin match name with 
+              | No_name -> 
+                P.string f L.function_;
+                P.space f ;
+                param_body ();
+                (* semi f ; *)
+              | Name_non_top x  -> 
+                P.string f L.var ;
+                P.space f ; 
+                ignore @@ ident inner_cxt f x ; 
+                P.space f ;
+                P.string f L.eq ;
+                P.space f ; 
+                P.string f L.function_;
+                P.space f ;
+                param_body ();
+                semi f ;
+              | Name_top x  -> 
+                P.string f L.function_;
+                P.space f ;
+                ignore (ident inner_cxt f x);
+                param_body ();
+              end;
+          end
+          else
+            (* print as 
+               {[(function(x,y){...} (x,y))]}           
+            *)
+            let lexical = Ident_set.elements lexical in
+            (if return then
+               begin 
+                 P.string f L.return ; 
+                 P.space f
+               end
+             else 
+               begin match name with
+                 | No_name -> ()
+                 | Name_non_top name | Name_top name->
+                   P.string f L.var;
+                   P.space f;
+                   ignore @@ ident inner_cxt f name ;
+                   P.space f ;
+                   P.string f L.eq;
+                   P.space f ;
+               end
+            )   
+            ;
+            P.string f L.lparen;
+            P.string f L.function_; 
+            P.string f L.lparen;
+            ignore @@ comma_idents inner_cxt f lexical;
+            P.string f L.rparen;
+            P.brace_vgroup f 0  (fun _ -> 
+                begin 
+                  P.string f L.return ;
+                  P.space f;
+                  P.string f L.function_;
+                  P.space f ;
+                  (match name with 
+                   | No_name  -> () 
+                   | Name_non_top x | Name_top x -> ignore (ident inner_cxt f x));
+                  param_body ()
+                end);
+            P.string f L.lparen;
+            ignore @@ comma_idents inner_cxt f lexical;
+            P.string f L.rparen;
+            P.string f L.rparen;
+            begin match name with 
+              | No_name -> () (* expression *)
+              | _ -> semi f (* has binding, a statement *)
+            end
+        in 
+        begin match name with 
+          | Name_top name | Name_non_top name  when Ident_set.mem name lexical ->
+            (*TODO: when calculating lexical we should not include itself *)
+            let lexical =  (Ident_set.remove name lexical) in
+            handle lexical
+          | _ -> handle lexical 
+        end
     in
-    enclose action lexical return 
+    enclose lexical return 
     ;
     outer_cxt
 
@@ -1125,8 +1189,10 @@ and variable_declaration top cxt f
         statement_desc top cxt f (J.Exp e)
       | _ -> 
         begin match e, top  with 
-          | {expression_desc = Fun (method_, params, b, env ); comment = _}, true -> 
-            pp_function method_ cxt f ~name false params b env 
+          | {expression_desc = Fun (method_, params, b, env ); comment = _}, _ -> 
+            pp_function method_ cxt f 
+              ~name:(if top then Name_top name else Name_non_top name) 
+              false params b env 
           | _, _ -> 
               P.string f L.var;
               P.space f;

--- a/jscomp/test/.depend
+++ b/jscomp/test/.depend
@@ -316,6 +316,10 @@ gpr_627_test.cmj : mt.cmi
 gpr_627_test.cmx : mt.cmx
 gpr_658.cmj : ../runtime/js.cmj
 gpr_658.cmx : ../runtime/js.cmx
+gpr_858_test.cmj : ../stdlib/list.cmi
+gpr_858_test.cmx : ../stdlib/list.cmx
+gpr_858_unit2_test.cmj :
+gpr_858_unit2_test.cmx :
 gpr_904_test.cmj : mt.cmi
 gpr_904_test.cmx : mt.cmx
 guide_for_ext.cmj :
@@ -1186,6 +1190,10 @@ gpr_627_test.cmo : mt.cmi
 gpr_627_test.cmj : mt.cmj
 gpr_658.cmo : ../runtime/js.cmo
 gpr_658.cmj : ../runtime/js.cmj
+gpr_858_test.cmo : ../stdlib/list.cmi
+gpr_858_test.cmj : ../stdlib/list.cmj
+gpr_858_unit2_test.cmo :
+gpr_858_unit2_test.cmj :
 gpr_904_test.cmo : mt.cmi
 gpr_904_test.cmj : mt.cmj
 guide_for_ext.cmo :

--- a/jscomp/test/Makefile
+++ b/jscomp/test/Makefile
@@ -69,7 +69,7 @@ OTHERS := literals a test_ari test_export2 test_internalOO test_obj_simple_ffi t
 	bytes_split_gpr_743_test module_splice_test hello.foo \
 	ffi_splice_test node_path_test js_string_test string_unicode_test node_fs_test\
 	flow_parser_reg_test	utf8_decode_test stream_parser_test condition_compilation_test semver_test update_record_test installation_test app_root_finder derive_projector_test\
-	gpr_904_test
+	gpr_904_test gpr_858_unit2_test
 
 
 

--- a/jscomp/test/a_scope_bug.js
+++ b/jscomp/test/a_scope_bug.js
@@ -14,7 +14,7 @@ function odd(_z) {
   };
 }
 
-var even = odd
+var even = odd;
 
 exports.odd  = odd;
 exports.even = even;

--- a/jscomp/test/caml_format_test.js
+++ b/jscomp/test/caml_format_test.js
@@ -131,7 +131,7 @@ function u(v) {
                 ]), v);
 }
 
-var to_str = Caml_format.caml_int_of_string
+var to_str = Caml_format.caml_int_of_string;
 
 var v = Curry._1(Printf.sprintf(/* Format */[
           /* Int */Block.__(4, [

--- a/jscomp/test/derive_dyntype.js
+++ b/jscomp/test/derive_dyntype.js
@@ -73,7 +73,7 @@ function _t_to_value(value) {
   }
 }
 
-var t_to_value = _t_to_value
+var t_to_value = _t_to_value;
 
 var shape = /* array */[
   "x",

--- a/jscomp/test/ext_pervasives.js
+++ b/jscomp/test/ext_pervasives.js
@@ -272,7 +272,7 @@ function dump(r) {
   }
 }
 
-var dump$1 = dump
+var dump$1 = dump;
 
 function hash_variant(s) {
   var accu = 0;

--- a/jscomp/test/float_test.js
+++ b/jscomp/test/float_test.js
@@ -142,7 +142,7 @@ function from_pairs(ps) {
                 }, ps));
 }
 
-var float_compare = Caml_float.caml_float_compare
+var float_compare = Caml_float.caml_float_compare;
 
 var param = Caml_float.caml_classify_float(3);
 

--- a/jscomp/test/flow_parser_reg_test.js
+++ b/jscomp/test/flow_parser_reg_test.js
@@ -5969,7 +5969,7 @@ function semicolon$1(env) {
   }
 }
 
-var _type = union
+var _type = union;
 
 function annotation(env) {
   if (!env[/* parse_options */20][/* types */4]) {
@@ -8514,7 +8514,7 @@ function _new(env, _finish_fn) {
         var start_loc = Curry._2(Parser_env_048[/* loc */2], /* None */0, env);
         token$4(env, /* T_NEW */42);
         var finish_fn$prime = (function(finish_fn,start_loc){
-        return function (callee, args) {
+        return function finish_fn$prime(callee, args) {
           var match;
           if (args) {
             var match$1 = args[0];

--- a/jscomp/test/gpr_858_test.ml
+++ b/jscomp/test/gpr_858_test.ml
@@ -1,0 +1,21 @@
+let direct = ref []
+let indirect = ref []
+
+
+let () =
+  for i = 0 to 3 do
+    let rec f = function
+      | 0 -> i
+      | -1 -> g (-2) (* to prevent g from been inlined *)
+      | n -> g (pred n)
+    and g = function
+      | 0 -> i
+      | -1 -> f (-2)  (* to prevent f from been inlined *)
+      | n -> f (pred n)
+    in
+    direct   := f i :: !direct;
+    indirect := (fun () -> f i) :: !indirect
+  done;
+  let indirect = List.map (fun f -> f ()) !indirect in
+  let direct = !direct in
+  assert (indirect = direct)

--- a/jscomp/test/gpr_858_unit2_test.js
+++ b/jscomp/test/gpr_858_unit2_test.js
@@ -1,0 +1,41 @@
+'use strict';
+
+var Caml_builtin_exceptions = require("../../lib/js/caml_builtin_exceptions");
+var Curry                   = require("../../lib/js/curry");
+
+var delayed = [function () {
+    return /* () */0;
+  }];
+
+for(var i = 1; i <= 2; ++i){
+  var f = (function(i){
+  return function f(n, j) {
+    if (j !== 0) {
+      var prev = delayed[0];
+      delayed[0] = function () {
+        Curry._1(prev, /* () */0);
+        return f(((n + 1 | 0) + i | 0) - i | 0, j - 1 | 0);
+      };
+      return /* () */0;
+    }
+    else if (i === n) {
+      return 0;
+    }
+    else {
+      throw [
+            Caml_builtin_exceptions.assert_failure,
+            [
+              "gpr_858_unit2_test.ml",
+              6,
+              13
+            ]
+          ];
+    }
+  }
+  }(i));
+  f(0, i);
+}
+
+Curry._1(delayed[0], /* () */0);
+
+/*  Not a pure module */

--- a/jscomp/test/gpr_858_unit2_test.ml
+++ b/jscomp/test/gpr_858_unit2_test.ml
@@ -1,0 +1,12 @@
+
+let () =
+  let delayed = ref (fun () -> ()) in
+  for i = 1 to 2 do
+    let rec f n = function
+      | 0 -> assert (i = n)
+      | j -> delayed :=
+          let prev = !delayed in
+          (fun () -> prev (); f (succ n + i - i) (pred j))
+    in f 0 i
+  done;
+  !delayed ();;

--- a/jscomp/test/hamming_test.js
+++ b/jscomp/test/hamming_test.js
@@ -35,13 +35,13 @@ var n5 = /* int64 */[
   /* lo */5
 ];
 
-var $percent = Caml_int64.mod_
+var $percent = Caml_int64.mod_;
 
-var $star = Caml_int64.mul
+var $star = Caml_int64.mul;
 
-var $slash = Caml_int64.div
+var $slash = Caml_int64.div;
 
-var $plus = Caml_int64.add
+var $plus = Caml_int64.add;
 
 var digit = Caml_format.caml_int64_of_string("1000000000000000000");
 

--- a/jscomp/test/int32_test.js
+++ b/jscomp/test/int32_test.js
@@ -150,7 +150,7 @@ var shift_left_tests = /* tuple */[
   shift_left_tests_001
 ];
 
-var $star$tilde = Caml_int32.imul
+var $star$tilde = Caml_int32.imul;
 
 Mt.from_pair_suites("int32_test.ml", Pervasives.$at(/* :: */[
           /* tuple */[

--- a/jscomp/test/int64_test.js
+++ b/jscomp/test/int64_test.js
@@ -38,7 +38,7 @@ function commutative_add(result, a, b) {
           ]);
 }
 
-var generic_compare = Caml_obj.caml_compare
+var generic_compare = Caml_obj.caml_compare;
 
 var shift_left_tests_000 = $$Array.map(function (i) {
       return Caml_int64.lsl_(/* int64 */[

--- a/jscomp/test/int_hashtbl_test.js
+++ b/jscomp/test/int_hashtbl_test.js
@@ -49,7 +49,7 @@ function g(H) {
   };
 }
 
-var hash = Hashtbl.hash
+var hash = Hashtbl.hash;
 
 function equal(x, y) {
   return +(x === y);

--- a/jscomp/test/qcc.js
+++ b/jscomp/test/qcc.js
@@ -1195,7 +1195,7 @@ function decl(g, _n, _stk) {
     if (Caml_obj.caml_equal(t, tokint)) {
       var top = stk ? stk[0][1] : 0;
       var vars = (function(top){
-      return function (_n, _stk) {
+      return function vars(_n, _stk) {
         while(true) {
           var stk = _stk;
           var n = _n;

--- a/jscomp/test/sexp.js
+++ b/jscomp/test/sexp.js
@@ -8,11 +8,11 @@ var Caml_format             = require("../../lib/js/caml_format");
 var Curry                   = require("../../lib/js/curry");
 var List                    = require("../../lib/js/list");
 
-var equal = Caml_obj.caml_equal
+var equal = Caml_obj.caml_equal;
 
-var compare = Caml_obj.caml_compare
+var compare = Caml_obj.caml_compare;
 
-var hash = Hashtbl.hash
+var hash = Hashtbl.hash;
 
 function of_int(x) {
   return /* `Atom */[

--- a/jscomp/test/swap_test.js
+++ b/jscomp/test/swap_test.js
@@ -938,7 +938,7 @@ var d16_000 = /* Format */[
   "%x"
 ];
 
-var d16_001 = Caml_int32.caml_bswap16
+var d16_001 = Caml_int32.caml_bswap16;
 
 var d16_002 = /* array */[
   /* tuple */[
@@ -967,7 +967,7 @@ var d32_000 = /* Format */[
   "%lx"
 ];
 
-var d32_001 = Caml_int32.caml_int32_bswap
+var d32_001 = Caml_int32.caml_int32_bswap;
 
 var d32_002 = /* array */[
   /* tuple */[

--- a/jscomp/test/test_bytes.js
+++ b/jscomp/test/test_bytes.js
@@ -2,9 +2,9 @@
 
 var Caml_string = require("../../lib/js/caml_string");
 
-var f = Caml_string.bytes_to_string
+var f = Caml_string.bytes_to_string;
 
-var ff = Caml_string.bytes_to_string
+var ff = Caml_string.bytes_to_string;
 
 exports.f  = f;
 exports.ff = ff;

--- a/jscomp/test/test_export2.js
+++ b/jscomp/test/test_export2.js
@@ -2,7 +2,7 @@
 
 var Caml_int32 = require("../../lib/js/caml_int32");
 
-var f = Caml_int32.imul
+var f = Caml_int32.imul;
 
 exports.f = f;
 /* No side effect */

--- a/jscomp/test/test_order.js
+++ b/jscomp/test/test_order.js
@@ -2,7 +2,7 @@
 
 var Caml_obj = require("../../lib/js/caml_obj");
 
-var compare = Caml_obj.caml_int_compare
+var compare = Caml_obj.caml_int_compare;
 
 exports.compare = compare;
 /* No side effect */

--- a/jscomp/test/test_zero_nullable.js
+++ b/jscomp/test/test_zero_nullable.js
@@ -271,9 +271,9 @@ function f8$2(x) {
 
 var u$2 = f8$2(/* None */0);
 
-var f9$2 = Js_primitive.js_from_nullable_def
+var f9$2 = Js_primitive.js_from_nullable_def;
 
-var f10$2 = Js_primitive.js_is_nil_undef
+var f10$2 = Js_primitive.js_is_nil_undef;
 
 var f11$2 = Js_primitive.js_is_nil_undef(3);
 

--- a/jscomp/test/to_string_test.js
+++ b/jscomp/test/to_string_test.js
@@ -4,7 +4,7 @@ var Pervasives = require("../../lib/js/pervasives");
 var Mt         = require("./mt");
 var Block      = require("../../lib/js/block");
 
-var ff = Pervasives.string_of_float
+var ff = Pervasives.string_of_float;
 
 function f(v) {
   return "" + v;

--- a/lib/js/arg.js
+++ b/lib/js/arg.js
@@ -324,7 +324,7 @@ function parse_argv_dynamic($staropt$star, argv, speclist, anonfun, errmsg) {
       }
       try {
         var treat_action = (function(s){
-        return function (param) {
+        return function treat_action(param) {
           switch (param.tag | 0) {
             case 0 : 
                 return Curry._1(param[0], /* () */0);

--- a/lib/js/array.js
+++ b/lib/js/array.js
@@ -435,7 +435,7 @@ function stable_sort(cmp, a) {
 
 var create_matrix = make_matrix;
 
-var concat = Caml_array.caml_array_concat
+var concat = Caml_array.caml_array_concat;
 
 var fast_sort = stable_sort;
 

--- a/lib/js/bytes.js
+++ b/lib/js/bytes.js
@@ -482,11 +482,11 @@ function rcontains_from(s, i, c) {
   }
 }
 
-var compare = Caml_obj.caml_compare
+var compare = Caml_obj.caml_compare;
 
-var unsafe_to_string = Caml_string.bytes_to_string
+var unsafe_to_string = Caml_string.bytes_to_string;
 
-var unsafe_of_string = Caml_string.bytes_of_string
+var unsafe_of_string = Caml_string.bytes_of_string;
 
 exports.make             = make;
 exports.init             = init;

--- a/lib/js/camlinternalFormat.js
+++ b/lib/js/camlinternalFormat.js
@@ -30,7 +30,7 @@ function add_in_char_set(char_set, c) {
   return /* () */0;
 }
 
-var freeze_char_set = Bytes.to_string
+var freeze_char_set = Bytes.to_string;
 
 function rev_char_set(char_set) {
   var char_set$prime = Bytes.make(32, /* "\000" */0);
@@ -3489,7 +3489,7 @@ function make_printf(_k, o, _acc, _fmt) {
             if (match.tag) {
               var rest$7 = fmt[1];
               var k$prime = (function(k,acc,rest$7){
-              return function (koc, kacc) {
+              return function k$prime(koc, kacc) {
                 return make_printf(k, koc, /* Acc_formatting_gen */Block.__(1, [
                               acc,
                               /* Acc_open_box */Block.__(1, [kacc])
@@ -3505,7 +3505,7 @@ function make_printf(_k, o, _acc, _fmt) {
             else {
               var rest$8 = fmt[1];
               var k$prime$1 = (function(k,acc,rest$8){
-              return function (koc, kacc) {
+              return function k$prime$1(koc, kacc) {
                 return make_printf(k, koc, /* Acc_formatting_gen */Block.__(1, [
                               acc,
                               /* Acc_open_tag */Block.__(0, [kacc])

--- a/lib/js/digest.js
+++ b/lib/js/digest.js
@@ -56,7 +56,7 @@ function file(filename) {
   
 }
 
-var output = Pervasives.output_string
+var output = Pervasives.output_string;
 
 function input(chan) {
   return Pervasives.really_input_string(chan, 16);

--- a/lib/js/format.js
+++ b/lib/js/format.js
@@ -623,7 +623,7 @@ function pp_print_as_size(state, size, s) {
   }
 }
 
-var pp_print_as = pp_print_as_size
+var pp_print_as = pp_print_as_size;
 
 function pp_print_string(state, s) {
   return pp_print_as(state, s.length, s);

--- a/lib/js/gc.js
+++ b/lib/js/gc.js
@@ -265,9 +265,9 @@ function delete_alarm(a) {
   return /* () */0;
 }
 
-var finalise = Caml_gc.caml_final_register
+var finalise = Caml_gc.caml_final_register;
 
-var finalise_release = Caml_gc.caml_final_release
+var finalise_release = Caml_gc.caml_final_release;
 
 exports.print_stat       = print_stat;
 exports.allocated_bytes  = allocated_bytes;

--- a/lib/js/hashtbl.js
+++ b/lib/js/hashtbl.js
@@ -863,7 +863,7 @@ function Make(H) {
         ];
 }
 
-var seeded_hash_param = Caml_hash.caml_hash
+var seeded_hash_param = Caml_hash.caml_hash;
 
 exports.create            = create;
 exports.clear             = clear;

--- a/lib/js/int32.js
+++ b/lib/js/int32.js
@@ -28,7 +28,7 @@ function to_string(n) {
   return Caml_format.caml_int32_format("%d", n);
 }
 
-var compare = Caml_obj.caml_int32_compare
+var compare = Caml_obj.caml_int32_compare;
 
 var zero = 0;
 

--- a/lib/js/int64.js
+++ b/lib/js/int64.js
@@ -40,7 +40,7 @@ function to_string(n) {
   return Caml_format.caml_int64_format("%d", n);
 }
 
-var compare = Caml_int64.compare
+var compare = Caml_int64.compare;
 
 var zero = /* int64 */[
   /* hi */0,

--- a/lib/js/nativeint.js
+++ b/lib/js/nativeint.js
@@ -33,7 +33,7 @@ function to_string(n) {
   return Caml_format.caml_nativeint_format("%d", n);
 }
 
-var compare = Caml_obj.caml_nativeint_compare
+var compare = Caml_obj.caml_nativeint_compare;
 
 var zero = 0;
 

--- a/lib/js/parsing.js
+++ b/lib/js/parsing.js
@@ -217,7 +217,7 @@ function parse_error() {
   return /* () */0;
 }
 
-var set_trace = Caml_parser.caml_set_parser_trace
+var set_trace = Caml_parser.caml_set_parser_trace;
 
 exports.symbol_start         = symbol_start;
 exports.symbol_end           = symbol_end;

--- a/lib/js/pervasives.js
+++ b/lib/js/pervasives.js
@@ -558,11 +558,11 @@ var min_float = Number.MIN_VALUE;
 
 var epsilon_float = 2.220446049250313e-16;
 
-var flush = Caml_io.caml_ml_flush
+var flush = Caml_io.caml_ml_flush;
 
-var output_char = Caml_io.caml_ml_output_char
+var output_char = Caml_io.caml_ml_output_char;
 
-var output_byte = Caml_io.caml_ml_output_char
+var output_byte = Caml_io.caml_ml_output_char;
 
 function output_binary_int(_, _$1) {
   return function () {
@@ -594,9 +594,9 @@ function set_binary_mode_out(_, _$1) {
           }();
 }
 
-var input_char = Caml_io.caml_ml_input_char
+var input_char = Caml_io.caml_ml_input_char;
 
-var input_byte = Caml_io.caml_ml_input_char
+var input_byte = Caml_io.caml_ml_input_char;
 
 function input_binary_int() {
   return function () {

--- a/lib/js/printexc.js
+++ b/lib/js/printexc.js
@@ -533,7 +533,7 @@ var Slot = [
   format_backtrace_slot
 ];
 
-var convert_raw_backtrace_slot = Caml_backtrace.caml_convert_raw_backtrace_slot
+var convert_raw_backtrace_slot = Caml_backtrace.caml_convert_raw_backtrace_slot;
 
 exports.to_string                      = to_string;
 exports.print                          = print;

--- a/lib/js/scanf.js
+++ b/lib/js/scanf.js
@@ -1636,7 +1636,7 @@ function make_scanf(ib, _fmt, readers) {
                     var match = stopper_of_formatting_lit(rest[0]);
                     var stp = match[0];
                     var scan = (function(stp){
-                    return function (width, _, ib) {
+                    return function scan(width, _, ib) {
                       return scan_string(/* Some */[stp], width, ib);
                     }
                     }(stp));
@@ -1681,7 +1681,7 @@ function make_scanf(ib, _fmt, readers) {
         case 4 : 
             var c$2 = CamlinternalFormat.char_of_iconv(fmt[0]);
             var scan$5 = (function(c$2){
-            return function (width, _, ib) {
+            return function scan$5(width, _, ib) {
               return scan_int_conv(c$2, width, ib);
             }
             }(c$2));
@@ -1693,7 +1693,7 @@ function make_scanf(ib, _fmt, readers) {
         case 5 : 
             var c$3 = CamlinternalFormat.char_of_iconv(fmt[0]);
             var scan$6 = (function(c$3){
-            return function (width, _, ib) {
+            return function scan$6(width, _, ib) {
               return scan_int_conv(c$3, width, ib);
             }
             }(c$3));
@@ -1705,7 +1705,7 @@ function make_scanf(ib, _fmt, readers) {
         case 6 : 
             var c$4 = CamlinternalFormat.char_of_iconv(fmt[0]);
             var scan$7 = (function(c$4){
-            return function (width, _, ib) {
+            return function scan$7(width, _, ib) {
               return scan_int_conv(c$4, width, ib);
             }
             }(c$4));
@@ -1717,7 +1717,7 @@ function make_scanf(ib, _fmt, readers) {
         case 7 : 
             var c$5 = CamlinternalFormat.char_of_iconv(fmt[0]);
             var scan$8 = (function(c$5){
-            return function (width, _, ib) {
+            return function scan$8(width, _, ib) {
               return scan_int_conv(c$5, width, ib);
             }
             }(c$5));

--- a/lib/js/string.js
+++ b/lib/js/string.js
@@ -179,7 +179,7 @@ function uncapitalize(s) {
   return Caml_string.bytes_to_string(Bytes.uncapitalize(Caml_string.bytes_of_string(s)));
 }
 
-var compare = Caml_string.caml_string_compare
+var compare = Caml_string.caml_string_compare;
 
 var fill = Bytes.fill;
 

--- a/lib/js/unix.js
+++ b/lib/js/unix.js
@@ -1448,7 +1448,7 @@ function environment() {
           }();
 }
 
-var getenv = Caml_sys.caml_sys_getenv
+var getenv = Caml_sys.caml_sys_getenv;
 
 function putenv(_, _$1) {
   return function () {
@@ -1534,9 +1534,9 @@ function close() {
           }();
 }
 
-var in_channel_of_descr = Caml_io.caml_ml_open_descriptor_in
+var in_channel_of_descr = Caml_io.caml_ml_open_descriptor_in;
 
-var out_channel_of_descr = Caml_io.caml_ml_open_descriptor_out
+var out_channel_of_descr = Caml_io.caml_ml_open_descriptor_out;
 
 function descr_of_in_channel() {
   return function () {

--- a/lib/js/weak.js
+++ b/lib/js/weak.js
@@ -252,7 +252,7 @@ function Make(H) {
           if (newlen > oldlen) {
             var newt = create(newlen);
             var add_weak = (function(newt){
-            return function (ob, oh, oi) {
+            return function add_weak(ob, oh, oi) {
               var setter = function (nb, ni, _) {
                 return Caml_weak.caml_weak_blit(ob, oi, nb, ni, 1);
               };
@@ -482,17 +482,17 @@ function Make(H) {
         ];
 }
 
-var create = Caml_weak.caml_weak_create
+var create = Caml_weak.caml_weak_create;
 
-var set = Caml_weak.caml_weak_set
+var set = Caml_weak.caml_weak_set;
 
-var get = Caml_weak.caml_weak_get
+var get = Caml_weak.caml_weak_get;
 
-var get_copy = Caml_weak.caml_weak_get_copy
+var get_copy = Caml_weak.caml_weak_get_copy;
 
-var check = Caml_weak.caml_weak_check
+var check = Caml_weak.caml_weak_check;
 
-var blit = Caml_weak.caml_weak_blit
+var blit = Caml_weak.caml_weak_blit;
 
 exports.create   = create;
 exports.length   = length;


### PR DESCRIPTION
The rational is that for loop closures, due to function hoisting, it will work better with lexical scope.

```
for(let i = 0; i < 10; ++i){
   var self = function self(){ if(i%2=0){self()}
}
```

Fix two issues:

1. lexical captured variables should not include itself (we exclude it)
```
var f = function (f,i){ ...}(f,i) 
```
The above code does not make sense, instead
```
var f = function(i){ return function f() {} } {i}
```
Note that we can improve it, the inner `f` only make sense for recursive function
2. Add a unit test for such edge cases

Now `pp_function` will dump either statement or expression depend on whether bindings are given or not