### PR TITLE
[bsb] Support refmt path

### DIFF
--- a/jscomp/bsb/bsb_default.ml
+++ b/jscomp/bsb/bsb_default.ml
@@ -1,5 +1,5 @@
 (* Copyright (C) 2015-2016 Bloomberg Finance L.P.
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
@@ -17,7 +17,7 @@
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
@@ -37,8 +37,8 @@ let get_package_name () = !package_name
 
 
 let bsc_flags = ref []
-let get_bsc_flags () = !bsc_flags 
-let set_bsc_flags s = bsc_flags := get_list_string s 
+let get_bsc_flags () = !bsc_flags
+let set_bsc_flags s = bsc_flags := get_list_string s
 
 
 
@@ -46,38 +46,46 @@ let set_bsc_flags s = bsc_flags := get_list_string s
 let bs_dependencies = ref []
 let get_bs_dependencies () = !bs_dependencies
 let set_bs_dependencies  s =
-  bs_dependencies := get_list_string s 
+  bs_dependencies := get_list_string s
 
 
 let bs_external_includes = ref []
-let set_bs_external_includes s = 
+let set_bs_external_includes s =
   bs_external_includes := List.map Bsb_build_util.convert_and_resolve_path (get_list_string s )
 let get_bs_external_includes () = !bs_external_includes
 
 
 let ocamllex =  ref  "ocamllex.opt"
-let set_ocamllex s = ocamllex := Bsb_build_util.convert_and_resolve_file s 
-let get_ocamllex () = !ocamllex 
+let set_ocamllex s = ocamllex := Bsb_build_util.convert_and_resolve_file s
+let get_ocamllex () = !ocamllex
+
+(* Magic path resolution:
+foo/bar => /absolute/path/to/projectRoot/node_modules/foo.bar
+/foo/bar => /foo/bar
+./foo/bar => /absolute/path/to/projectRoot/./foo/bar *)
+let resolve_bsb_magic_path ~cwd ~desc p =
+  if Filename.is_relative p && String.unsafe_get p 0 <> '.' then
+    let name = String.sub p 0 (String.index p '/') in
+    let package = (Bs_pkg.resolve_bs_package ~cwd name) in
+    match package with
+    | None -> failwith (name ^ " not found when resolving " ^ desc)
+    | Some package -> Bsb_build_util.convert_and_resolve_path (Filename.dirname package // p)
+  else
+    Bsb_build_util.convert_and_resolve_path p
+
+let refmt = ref "refmt"
+let get_refmt () = !refmt
+let set_refmt ~cwd p = refmt := resolve_bsb_magic_path ~cwd ~desc:"refmt" p
 
 
 let ppx_flags = ref []
 let get_ppx_flags () = !ppx_flags
-let set_ppx_flags ~cwd s = 
-  let s = 
+let set_ppx_flags ~cwd s =
+  let s =
     s (* TODO: unix conversion *)
-    |> get_list_string 
-    |> List.map (fun x -> 
-        if x = "" then failwith "invalid ppx, empty string found"
-        else 
-        if Filename.is_relative x &&  String.unsafe_get x 0 <> '.' then 
-          let name = String.sub x 0 ( String.index x '/') in
-          let package = (Bs_pkg.resolve_bs_package ~cwd name ) in
-          match package with
-          | None ->
-            failwith (name ^ "not found when resolving ppx")
-          | Some package
-            -> Bsb_build_util.convert_and_resolve_path (Filename.dirname package // x) 
-        else 
-          Bsb_build_util.convert_and_resolve_path x 
-      ) in 
+    |> get_list_string
+    |> List.map (fun p ->
+        if p = "" then failwith "invalid ppx, empty string found"
+        else resolve_bsb_magic_path ~cwd ~desc:"ppx" p
+      ) in
   ppx_flags := s

--- a/jscomp/bsb/bsb_default.mli
+++ b/jscomp/bsb/bsb_default.mli
@@ -1,5 +1,5 @@
 (* Copyright (C) 2015-2016 Bloomberg Finance L.P.
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
@@ -17,33 +17,35 @@
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
 
 
-val set_ocamllex : string -> unit 
-val get_ocamllex : unit -> string 
+val set_ocamllex : string -> unit
+val get_ocamllex : unit -> string
 
 
 
-val set_bs_external_includes : Bsb_json.t array -> unit 
-val get_bs_external_includes : unit -> string list 
+val set_bs_external_includes : Bsb_json.t array -> unit
+val get_bs_external_includes : unit -> string list
 
 
 
 
-val set_bsc_flags : Bsb_json.t array -> unit 
+val set_bsc_flags : Bsb_json.t array -> unit
 val get_bsc_flags : unit -> string list
 
-val set_ppx_flags : cwd:string -> Bsb_json.t array -> unit 
+val set_ppx_flags : cwd:string -> Bsb_json.t array -> unit
 val get_ppx_flags : unit -> string list
 
 val set_package_name : string -> unit
-val get_package_name : unit -> string option 
+val get_package_name : unit -> string option
+
+val set_refmt : cwd:string -> string -> unit
+val get_refmt : unit -> string
 
 
-val get_bs_dependencies : unit  -> string list 
+val get_bs_dependencies : unit  -> string list
 val set_bs_dependencies : Bsb_json.t array  -> unit
-

--- a/jscomp/bsb/bsb_gen.ml
+++ b/jscomp/bsb/bsb_gen.ml
@@ -36,6 +36,7 @@ let output_ninja
     bsc_flags
     ppx_flags
     bs_dependencies
+    refmt
   =
   let ppx_flags = Bsb_build_util.flag_concat "-ppx" ppx_flags in
   let bs_groups, source_dirs,static_resources  =
@@ -82,6 +83,7 @@ let output_ninja
           "bsc_flags", bsc_flags ;
           "ppx_flags", ppx_flags;
           "bs_package_includes", bs_package_includes;
+          "refmt", refmt;
           (* "builddir", builddir; we should not have it set, since it's correct here *)
 
         ]

--- a/jscomp/bsb/bsb_gen.mli
+++ b/jscomp/bsb/bsb_gen.mli
@@ -1,5 +1,5 @@
 (* Copyright (C) 2015-2016 Bloomberg Finance L.P.
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
@@ -17,13 +17,13 @@
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
 
 
-val output_ninja : 
+val output_ninja :
   builddir:string ->
   cwd:string ->
   string ->
@@ -32,4 +32,8 @@ val output_ninja :
   string ->
   string list ->
   Bsb_build_ui.file_group list ->
-  string list -> string list -> string list -> unit
+  string list ->
+  string list ->
+  string list ->
+  string ->
+  unit

--- a/jscomp/bsb/bsb_ninja.ml
+++ b/jscomp/bsb/bsb_ninja.ml
@@ -78,7 +78,7 @@ module Rules = struct
         "build_ast"
      let build_ast_from_reason_impl =
        define
-         ~command:"${bsc} -pp refmt ${ppx_flags} ${bsc_flags} -c -o ${out} -bs-syntax-only -bs-binary-ast -impl ${in}"
+         ~command:"${bsc} -pp ${refmt} ${ppx_flags} ${bsc_flags} -c -o ${out} -bs-syntax-only -bs-binary-ast -impl ${in}"
          "build_ast_from_reason_impl"
 
      let build_ast_from_reason_intf =
@@ -86,7 +86,7 @@ module Rules = struct
           because it need to be ppxed by bucklescript
        *)
        define
-         ~command:"${bsc} -pp refmt ${ppx_flags} ${bsc_flags} -c -o ${out} -bs-syntax-only -bs-binary-ast -intf ${in}"
+         ~command:"${bsc} -pp ${refmt} ${ppx_flags} ${bsc_flags} -c -o ${out} -bs-syntax-only -bs-binary-ast -intf ${in}"
          "build_ast_from_reason_intf"
 
      let build_deps =


### PR DESCRIPTION
This makes refmt resolve the same way ppx resolve. See the path resolution comment.
One difference is that this defaults to refmt rather than nothing. Not sure about this behavior.