### PR TITLE
1. provide amdjs and google module support in the build system 

### DIFF
--- a/bsconfig.json
+++ b/bsconfig.json
@@ -3,6 +3,10 @@
     "version": "1.2.2",
     "ocaml-config" : 
     {
+        "package-specs": [
+            "commonjs"
+            // ,"amdjs"
+        ],
         "bs-external-includes" : [
             "jscomp/runtime", 
             "jscomp/stdlib", 

--- a/docs/docson/build-schema.json
+++ b/docs/docson/build-schema.json
@@ -8,24 +8,12 @@
                 "goog"
             ]
         },
-        "module-output": {
-            "type": "array",
-            "items": [
-                {
-                    "$ref": "#/definitions/module-format"
-                },
-                {
-                    "type": "string",
-                    "description": "output path, if not set, it will be `lib/js/commonjs`, `lib/js/amdjs` or `lib/js/goog` "
-                }
-            ]
-        },
-        "package-spec": {
+        "package-specs": {
             "oneOf": [
                 {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/module-output"
+                        "$ref": "#/definitions/module-format"
                     },
                     "description": "package output"
                 },
@@ -196,8 +184,8 @@
                     "$ref": "#/definitions/stringArray",
                     "description": "A list of flags for bsc.exe"
                 },
-                "package-spec": {
-                    "$ref": "#/definitions/package-spec",
+                "package-specs": {
+                    "$ref": "#/definitions/package-specs",
                     "description": "TODO: currently only support commonjs"
                 },
                 "ocamllex": {

--- a/jscomp/all.depend
+++ b/jscomp/all.depend
@@ -509,8 +509,9 @@ bsb/bsb_build_util.cmx : ext/ext_list.cmx ext/ext_filename.cmx \
     bsb/bsb_build_util.cmi
 bsb/bsb_config.cmx : common/js_config.cmx ext/ext_filename.cmx \
     bsb/bsb_config.cmi
-bsb/bsb_default.cmx : ext/ext_filename.cmx bsb/bsb_build_util.cmx \
-    common/bs_pkg.cmx bsb/bsb_default.cmi
+bsb/bsb_default.cmx : ext/string_set.cmx ext/literals.cmx \
+    ext/ext_filename.cmx bsb/bsb_build_util.cmx common/bs_pkg.cmx \
+    bsb/bsb_default.cmi
 bsb/bsb_dep_infos.cmx : bsb/bsb_dep_infos.cmi
 bsb/bsb_dir.cmx : bsb/bsb_dir.cmi
 bsb/bsb_gen.cmx : ext/string_map.cmx ext/literals.cmx ext/ext_filename.cmx \
@@ -533,14 +534,14 @@ bsb/bsb_build_ui.cmi : ext/string_set.cmi ext/ext_file_pp.cmi \
     bsb/bsb_json.cmi common/binary_cache.cmi
 bsb/bsb_build_util.cmi : bsb/bsb_json.cmi
 bsb/bsb_config.cmi :
-bsb/bsb_default.cmi : bsb/bsb_json.cmi
+bsb/bsb_default.cmi : ext/string_set.cmi bsb/bsb_json.cmi
 bsb/bsb_dep_infos.cmi :
 bsb/bsb_dir.cmi :
-bsb/bsb_gen.cmi : bsb/bsb_build_ui.cmi
+bsb/bsb_gen.cmi : bsb/bsb_default.cmi bsb/bsb_build_ui.cmi
 bsb/bsb_helper_main.cmi :
 bsb/bsb_json.cmi : ext/string_map.cmi
 bsb/bsb_main.cmi :
-bsb/bsb_ninja.cmi : bsb/bsb_build_ui.cmi
+bsb/bsb_ninja.cmi : bsb/bsb_default.cmi bsb/bsb_build_ui.cmi
 bsb/sexp_lexer.cmi :
 ounit/oUnit.cmi :
 ounit/oUnitDiff.cmi :

--- a/jscomp/bin/all_ounit_tests.ml
+++ b/jscomp/bin/all_ounit_tests.ml
@@ -5984,7 +5984,9 @@ val suffix_mliastd : string
 val suffix_js : string
 
 
-
+val commonjs : string 
+val amdjs : string 
+val goog : string 
 end = struct
 #1 "literals.ml"
 (* Copyright (C) 2015-2016 Bloomberg Finance L.P.
@@ -6077,6 +6079,9 @@ let suffix_mlastd = ".mlast.d"
 let suffix_mliastd = ".mliast.d"
 let suffix_js = ".js"
 
+let commonjs = "commonjs" 
+let amdjs = "amdjs"
+let goog = "goog"
 end
 module Ext_filename : sig 
 #1 "ext_filename.mli"

--- a/jscomp/bin/bsb_helper.ml
+++ b/jscomp/bin/bsb_helper.ml
@@ -782,7 +782,9 @@ val suffix_mliastd : string
 val suffix_js : string
 
 
-
+val commonjs : string 
+val amdjs : string 
+val goog : string 
 end = struct
 #1 "literals.ml"
 (* Copyright (C) 2015-2016 Bloomberg Finance L.P.
@@ -875,6 +877,9 @@ let suffix_mlastd = ".mlast.d"
 let suffix_mliastd = ".mliast.d"
 let suffix_js = ".js"
 
+let commonjs = "commonjs" 
+let amdjs = "amdjs"
+let goog = "goog"
 end
 module Ext_filename : sig 
 #1 "ext_filename.mli"

--- a/jscomp/bin/bsdep.ml
+++ b/jscomp/bin/bsdep.ml
@@ -24670,7 +24670,9 @@ val suffix_mliastd : string
 val suffix_js : string
 
 
-
+val commonjs : string 
+val amdjs : string 
+val goog : string 
 end = struct
 #1 "literals.ml"
 (* Copyright (C) 2015-2016 Bloomberg Finance L.P.
@@ -24763,6 +24765,9 @@ let suffix_mlastd = ".mlast.d"
 let suffix_mliastd = ".mliast.d"
 let suffix_js = ".js"
 
+let commonjs = "commonjs" 
+let amdjs = "amdjs"
+let goog = "goog"
 end
 module Ast_derive : sig 
 #1 "ast_derive.mli"

--- a/jscomp/bin/bsppx.ml
+++ b/jscomp/bin/bsppx.ml
@@ -6528,7 +6528,9 @@ val suffix_mliastd : string
 val suffix_js : string
 
 
-
+val commonjs : string 
+val amdjs : string 
+val goog : string 
 end = struct
 #1 "literals.ml"
 (* Copyright (C) 2015-2016 Bloomberg Finance L.P.
@@ -6621,6 +6623,9 @@ let suffix_mlastd = ".mlast.d"
 let suffix_mliastd = ".mliast.d"
 let suffix_js = ".js"
 
+let commonjs = "commonjs" 
+let amdjs = "amdjs"
+let goog = "goog"
 end
 module Ast_derive : sig 
 #1 "ast_derive.mli"

--- a/jscomp/bin/whole_compiler.ml
+++ b/jscomp/bin/whole_compiler.ml
@@ -20096,7 +20096,9 @@ val suffix_mliastd : string
 val suffix_js : string
 
 
-
+val commonjs : string 
+val amdjs : string 
+val goog : string 
 end = struct
 #1 "literals.ml"
 (* Copyright (C) 2015-2016 Bloomberg Finance L.P.
@@ -20189,6 +20191,9 @@ let suffix_mlastd = ".mlast.d"
 let suffix_mliastd = ".mliast.d"
 let suffix_js = ".js"
 
+let commonjs = "commonjs" 
+let amdjs = "amdjs"
+let goog = "goog"
 end
 module Bs_pkg : sig 
 #1 "bs_pkg.mli"

--- a/jscomp/bsb/bsb.adoc
+++ b/jscomp/bsb/bsb.adoc
@@ -120,3 +120,34 @@ let () =
 *)
 
 --------------
+
+# package-flags
+
+ when designing bsc commandline flags, we ask user to specify the output path of package output 
+ instead of calculating, 
+ the reason is that the user input can be absolute path or relative path, to calculate 
+ we also need the location of package.json.
+
+ ## TODO: seems we can do it 
+ 
+ ```
+-bs-package-output commonjs:+lib/js -bs-package-output amdjs:+lib/amdjs xx.mlast
+ ```   
+
+ With this we would simplify the build a lot.
+
+ on Windows
+ ```
+ -bs-package-output commonjs:+lib\js -bs-package-output:+lib\amdjs xx.ml a/b/c/xx.mlast
+ ``` 
+
+ so when the user input is relative path, we do the concat,
+ if it is absolute path, we calculate the relative path first.
+
+ This is complicated vs  
+ 
+ ```
+ -bs-package-output commonjs -bs-package-output amdjs
+ ```
+
+ however, the bsc is almost sitting in `lib/bs`

--- a/jscomp/bsb/bsb_build_schemas.ml
+++ b/jscomp/bsb/bsb_build_schemas.ml
@@ -24,3 +24,5 @@ let public = "public"
 let js_post_build = "js-post-build"
 let cmd = "cmd"
 let ninja = "ninja" 
+let package_specs = "package-specs"
+

--- a/jscomp/bsb/bsb_config.ml
+++ b/jscomp/bsb/bsb_config.ml
@@ -24,11 +24,15 @@
 let (//) = Ext_filename.combine 
 
 let lib_js = "lib"//"js"
+let lib_amd = "lib"//"amdjs"
+let lib_goog = "lib" // "goog"
 let lib_ocaml = Js_config.lib_ocaml_dir
 let lib_bs = "lib" // "bs"
 let rev_lib_bs = ".."// ".."
 let rev_lib_bs_prefix p = rev_lib_bs // p 
-let common_js_prefix p  =  lib_js  // p 
+let common_js_prefix p  =  lib_js  // p
+let amd_js_prefix p = lib_amd // p 
+let goog_prefix p = lib_goog // p  
 let ocaml_bin_install_prefix p = lib_ocaml // p
 
 let lazy_src_root_dir = "$src_root_dir" 

--- a/jscomp/bsb/bsb_config.mli
+++ b/jscomp/bsb/bsb_config.mli
@@ -24,6 +24,8 @@
 
 
 val common_js_prefix : string -> string
+val amd_js_prefix : string -> string 
+val goog_prefix : string -> string 
 val ocaml_bin_install_prefix : string -> string
 val proj_rel : string -> string
 val lib_bs : string

--- a/jscomp/bsb/bsb_default.ml
+++ b/jscomp/bsb/bsb_default.ml
@@ -113,3 +113,25 @@ let get_ninja () = !ninja
 *)
 let set_ninja ~cwd p  =
   ninja := resolve_bsb_magic_file ~cwd ~desc:"ninja" p 
+
+
+type package_specs = String_set.t
+
+let package_specs = ref (String_set.singleton Literals.commonjs)
+
+let get_package_specs () = !package_specs
+
+let set_package_specs_from_array arr = 
+    let new_package_specs = 
+      arr 
+      |> get_list_string
+      |> List.fold_left (fun acc x ->
+          let v = 
+            if x = Literals.amdjs || x = Literals.commonjs || x = Literals.goog   then String_set.add x acc
+            else   
+              failwith ("Unkonwn package spec" ^ x) in 
+          v
+        ) String_set.empty in 
+   package_specs := new_package_specs
+
+

--- a/jscomp/bsb/bsb_default.mli
+++ b/jscomp/bsb/bsb_default.mli
@@ -56,3 +56,7 @@ val set_js_post_build_cmd : cwd:string -> string -> unit
 
 val get_ninja : unit -> string 
 val set_ninja : cwd:string -> string -> unit
+
+type package_specs = String_set.t
+val get_package_specs : unit -> package_specs
+val set_package_specs_from_array : Bsb_json.t array -> unit  

--- a/jscomp/bsb/bsb_gen.mli
+++ b/jscomp/bsb/bsb_gen.mli
@@ -27,6 +27,7 @@ val output_ninja :
   builddir:string ->
   cwd:string ->
   js_post_build_cmd:string option -> 
+  package_specs:Bsb_default.package_specs ->
   string ->
   string ->
   string option ->

--- a/jscomp/bsb/bsb_main.ml
+++ b/jscomp/bsb/bsb_main.ml
@@ -55,10 +55,11 @@ let write_ninja_file cwd =
       |?
       (Bsb_build_schemas.ocaml_config,   `Obj  begin fun m ->
           m
+          |? (Bsb_build_schemas.package_specs, `Arr Bsb_default.set_package_specs_from_array )
           |? (Bsb_build_schemas.js_post_build, `Obj begin fun m -> 
               m |? (Bsb_build_schemas.cmd , `Str (Bsb_default.set_js_post_build_cmd ~cwd)
-                )
-            |> ignore 
+                   )
+              |> ignore 
             end)
           |? (Bsb_build_schemas.ocamllex, `Str (Bsb_default.set_ocamllex ~cwd))
           |? (Bsb_build_schemas.ninja, `Str (Bsb_default.set_ninja ~cwd))
@@ -93,19 +94,23 @@ let write_ninja_file cwd =
       Unix.rename config_file_bak Literals.bsconfig_json
   end;
 
-  Bsb_gen.output_ninja ~builddir ~cwd ~js_post_build_cmd: Bsb_default.(get_js_post_build_cmd ())
-             bsc
-             bsdep
-             (Bsb_default.get_package_name ())
-             (Bsb_default.get_ocamllex ())
-             (Bsb_default.get_bs_external_includes ())
-             !bs_file_groups
-             Bsb_default.(get_bsc_flags ())
-             Bsb_default.(get_ppx_flags ())
-             Bsb_default.(get_bs_dependencies ())
-             Bsb_default.(get_refmt ())
+  Bsb_gen.output_ninja 
+    ~builddir 
+    ~cwd 
+    ~js_post_build_cmd: Bsb_default.(get_js_post_build_cmd ())
+    ~package_specs:(Bsb_default.get_package_specs())
+    bsc
+    bsdep
+    (Bsb_default.get_package_name ())
+    (Bsb_default.get_ocamllex ())
+    (Bsb_default.get_bs_external_includes ())
+    !bs_file_groups
+    Bsb_default.(get_bsc_flags ())
+    Bsb_default.(get_ppx_flags ())
+    Bsb_default.(get_bs_dependencies ())
+    Bsb_default.(get_refmt ())
 
-          ;
+  ;
   !globbed_dirs
 
 
@@ -165,10 +170,10 @@ let regenerate_ninja cwd forced =
    ninja -C _build
 *)
 let usage = "Usage : bsb.exe <bsb-options> <files> -- <ninja_options>\n\
-For ninja options, try ninja -h \n\
-ninja will be loaded either by just running `bsb.exe' or `bsb.exe .. -- ..`\n\
-It is always recommended to run ninja via bsb.exe \n\
-Bsb options are:"
+             For ninja options, try ninja -h \n\
+             ninja will be loaded either by just running `bsb.exe' or `bsb.exe .. -- ..`\n\
+             It is always recommended to run ninja via bsb.exe \n\
+             Bsb options are:"
 
 let () =
   let cwd = Sys.getcwd () in

--- a/jscomp/bsb/bsb_ninja.mli
+++ b/jscomp/bsb/bsb_ninja.mli
@@ -74,6 +74,7 @@ val output_kvs : (string * string) list -> out_channel -> unit
 
 type info = string list  * string list 
 val handle_file_groups : out_channel ->
+  package_specs:Bsb_default.package_specs ->  
   js_post_build_cmd:string option -> 
   Bsb_build_ui.file_group list ->
   info -> info

--- a/jscomp/ext/literals.ml
+++ b/jscomp/ext/literals.ml
@@ -87,3 +87,7 @@ let suffix_d = ".d"
 let suffix_mlastd = ".mlast.d"
 let suffix_mliastd = ".mliast.d"
 let suffix_js = ".js"
+
+let commonjs = "commonjs" 
+let amdjs = "amdjs"
+let goog = "goog"

--- a/jscomp/ext/literals.mli
+++ b/jscomp/ext/literals.mli
@@ -89,3 +89,6 @@ val suffix_mliastd : string
 val suffix_js : string
 
 
+val commonjs : string 
+val amdjs : string 
+val goog : string 

--- a/jscomp/test/literals.js
+++ b/jscomp/test/literals.js
@@ -91,6 +91,12 @@ var suffix_mliastd = ".mliast.d";
 
 var suffix_js = ".js";
 
+var commonjs = "commonjs";
+
+var amdjs = "amdjs";
+
+var goog = "goog";
+
 exports.js_array_ctor       = js_array_ctor;
 exports.js_type_number      = js_type_number;
 exports.js_type_string      = js_type_string;
@@ -136,4 +142,7 @@ exports.suffix_d            = suffix_d;
 exports.suffix_mlastd       = suffix_mlastd;
 exports.suffix_mliastd      = suffix_mliastd;
 exports.suffix_js           = suffix_js;
+exports.commonjs            = commonjs;
+exports.amdjs               = amdjs;
+exports.goog                = goog;
 /* No side effect */


### PR DESCRIPTION
catches: its dependency has to be built  with such support two (improve its error message) the rule output has to be update (otherwise users have to create directories beforehand) the flags (currently) has to be updated for each target (due to that we need to specify the output location and new outputs)