### PR TITLE
address #986 and #984

### DIFF
--- a/bsconfig.json
+++ b/bsconfig.json
@@ -467,5 +467,8 @@
                 "a.ml"
             ]
         }
+    // ,
+    // "bs-dependencies" : ["mocha"]
+    // , "generate-merlin" : true
     
 }

--- a/bsconfig.json
+++ b/bsconfig.json
@@ -466,7 +466,9 @@
                 "a_filename_test.ml",
                 "a.ml"
             ]
-        }
+    },
+
+    // "ppx-flags": ["reason/bin/reactjs_jsx_ppx"]
     // ,
     // "bs-dependencies" : ["mocha"]
     // , "generate-merlin" : true

--- a/jscomp/bin/bsb.ml
+++ b/jscomp/bin/bsb.ml
@@ -7312,10 +7312,16 @@ let write_ninja_file cwd =
     let ochan = open_out_bin (builddir // sourcedirs_meta) in
     let lib_ocaml_dir = (bsc_dir // ".."//"lib"//"ocaml") in 
     let buffer = Buffer.create 100 in 
+    let () = 
+      Bsb_default.get_ppx_flags ()
+      |> List.iter (fun x -> 
+          Buffer.add_string buffer (Printf.sprintf "PPX %s\n" x )
+        )
+    in 
     let () = Buffer.add_string buffer
         (Printf.sprintf "S %s\n\
                          B %s\n\
-                         PPX %s\n
+                         PPX %s\n\
                        " lib_ocaml_dir lib_ocaml_dir bsppx
         ) in 
     let () = 

--- a/jscomp/bsb/bsb_default.ml
+++ b/jscomp/bsb/bsb_default.ml
@@ -27,9 +27,13 @@ let (//) = Ext_filename.combine
 
 
 (* Magic path resolution:
-foo/bar => /absolute/path/to/projectRoot/node_modules/foo.bar
-/foo/bar => /foo/bar
-./foo/bar => /absolute/path/to/projectRoot/./foo/bar *)
+   foo => foo 
+   foo/ => /absolute/path/to/projectRoot/node_modules/foo
+   foo/bar => /absolute/path/to/projectRoot/node_modules/foo.bar
+   /foo/bar => /foo/bar
+   ./foo/bar => /absolute/path/to/projectRoot/./foo/bar 
+   Input is node path, output is OS dependent path
+*)
 let resolve_bsb_magic_file ~cwd ~desc p =
   let p_len = String.length p in 
   let no_slash = Ext_filename.no_slash p 0 p_len in  

--- a/jscomp/bsb/bsb_default.mli
+++ b/jscomp/bsb/bsb_default.mli
@@ -23,6 +23,7 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
 
 
+val resolve_bsb_magic_file : cwd:string -> desc:string -> string -> string
 
 val get_ocamllex : unit -> string
 val set_ocamllex : cwd:string -> string -> unit

--- a/jscomp/bsb/bsb_main.ml
+++ b/jscomp/bsb/bsb_main.ml
@@ -93,10 +93,16 @@ let write_ninja_file cwd =
     let ochan = open_out_bin (builddir // sourcedirs_meta) in
     let lib_ocaml_dir = (bsc_dir // ".."//"lib"//"ocaml") in 
     let buffer = Buffer.create 100 in 
+    let () = 
+      Bsb_default.get_ppx_flags ()
+      |> List.iter (fun x -> 
+          Buffer.add_string buffer (Printf.sprintf "PPX %s\n" x )
+        )
+    in 
     let () = Buffer.add_string buffer
         (Printf.sprintf "S %s\n\
                          B %s\n\
-                         PPX %s\n
+                         PPX %s\n\
                        " lib_ocaml_dir lib_ocaml_dir bsppx
         ) in 
     let () = 

--- a/jscomp/bsb/bsb_main.ml
+++ b/jscomp/bsb/bsb_main.ml
@@ -86,6 +86,9 @@ let write_ninja_file cwd =
 
   let update_queue = ref [] in
   let globbed_dirs = ref [] in
+  (* ATTENTION: order matters here, need resolve global properties before
+     merlin generation
+  *)
   let handle_bsb_build_ui (res : Bsb_build_ui.t) = 
     let ochan = open_out_bin (builddir // sourcedirs_meta) in
     let lib_ocaml_dir = (bsc_dir // ".."//"lib"//"ocaml") in 
@@ -96,6 +99,19 @@ let write_ninja_file cwd =
                          PPX %s\n
                        " lib_ocaml_dir lib_ocaml_dir bsppx
         ) in 
+    let () = 
+      Bsb_default.get_bs_dependencies ()
+      |> List.iter (fun package -> 
+          let path = (Bsb_default.resolve_bsb_magic_file ~cwd ~desc:"dependecies" 
+                         (package ^ "/")// "lib"//"ocaml") in 
+          Buffer.add_string buffer "\nS "; 
+          Buffer.add_string buffer path ;
+          Buffer.add_string buffer "\nB ";
+          Buffer.add_string buffer path ; 
+          Buffer.add_string buffer "\n";
+           
+        )
+    in 
     res.files |> List.iter 
       (fun (x : Bsb_build_ui.file_group) -> 
          output_string ochan x.dir;


### PR DESCRIPTION
if we have `bs-mocha` in the dependencies:

```
S /Users/hzhang295/git/bucklescript-addons/bindings/bs-string/node_modules/bs-mocha/lib/ocaml
B /Users/hzhang295/git/bucklescript-addons/bindings/bs-string/node_modules/bs-mocha/lib/ocaml
```
To make peek source definition work, our installation should also install source files (cc @chenglou )
