### PR TITLE
stream line clean-world, make-world, allow user to override package-specs

### DIFF
--- a/bin/bsb
+++ b/bin/bsb
@@ -14,7 +14,7 @@ if (fs.existsSync(bsconfig)) {
     try {
         child_process.execFileSync(bsb_exe, delegate_args, { stdio: 'inherit' })
     } catch (e) {
-        console.error('Error happend when running command', bsb_exe, 'with args', delete_args)
+        console.error('Error happend when running command', bsb_exe, 'with args', delegate_args)
     }
 } else {
     var path = require('path')
@@ -32,7 +32,7 @@ if (fs.existsSync(bsconfig)) {
         try {
             child_process.execFileSync(bsb_exe, delegate_args, { stdio: 'inherit', cwd: search_dir })
         } catch (e) {
-            console.error('Error happend when running command', bsb_exe, 'with args', delete_args)
+            console.error('Error happend when running command', bsb_exe, 'with args', delegate_args)
         }
     }
 }

--- a/docs/docson/build-schema.json
+++ b/docs/docson/build-schema.json
@@ -177,7 +177,7 @@
         },
         "ppx-flags": {
             "$ref": "#/definitions/ppx-specs",
-            "description": "TODO: ppx flags"
+            "description": "syntax is package_name/binary, for example: reason/reactjs_jsx_ppx.native"
         },
         "bsc-flags": {
             "$ref": "#/definitions/stringArray",
@@ -185,7 +185,7 @@
         },
         "package-specs": {
             "$ref": "#/definitions/package-specs",
-            "description": "TODO: currently only support commonjs"
+            "description": "currently support commonjs, amdjs and google module"
         },
         "ocamllex": {
             "type": "string",
@@ -201,11 +201,11 @@
         },
         "refmt": {
             "type": "string",
-            "description": "Path to refmt"
+            "description": "Path to refmt for Reason syntax, for example: reason/refmt_impl.native"
         },
         "bs-external-includes": {
             "$ref": "#/definitions/stringArray",
-            "description": "external include directories, which will be applied -I to all compilation units, it is not needed in most cases"
+            "description": "external include directories, which will be applied -I to all compilation units, it is *not needed* in most cases"
         },
         "sources": {
             "oneOf": [
@@ -213,10 +213,12 @@
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/sourceItem"
-                    }
+                    },
+                    "description" : "A list of source items"
                 },
                 {
-                    "$ref": "#/definitions/sourceItem"
+                    "$ref": "#/definitions/sourceItem",
+                    "description": "A single source item"
                 }
             ]
         },

--- a/jscomp/Makefile
+++ b/jscomp/Makefile
@@ -251,8 +251,10 @@ OTHER_CORE_SRCS= bsppx_main bspack_main jsoo_main  bspp_main js_cmi_datasets \
 		 js_main
 OTHER_CORE_CMXS= $(addprefix core/, $(addsuffix .cmx, $(OTHER_CORE_SRCS)))
 BSB_SRCS= bsb_config bsb_build_schemas bsb_build_util \
-	bsb_dep_infos bsb_dir bsb_ninja \
-	bsb_build_ui bsb_default bsb_gen\
+	bsb_dir bsb_ninja \
+	bsb_build_ui bsb_default\
+	bsb_dep_infos\
+	 bsb_gen\
 	bsb_unix
 
 BSB_CMXS=$(addprefix bsb/, $(addsuffix .cmx, $(BSB_SRCS)))

--- a/jscomp/all.depend
+++ b/jscomp/all.depend
@@ -661,11 +661,12 @@ bsb/bsb_gen.cmx : ext/string_map.cmx ext/literals.cmx ext/ext_filename.cmx \
     bsb/bsb_gen.cmi
 bsb/bsb_helper_main.cmx : depends/depends_post_process.cmx \
     bsb/bsb_helper_main.cmi
-bsb/bsb_main.cmx : ext/string_vec.cmx ext/literals.cmx ext/ext_string.cmx \
-    ext/ext_json.cmx ext/ext_filename.cmx ext/ext_file_pp.cmx \
-    ext/ext_array.cmx bsb/bsb_unix.cmx bsb/bsb_gen.cmx bsb/bsb_dep_infos.cmx \
-    bsb/bsb_default.cmx bsb/bsb_config.cmx bsb/bsb_build_util.cmx \
-    bsb/bsb_build_ui.cmx bsb/bsb_build_schemas.cmx bsb/bsb_main.cmi
+bsb/bsb_main.cmx : ext/string_vec.cmx ext/string_set.cmx ext/literals.cmx \
+    ext/ext_string.cmx ext/ext_json.cmx ext/ext_filename.cmx \
+    ext/ext_file_pp.cmx ext/ext_array.cmx bsb/bsb_unix.cmx bsb/bsb_gen.cmx \
+    bsb/bsb_dep_infos.cmx bsb/bsb_default.cmx bsb/bsb_config.cmx \
+    bsb/bsb_build_util.cmx bsb/bsb_build_ui.cmx bsb/bsb_build_schemas.cmx \
+    bsb/bsb_main.cmi
 bsb/bsb_ninja.cmx : ext/string_set.cmx ext/string_map.cmx ext/literals.cmx \
     ext/ext_filename.cmx bsb/bsb_config.cmx bsb/bsb_build_util.cmx \
     bsb/bsb_build_ui.cmx bsb/bsb_build_schemas.cmx common/binary_cache.cmx \

--- a/jscomp/bin/bsb.ml
+++ b/jscomp/bin/bsb.ml
@@ -7926,6 +7926,10 @@ val run_commands : command list -> unit
 val run_command_execv : bool ->  command -> unit 
 
 (* val run_command_execvp : command -> unit *)
+
+val remove_dirs_recursive : string ->  string array -> unit 
+
+val remove_dir_recursive : string -> unit 
 end = struct
 #1 "bsb_unix.ml"
 (* Copyright (C) 2015-2016 Bloomberg Finance L.P.
@@ -8041,12 +8045,40 @@ let run_command_execv fail_exit cmd =
             prerr_endline ("* Failure : " ^ cmd.cmd ^ "\n* Location: " ^ cmd.cwd);
             if fail_exit then exit eid    
           end;
-        
+
       | Unix.WSIGNALED _ | Unix.WSTOPPED _ -> 
         begin 
           prerr_endline (cmd.cmd ^ " interrupted");
           exit 2 
         end        
+
+(** it assume you have permissions, so always catch it to fail 
+    gracefully
+*)
+let rec remove_dirs_recursive cwd roots = 
+  Array.iter 
+    (fun root -> 
+       let cur = Filename.concat cwd root in 
+       if Sys.is_directory cur then 
+         begin       
+           remove_dirs_recursive cur (Sys.readdir cur); 
+           Unix.rmdir cur ; 
+         end
+       else 
+         Sys.remove cur
+    )
+    roots        
+
+let rec remove_dir_recursive dir = 
+  if Sys.is_directory dir then 
+    begin 
+      let files = Sys.readdir dir in 
+      for i = 0 to Array.length files - 1 do 
+        remove_dir_recursive (Filename.concat dir (Array.unsafe_get files i))
+      done ;
+      Unix.rmdir dir 
+    end
+  else Sys.remove dir 
 (*  
 let () = 
   run_commands 
@@ -8148,7 +8180,7 @@ let revise_merlin new_content =
 let write_ninja_file bsc_dir cwd =
   let builddir = Bsb_config.lib_bs in
   let () = Bsb_build_util.mkp builddir in
-    let bsc, bsdep, bsppx =
+  let bsc, bsdep, bsppx =
     bsc_dir // "bsc.exe",
     bsc_dir // "bsb_helper.exe",
     bsc_dir // "bsppx.exe" in
@@ -8173,7 +8205,7 @@ let write_ninja_file bsc_dir cwd =
                          S %s\n\
                          B %s\n\
                          FLG -ppx %s\n\
-                       " lib_ocaml_dir lib_ocaml_dir bsppx
+                        " lib_ocaml_dir lib_ocaml_dir bsppx
         ) in
     let () = 
       match Bsb_default.get_bsc_flags () with 
@@ -8185,7 +8217,7 @@ let write_ninja_file bsc_dir cwd =
       Bsb_default.get_bs_dependencies ()
       |> List.iter (fun package ->
           let path = (Bsb_default.resolve_bsb_magic_file ~cwd ~desc:"dependecies"
-                         (package ^ "/")// "lib"//"ocaml") in
+                        (package ^ "/")// "lib"//"ocaml") in
           Buffer.add_string buffer "\nS ";
           Buffer.add_string buffer path ;
           Buffer.add_string buffer "\nB ";
@@ -8303,6 +8335,7 @@ let cwd = Sys.getcwd ()
 
 
 let watch () =
+  print_endline "\nStart Watching now ";
   let bsb_watcher =
     Bsb_build_util.get_bsc_dir cwd // "bsb_watcher.js" in
   let bsb_watcher =
@@ -8321,28 +8354,46 @@ let separator = "--"
 
 let internal_package_specs = "-internal-package-specs"
 let build_bs_deps package_specs   = 
-    let bsc_dir = Bsb_build_util.get_bsc_dir cwd in 
-    let bsb_exe = bsc_dir // "bsb.exe" in 
-    Bsb_default.walk_all_deps true cwd 
-    (fun top cwd -> 
-    if not top then 
-        Bsb_unix.run_command_execv true
-        {cmd = bsb_exe; cwd = cwd; args  = 
-          [| bsb_exe ; no_dev; internal_package_specs; package_specs; regen; separator |]})
-
-let clean_bs_deps () = 
   let bsc_dir = Bsb_build_util.get_bsc_dir cwd in 
-    let bsb_exe = bsc_dir // "bsb.exe" in 
-    Bsb_default.walk_all_deps true cwd 
-    (fun top cwd -> Bsb_unix.run_command_execv (not top)
-      {cmd = bsb_exe; cwd = cwd; args  = [| bsb_exe ; separator; "-t" ; "clean"|]})
+  let bsb_exe = bsc_dir // "bsb.exe" in 
+  Bsb_default.walk_all_deps true cwd 
+    (fun top cwd -> 
+       if not top then 
+         Bsb_unix.run_command_execv true
+           {cmd = bsb_exe; cwd = cwd; args  = 
+                                        [| bsb_exe ; no_dev; internal_package_specs; package_specs; regen; separator |]})
+
 let annoymous filename =
   String_vec.push  filename targets
 
 let watch_mode = ref false 
 let make_world = ref false 
 
-    
+let lib_bs = "lib" // "bs"
+let lib_amdjs = "lib" // "amdjs"
+let lib_goog = "lib" // "goog"
+let lib_js = "lib" // "js"
+
+let clean_bs_garbage cwd = 
+  print_string "Doing cleaning in ";
+  print_endline cwd; 
+  let aux x = 
+    let x = (cwd // x)  in 
+    if Sys.file_exists x then 
+      Bsb_unix.remove_dir_recursive x  in 
+  try 
+    aux lib_bs ; 
+    aux lib_amdjs ; 
+    aux lib_goog;
+    aux lib_js    
+  with 
+    e -> 
+    prerr_endline ("Failed to clean due to " ^ Printexc.to_string e)
+
+let clean_bs_deps () =   
+  Bsb_default.walk_all_deps true cwd  (fun top cwd -> 
+      clean_bs_garbage cwd 
+    )
 let bsb_main_flags =
   [
     "-w", Arg.Set watch_mode,
@@ -8350,7 +8401,7 @@ let bsb_main_flags =
     no_dev, Arg.Set Bsb_config.no_dev, 
     " (internal)Build dev dependencies in make-world and dev group(in combination with -regen)";
     regen, Arg.Set force_regenerate,
-     " Always regenerate build.ninja no matter bsconfig.json is changed or not (for debugging purpose)"
+    " Always regenerate build.ninja no matter bsconfig.json is changed or not (for debugging purpose)"
     ;
     internal_package_specs, Arg.String Bsb_default.internal_override_package_specs, 
     " (internal)Overide package specs (in combination with -regen)"; 
@@ -8361,7 +8412,7 @@ let bsb_main_flags =
   ]
 
 (** Regenerate ninja file and return None if we dont need regenerate 
-  otherwise return some info 
+    otherwise return some info 
 *)
 let regenerate_ninja cwd bsc_dir forced : Bsb_default.package_specs option =
   let output_deps = Bsb_config.lib_bs // bsdeps in
@@ -8388,31 +8439,43 @@ let regenerate_ninja cwd bsc_dir forced : Bsb_default.package_specs option =
   else None   
 
 let ninja_error_message = "ninja (required for bsb build system) is not installed, \n\
-please visit https://github.com/ninja-build/ninja to have it installed\n"
+                           please visit https://github.com/ninja-build/ninja to have it installed\n"
 let () = 
   Printexc.register_printer (function 
-  | Unix.Unix_error(Unix.ENOENT, "execvp", "ninja") -> 
-    Some ninja_error_message
-  | _ -> None
-  )
+      | Unix.Unix_error(Unix.ENOENT, "execvp", "ninja") -> 
+        Some ninja_error_message
+      | _ -> None
+    )
 
-  
+let print_string_args (args : string array) = 
+  for i  = 0 to Array.length args - 1 do 
+    print_string (Array.unsafe_get args i) ; 
+    print_string " ";
+  done ; 
+  print_newline ()  
+
 (* Note that [keepdepfile] only makes sense when combined with [deps] for optimizatoin *)
 let ninja_command ninja ninja_args = 
   let ninja_args_len = Array.length ninja_args in
   if ninja_args_len = 0 then     
-    Unix.execvp ninja [|"ninja"; "-C"; Bsb_config.lib_bs |]    
+    begin 
+      let args = [|"ninja"; "-C"; Bsb_config.lib_bs |]    in 
+      print_string_args args ; 
+      Unix.execvp ninja args 
+    end    
   else 
     let fixed_args_length = 3 in 
-    begin Unix.execvp ninja 
-    (Array.init (fixed_args_length + ninja_args_len)
-     (fun i -> match i with 
-     | 0 -> "ninja"
-     | 1 -> "-C"
-     | 2 -> Bsb_config.lib_bs
-     | _ -> Array.unsafe_get ninja_args (i - fixed_args_length) ))
-     end 
-    
+    let args = (Array.init (fixed_args_length + ninja_args_len)
+                  (fun i -> match i with 
+                     | 0 -> "ninja"
+                     | 1 -> "-C"
+                     | 2 -> Bsb_config.lib_bs
+                     | _ -> Array.unsafe_get ninja_args (i - fixed_args_length) )) in 
+    print_string_args args ;
+    Unix.execvp ninja args 
+
+
+
 (**
    Cache files generated:
    - .bsdircache in project root dir
@@ -8427,6 +8490,31 @@ let usage = "Usage : bsb.exe <bsb-options> <files> -- <ninja_options>\n\
              It is always recommended to run ninja via bsb.exe \n\
              Bsb options are:"
 
+
+  (*
+  let bsb_exe = bsc_dir // "bsb.exe" in 
+  Bsb_default.walk_all_deps true cwd 
+    (fun top cwd -> Bsb_unix.run_command_execv (not top)
+        {cmd = bsb_exe; cwd = cwd; args  = [| bsb_exe ; separator; "-t" ; "clean"|]})
+  *)
+let make_world_deps deps =  
+  print_endline "\nMaking the dependency world!";
+  let deps = 
+    match deps with 
+    | None -> 
+      let json = Ext_json.parse_json_from_file Literals.bsconfig_json in 
+      begin match json with 
+        | `Obj map -> 
+          map 
+          |? (Bsb_build_schemas.package_specs, 
+              `Arr Bsb_default.set_package_specs_from_array)
+          |> ignore ;
+          Bsb_default.get_package_specs ()
+        | _ -> assert false
+      end 
+    | Some spec -> spec in                               
+  build_bs_deps (  String_set.fold 
+                     (fun k acc -> k ^ "," ^ acc ) deps Ext_string.empty ) 
 let () =
   let bsc_dir = Bsb_build_util.get_bsc_dir cwd in
   let ninja = 
@@ -8434,73 +8522,44 @@ let () =
       bsc_dir // "ninja.exe"
     else 
       "ninja" 
-    in 
+  in 
   (* try *)
-    (* see discussion #929 *)
-    if Array.length Sys.argv <= 1 then
-      begin
-        ignore (regenerate_ninja cwd bsc_dir false);
-        ninja_command ninja [||]
-      end
-    else
-      begin
-        match Ext_array.find_and_split Sys.argv Ext_string.equal "--" with
-        | `No_split
-          ->
-          begin
-            Arg.parse bsb_main_flags annoymous usage;
+  (* see discussion #929 *)
+  if Array.length Sys.argv <= 1 then
+    begin
+      ignore (regenerate_ninja cwd bsc_dir false);
+      ninja_command ninja [||]
+    end
+  else
+    begin
+      match Ext_array.find_and_split Sys.argv Ext_string.equal "--" with
+      | `No_split
+        ->
+        begin
+          Arg.parse bsb_main_flags annoymous usage;          
+          (* [-make-world] should never be combined with [-package-specs] *)
+          if !make_world then
+            (* don't regenerate files when we only run [bsb -clean-world] *)
             let deps = regenerate_ninja cwd bsc_dir !force_regenerate in 
-            (* [-make-world] should never be combined with [-package-specs] *)
-            if !make_world then
-             let deps = 
-                match deps with 
-                | None -> 
-                  let json = Ext_json.parse_json_from_file Literals.bsconfig_json in 
-                  begin match json with 
-                  | `Obj map -> 
-                     map 
-                     |? (Bsb_build_schemas.package_specs, 
-                     `Arr Bsb_default.set_package_specs_from_array)
-                     |> ignore ;
-                     Bsb_default.get_package_specs ()
-                  | _ -> assert false
-                  end 
-                | Some spec -> spec in                               
-              build_bs_deps (  String_set.fold 
-              (fun k acc -> k ^ "," ^ acc ) deps Ext_string.empty ) ;  
-            if  !watch_mode then 
-                watch ()
+            make_world_deps deps ;  
+          if  !watch_mode then 
+            watch ()
             (* ninja is not triggered in this case *)
-          end
-        | `Split (bsb_args,ninja_args)
-          ->
-          begin
-            Arg.parse_argv bsb_args bsb_main_flags annoymous usage ;
-            let deps = (regenerate_ninja cwd bsc_dir !force_regenerate) in 
-            (* [-make-world] should never be combined with [-package-specs] *)
-            if !make_world then 
-              let deps = 
-                match deps with 
-                | None -> 
-                  let json = Ext_json.parse_json_from_file Literals.bsconfig_json in 
-                  begin match json with 
-                  | `Obj map -> 
-                     map 
-                     |? (Bsb_build_schemas.package_specs, 
-                     `Arr Bsb_default.set_package_specs_from_array)
-                     |> ignore ;
-                     Bsb_default.get_package_specs ()
-                  | _ -> assert false
-                  end 
-                | Some spec -> spec in                               
-              build_bs_deps (  String_set.fold 
-              (fun k acc -> k ^ "," ^ acc ) deps Ext_string.empty ) ;   
-            if !watch_mode then watch ()  
-            else ninja_command ninja ninja_args
-          end
-      end
-  (*with x ->
-    prerr_endline @@ Printexc.to_string x ;
-    exit 2*)
-  (* with [try, with], there is no stacktrace anymore .. *)  
+        end
+      | `Split (bsb_args,ninja_args)
+        ->
+        begin
+          Arg.parse_argv bsb_args bsb_main_flags annoymous usage ;
+          let deps = (regenerate_ninja cwd bsc_dir !force_regenerate) in 
+          (* [-make-world] should never be combined with [-package-specs] *)
+          if !make_world then 
+            make_world_deps deps ;   
+          if !watch_mode then watch ()  
+          else ninja_command ninja ninja_args
+        end
+    end
+(*with x ->
+  prerr_endline @@ Printexc.to_string x ;
+  exit 2*)
+(* with [try, with], there is no stacktrace anymore .. *)  
 end

--- a/jscomp/bin/whole_compiler.ml
+++ b/jscomp/bin/whole_compiler.ml
@@ -105780,6 +105780,9 @@ let buckle_script_flags =
    " only check syntax"
   )
   ::
+  ("-bs-no-bin-annot", Arg.Clear Clflags.binary_annotations, 
+   " disable binary annotations (by default on)")
+  ::
   ("-bs-eval", 
    Arg.String set_eval_string, 
    " (experimental) Set the string to be evaluated, note this flag will be conflicted with -bs-main"
@@ -105883,6 +105886,7 @@ let buckle_script_flags =
 let _ = 
   Clflags.unsafe_string := false;
   Clflags.debug := true;
+  Clflags.binary_annotations := true; 
   Bs_conditional_initial.setup_env ();
   try
     Compenv.readenv ppf Before_args;

--- a/jscomp/bsb/bsb_default.ml
+++ b/jscomp/bsb/bsb_default.ml
@@ -156,10 +156,12 @@ let set_ninja ~cwd p  =
 type package_specs = String_set.t
 
 let package_specs = ref (String_set.singleton Literals.commonjs)
+let package_specs_overriden = ref false 
 
 let get_package_specs () = !package_specs
 
 let set_package_specs_from_array arr = 
+    if not  !package_specs_overriden then 
     let new_package_specs = 
       arr 
       |> get_list_string
@@ -171,6 +173,22 @@ let set_package_specs_from_array arr =
           v
         ) String_set.empty in 
    package_specs := new_package_specs
+
+
+
+
+let internal_override_package_specs str = 
+  package_specs_overriden := true ; 
+  let lst = Ext_string.split ~keep_empty:false str ',' in 
+  package_specs := 
+    List.fold_left (fun acc x -> 
+          let v = 
+            if x = Literals.amdjs || x = Literals.commonjs || x = Literals.goog   then String_set.add x acc
+            else   
+              failwith ("Unkonwn package spec" ^ x) in 
+          v
+    ) String_set.empty lst 
+
 
 let generate_merlin = ref false
 

--- a/jscomp/bsb/bsb_default.mli
+++ b/jscomp/bsb/bsb_default.mli
@@ -61,6 +61,8 @@ val set_ninja : cwd:string -> string -> unit
 type package_specs = String_set.t
 val get_package_specs : unit -> package_specs
 val set_package_specs_from_array : Ext_json.t array -> unit  
+val internal_override_package_specs : string -> unit 
+
 
 val get_generate_merlin : unit -> bool 
 val set_generate_merlin : bool -> unit 

--- a/jscomp/bsb/bsb_main.ml
+++ b/jscomp/bsb/bsb_main.ml
@@ -239,8 +239,7 @@ let targets = String_vec.make 5
 
 let cwd = Sys.getcwd ()
 
-let create_bs_config () =
-  ()
+
 let watch () =
   let bsb_watcher =
     Bsb_build_util.get_bsc_dir cwd // "bsb_watcher.js" in
@@ -257,16 +256,17 @@ let no_dev = "-no-dev"
 let regen = "-regen"
 let separator = "--"
 
-let build_bs_deps ()   = 
+
+let internal_package_specs = "-internal-package-specs"
+let build_bs_deps package_specs   = 
     let bsc_dir = Bsb_build_util.get_bsc_dir cwd in 
     let bsb_exe = bsc_dir // "bsb.exe" in 
     Bsb_default.walk_all_deps true cwd 
     (fun top cwd -> 
-      if top then 
-        Bsb_unix.run_command_execv false { cmd = bsb_exe ; cwd ; args = [|bsb_exe ; regen ; separator|]}
-      else 
+    if not top then 
         Bsb_unix.run_command_execv true
-        {cmd = bsb_exe; cwd = cwd; args  = [| bsb_exe ; no_dev; regen; separator |]})
+        {cmd = bsb_exe; cwd = cwd; args  = 
+          [| bsb_exe ; no_dev; internal_package_specs; package_specs; regen; separator |]})
 
 let clean_bs_deps () = 
   let bsc_dir = Bsb_build_util.get_bsc_dir cwd in 
@@ -277,31 +277,31 @@ let clean_bs_deps () =
 let annoymous filename =
   String_vec.push  filename targets
 
+let watch_mode = ref false 
+let make_world = ref false 
 
-
-
+    
 let bsb_main_flags =
   [
-    "-w", Arg.Unit watch,
+    "-w", Arg.Set watch_mode,
     " Watch mode" ;
-    no_dev, Arg.Unit (fun _ -> Bsb_config.no_dev := true), 
-    " (experimental)Build dev dependencies in make-world and dev group";
-    " -no-dev", Arg.Set Bsb_config.no_dev, 
-    " (experimental)Don't build dev directories(internal for -make-world)" ; 
-    (*    "-init", Arg.Unit create_bs_config ,
-          " Create an simple bsconfig.json"
-          ;
-    *)   
-     regen, Arg.Set force_regenerate,
+    no_dev, Arg.Set Bsb_config.no_dev, 
+    " (internal)Build dev dependencies in make-world and dev group(in combination with -regen)";
+    regen, Arg.Set force_regenerate,
      " Always regenerate build.ninja no matter bsconfig.json is changed or not (for debugging purpose)"
     ;
+    internal_package_specs, Arg.String Bsb_default.internal_override_package_specs, 
+    " (internal)Overide package specs (in combination with -regen)"; 
     "-clean-world", Arg.Unit clean_bs_deps,
     " Clean all bs dependencies";
-    "-make-world", Arg.Unit build_bs_deps,
+    "-make-world", Arg.Set make_world,
     " Build all dependencies and itself "
   ]
 
-let regenerate_ninja cwd bsc_dir forced =
+(** Regenerate ninja file and return None if we dont need regenerate 
+  otherwise return some info 
+*)
+let regenerate_ninja cwd bsc_dir forced : Bsb_default.package_specs option =
   let output_deps = Bsb_config.lib_bs // bsdeps in
   let reason =
     if forced then "Regenerating ninja (triggered by command line -regen)"
@@ -319,9 +319,11 @@ let regenerate_ninja cwd bsc_dir forced =
              stamp = (Unix.stat x).st_mtime
            }
         )
-      |> (fun x -> Bsb_dep_infos.store ~cwd output_deps (Array.of_list x))
-
+      |> (fun x -> Bsb_dep_infos.store ~cwd output_deps (Array.of_list x));
+      Some (Bsb_default.get_package_specs ())
+      (* This makes sense since we did parse the json file *)
     end
+  else None   
 
 let ninja_error_message = "ninja (required for bsb build system) is not installed, \n\
 please visit https://github.com/ninja-build/ninja to have it installed\n"
@@ -375,7 +377,7 @@ let () =
     (* see discussion #929 *)
     if Array.length Sys.argv <= 1 then
       begin
-        regenerate_ninja cwd bsc_dir false;
+        ignore (regenerate_ninja cwd bsc_dir false);
         ninja_command ninja [||]
       end
     else
@@ -385,17 +387,54 @@ let () =
           ->
           begin
             Arg.parse bsb_main_flags annoymous usage;
-            regenerate_ninja cwd bsc_dir !force_regenerate;
-            (* String_vec.iter (fun s -> print_endline s) targets; *)
+            let deps = regenerate_ninja cwd bsc_dir !force_regenerate in 
+            (* [-make-world] should never be combined with [-package-specs] *)
+            if !make_world then
+             let deps = 
+                match deps with 
+                | None -> 
+                  let json = Ext_json.parse_json_from_file Literals.bsconfig_json in 
+                  begin match json with 
+                  | `Obj map -> 
+                     map 
+                     |? (Bsb_build_schemas.package_specs, 
+                     `Arr Bsb_default.set_package_specs_from_array)
+                     |> ignore ;
+                     Bsb_default.get_package_specs ()
+                  | _ -> assert false
+                  end 
+                | Some spec -> spec in                               
+              build_bs_deps (  String_set.fold 
+              (fun k acc -> k ^ "," ^ acc ) deps Ext_string.empty ) ;  
+            if  !watch_mode then 
+                watch ()
             (* ninja is not triggered in this case *)
           end
         | `Split (bsb_args,ninja_args)
           ->
           begin
             Arg.parse_argv bsb_args bsb_main_flags annoymous usage ;
-            (* String_vec.iter (fun s -> print_endline s) targets; *)
-            regenerate_ninja cwd bsc_dir !force_regenerate;
-            ninja_command ninja ninja_args
+            let deps = (regenerate_ninja cwd bsc_dir !force_regenerate) in 
+            (* [-make-world] should never be combined with [-package-specs] *)
+            if !make_world then 
+              let deps = 
+                match deps with 
+                | None -> 
+                  let json = Ext_json.parse_json_from_file Literals.bsconfig_json in 
+                  begin match json with 
+                  | `Obj map -> 
+                     map 
+                     |? (Bsb_build_schemas.package_specs, 
+                     `Arr Bsb_default.set_package_specs_from_array)
+                     |> ignore ;
+                     Bsb_default.get_package_specs ()
+                  | _ -> assert false
+                  end 
+                | Some spec -> spec in                               
+              build_bs_deps (  String_set.fold 
+              (fun k acc -> k ^ "," ^ acc ) deps Ext_string.empty ) ;   
+            if !watch_mode then watch ()  
+            else ninja_command ninja ninja_args
           end
       end
   (*with x ->

--- a/jscomp/bsb/bsb_unix.mli
+++ b/jscomp/bsb/bsb_unix.mli
@@ -38,3 +38,7 @@ val run_commands : command list -> unit
 val run_command_execv : bool ->  command -> unit 
 
 (* val run_command_execvp : command -> unit *)
+
+val remove_dirs_recursive : string ->  string array -> unit 
+
+val remove_dir_recursive : string -> unit 

--- a/jscomp/core/js_main.ml
+++ b/jscomp/core/js_main.ml
@@ -155,6 +155,9 @@ let buckle_script_flags =
    " only check syntax"
   )
   ::
+  ("-bs-no-bin-annot", Arg.Clear Clflags.binary_annotations, 
+   " disable binary annotations (by default on)")
+  ::
   ("-bs-eval", 
    Arg.String set_eval_string, 
    " (experimental) Set the string to be evaluated, note this flag will be conflicted with -bs-main"
@@ -258,6 +261,7 @@ let buckle_script_flags =
 let _ = 
   Clflags.unsafe_string := false;
   Clflags.debug := true;
+  Clflags.binary_annotations := true; 
   Bs_conditional_initial.setup_env ();
   try
     Compenv.readenv ppf Before_args;


### PR DESCRIPTION
1,
```
bsb -clean-world -make-world -w
```
2. allow user to override package-spec from his repo, 
suppose he has package a, which depends on package b, package c.
as long as package a asks to build goog module, we do the same for b and c regardless of how b and c is set up 
