### PR TITLE
[bsb] default refmt-flags to ["--print", "binary"]

### DIFF
--- a/jscomp/bin/bsb.ml
+++ b/jscomp/bin/bsb.ml
@@ -6945,13 +6945,12 @@ let set_ocamllex ~cwd s =
 let get_ocamllex () = !ocamllex
 
 
-
 let refmt = ref "refmt"
 let get_refmt () = !refmt
 let set_refmt ~cwd p =
   refmt := resolve_bsb_magic_file ~cwd ~desc:"refmt" p
 
-let refmt_flags = ref []
+let refmt_flags = ref ["--print"; "binary"]
 let get_refmt_flags () = !refmt_flags
 let set_refmt_flags s =
   refmt_flags := get_list_string s

--- a/jscomp/bsb/bsb_default.ml
+++ b/jscomp/bsb/bsb_default.ml
@@ -116,13 +116,12 @@ let set_ocamllex ~cwd s =
 let get_ocamllex () = !ocamllex
 
 
-
 let refmt = ref "refmt"
 let get_refmt () = !refmt
 let set_refmt ~cwd p =
   refmt := resolve_bsb_magic_file ~cwd ~desc:"refmt" p
 
-let refmt_flags = ref []
+let refmt_flags = ref ["--print"; "binary"]
 let get_refmt_flags () = !refmt_flags
 let set_refmt_flags s =
   refmt_flags := get_list_string s


### PR DESCRIPTION
I didn't change refmt to "reason/refmt_impl.native" yet. Esy might be able to kill this implementation detail and put `refmt` into the environment correctly.