### PR TITLE
experimental support of es6 global module

### DIFF
--- a/jscomp/Makefile
+++ b/jscomp/Makefile
@@ -10,7 +10,8 @@ BYTE=ocamlc.opt$(EXE)
 OCAMLLEX=ocamllex.opt$(EXE)
 CAMLP4OF=camlp4of
 CAMLDEP=ocamldep.opt$(EXE)
-COMPFLAGS=  -g -w +6-40-30-23 -warn-error +a-40-30-23
+COMPFLAGS=-g -w +6-40-30-23 -warn-error +a-40-30-23
+# COMPFLAGS+= -S
 
 
 .SUFFIXES: .mli .ml .cmi .cmx .mll .c .o .cmo

--- a/jscomp/all.depend
+++ b/jscomp/all.depend
@@ -437,7 +437,8 @@ core/lam_group_pass.cmx : core/lam.cmx
 core/lam_compile_env.cmx : core/type_util.cmx ext/string_map.cmx \
     core/lam_module_ident.cmx core/lam.cmx core/js_stmt_make.cmx \
     core/js_exp_make.cmx common/js_config.cmx core/js_cmj_format.cmx \
-    ext/ext_ident.cmx core/config_util.cmx core/lam_compile_env.cmi
+    ext/ext_string.cmx ext/ext_ident.cmx core/config_util.cmx \
+    core/lam_compile_env.cmi
 core/lam_stats_util.cmx : core/lam_stats.cmx core/lam_compile_env.cmx \
     core/lam.cmx ext/ident_hashtbl.cmx ext/ext_list.cmx \
     core/lam_stats_util.cmi

--- a/jscomp/bin/all_ounit_tests.i.ml
+++ b/jscomp/bin/all_ounit_tests.i.ml
@@ -75,7 +75,7 @@ open OUnitTypes
 
 (** Most simple heuristic, just pick the first test. *)
 let simple state =
-  (* 130 *) List.hd state.tests_planned
+  (* 132 *) List.hd state.tests_planned
 
 end
 module OUnitUtils
@@ -98,22 +98,22 @@ let is_success =
 let is_failure = 
   function
     | RFailure _ -> (* 0 *) true
-    | RSuccess _ | RError _  | RSkip _ | RTodo _ -> (* 260 *) false
+    | RSuccess _ | RError _  | RSkip _ | RTodo _ -> (* 264 *) false
 
 let is_error = 
   function 
     | RError _ -> (* 0 *) true
-    | RSuccess _ | RFailure _ | RSkip _ | RTodo _ -> (* 260 *) false
+    | RSuccess _ | RFailure _ | RSkip _ | RTodo _ -> (* 264 *) false
 
 let is_skip = 
   function
     | RSkip _ -> (* 0 *) true
-    | RSuccess _ | RFailure _ | RError _  | RTodo _ -> (* 260 *) false
+    | RSuccess _ | RFailure _ | RError _  | RTodo _ -> (* 264 *) false
 
 let is_todo = 
   function
     | RTodo _ -> (* 0 *) true
-    | RSuccess _ | RFailure _ | RError _  | RSkip _ -> (* 260 *) false
+    | RSuccess _ | RFailure _ | RError _  | RSkip _ -> (* 264 *) false
 
 let result_flavour = 
   function
@@ -145,7 +145,7 @@ let rec was_successful =
     | [] -> (* 3 *) true
     | RSuccess _::t 
     | RSkip _::t -> 
-        (* 390 *) was_successful t
+        (* 396 *) was_successful t
 
     | RFailure _::_
     | RError _::_ 
@@ -155,22 +155,22 @@ let rec was_successful =
 let string_of_node = 
   function
     | ListItem n -> 
-        (* 520 *) string_of_int n
+        (* 528 *) string_of_int n
     | Label s -> 
-        (* 780 *) s
+        (* 792 *) s
 
 (* Return the number of available tests *)
 let rec test_case_count = 
   function
-    | TestCase _ -> (* 130 *) 1 
-    | TestLabel (_, t) -> (* 151 *) test_case_count t
+    | TestCase _ -> (* 132 *) 1 
+    | TestLabel (_, t) -> (* 153 *) test_case_count t
     | TestList l -> 
         (* 21 *) List.fold_left 
-          (fun c t -> (* 150 *) c + test_case_count t) 
+          (fun c t -> (* 152 *) c + test_case_count t) 
           0 l
 
 let string_of_path path =
-  (* 260 *) String.concat ":" (List.rev_map string_of_node path)
+  (* 264 *) String.concat ":" (List.rev_map string_of_node path)
 
 let buff_format_printf f = 
   (* 0 *) let buff = Buffer.create 13 in
@@ -194,12 +194,12 @@ let mapi f l =
 
 let fold_lefti f accu l =
   (* 21 *) let rec rfold_lefti cnt accup l = 
-    (* 171 *) match l with
+    (* 173 *) match l with
       | [] -> 
           (* 21 *) accup
 
       | h::t -> 
-          (* 150 *) rfold_lefti (cnt + 1) (f accup h cnt) t
+          (* 152 *) rfold_lefti (cnt + 1) (f accup h cnt) t
   in
     rfold_lefti 0 accu l
 
@@ -217,7 +217,7 @@ open OUnitUtils
 type event_type = GlobalEvent of global_event | TestEvent of test_event
 
 let format_event verbose event_type =
-  (* 782 *) match event_type with
+  (* 794 *) match event_type with
     | GlobalEvent e ->
         (* 2 *) begin
           match e with 
@@ -276,31 +276,31 @@ let format_event verbose event_type =
         end
 
     | TestEvent e ->
-        (* 780 *) begin
+        (* 792 *) begin
           let string_of_result = 
             if verbose then
-              (* 390 *) function
-                | RSuccess _      -> (* 130 *) "ok\n"
+              (* 396 *) function
+                | RSuccess _      -> (* 132 *) "ok\n"
                 | RFailure (_, _) -> (* 0 *) "FAIL\n"
                 | RError (_, _)   -> (* 0 *) "ERROR\n"
                 | RSkip (_, _)    -> (* 0 *) "SKIP\n"
                 | RTodo (_, _)    -> (* 0 *) "TODO\n"
             else
-              (* 390 *) function
-                | RSuccess _      -> (* 130 *) "."
+              (* 396 *) function
+                | RSuccess _      -> (* 132 *) "."
                 | RFailure (_, _) -> (* 0 *) "F"
                 | RError (_, _)   -> (* 0 *) "E"
                 | RSkip (_, _)    -> (* 0 *) "S"
                 | RTodo (_, _)    -> (* 0 *) "T"
           in
             if verbose then
-              (* 390 *) match e with 
+              (* 396 *) match e with 
                 | EStart p -> 
-                    (* 130 *) Printf.sprintf "%s start\n" (string_of_path p)
+                    (* 132 *) Printf.sprintf "%s start\n" (string_of_path p)
                 | EEnd p -> 
-                    (* 130 *) Printf.sprintf "%s end\n" (string_of_path p)
+                    (* 132 *) Printf.sprintf "%s end\n" (string_of_path p)
                 | EResult result -> 
-                    (* 130 *) string_of_result result
+                    (* 132 *) string_of_result result
                 | ELog (lvl, str) ->
                     (* 0 *) let prefix = 
                       match lvl with 
@@ -312,21 +312,21 @@ let format_event verbose event_type =
                 | ELogRaw str ->
                     (* 0 *) str
             else 
-              (* 390 *) match e with 
-                | EStart _ | EEnd _ | ELog _ | ELogRaw _ -> (* 260 *) ""
-                | EResult result -> (* 130 *) string_of_result result
+              (* 396 *) match e with 
+                | EStart _ | EEnd _ | ELog _ | ELogRaw _ -> (* 264 *) ""
+                | EResult result -> (* 132 *) string_of_result result
         end
 
 let file_logger fn =
   (* 1 *) let chn = open_out fn in
     (fun ev ->
-       (* 391 *) output_string chn (format_event true ev);
+       (* 397 *) output_string chn (format_event true ev);
        flush chn),
     (fun () -> (* 1 *) close_out chn)
 
 let std_logger verbose =
   (* 1 *) (fun ev -> 
-     (* 391 *) print_string (format_event verbose ev);
+     (* 397 *) print_string (format_event verbose ev);
      flush stdout),
   (fun () -> (* 1 *) ())
 
@@ -343,7 +343,7 @@ let create output_file_opt verbose (log,close) =
           (* 0 *) null_logger
   in
     (fun ev ->
-       (* 391 *) std_log ev; file_log ev; log ev),
+       (* 397 *) std_log ev; file_log ev; log ev),
     (fun () ->
        (* 1 *) std_close (); file_close (); close ())
 
@@ -711,7 +711,7 @@ let assert_string str =
   (* 0 *) if not (str = "") then (* 0 *) assert_failure str
 
 let assert_equal ?(cmp = ( = )) ?printer ?pp_diff ?msg expected actual =
-  (* 2001486 *) let get_error_string () =
+  (* 2001488 *) let get_error_string () =
     (* 0 *) let res =
       buff_format_printf
         (fun fmt ->
@@ -951,7 +951,7 @@ let (@?) = assert_bool
 
 (* Some shorthands which allows easy test construction *)
 let (>:) s t = (* 0 *) TestLabel(s, t)             (* infix *)
-let (>::) s f = (* 130 *) TestLabel(s, TestCase(f))  (* infix *)
+let (>::) s f = (* 132 *) TestLabel(s, TestCase(f))  (* infix *)
 let (>:::) s l = (* 21 *) TestLabel(s, TestList(l)) (* infix *)
 
 (* Utility function to manipulate test *)
@@ -1087,7 +1087,7 @@ let maybe_backtrace = ""
 (* Run all tests, report starts, errors, failures, and return the results *)
 let perform_test report test =
   (* 1 *) let run_test_case f path =
-    (* 130 *) try 
+    (* 132 *) try 
       f ();
       RSuccess path
     with
@@ -1106,22 +1106,22 @@ let perform_test report test =
   let rec flatten_test path acc = 
     function
       | TestCase(f) -> 
-          (* 130 *) (path, f) :: acc
+          (* 132 *) (path, f) :: acc
 
       | TestList (tests) ->
           (* 21 *) fold_lefti 
             (fun acc t cnt -> 
-               (* 150 *) flatten_test 
+               (* 152 *) flatten_test 
                  ((ListItem cnt)::path) 
                  acc t)
             acc tests
       
       | TestLabel (label, t) -> 
-          (* 151 *) flatten_test ((Label label)::path) acc t
+          (* 153 *) flatten_test ((Label label)::path) acc t
   in
   let test_cases = List.rev (flatten_test [] [] test) in
   let runner (path, f) = 
-    (* 130 *) let result = 
+    (* 132 *) let result = 
       report (EStart path);
       run_test_case f path 
     in
@@ -1130,18 +1130,18 @@ let perform_test report test =
       result
   in
   let rec iter state = 
-    (* 131 *) match state.tests_planned with 
+    (* 133 *) match state.tests_planned with 
       | [] ->
           (* 1 *) state.results
       | _ ->
-          (* 130 *) let (path, f) = !global_chooser state in            
+          (* 132 *) let (path, f) = !global_chooser state in            
           let result = runner (path, f) in
             iter 
               {
                 results = result :: state.results;
                 tests_planned = 
                   List.filter 
-                    (fun (path', _) -> (* 8515 *) path <> path') state.tests_planned
+                    (fun (path', _) -> (* 8778 *) path <> path') state.tests_planned
               }
   in
     iter {results = []; tests_planned = test_cases}
@@ -1171,7 +1171,7 @@ let run_test_tt ?verbose test =
     time_fun 
       perform_test 
       (fun ev ->
-         (* 390 *) log (OUnitLogger.TestEvent ev))
+         (* 396 *) log (OUnitLogger.TestEvent ev))
       test 
   in
     
@@ -1294,6 +1294,12 @@ val map2i : (int -> 'a -> 'b -> 'c ) -> 'a array -> 'b array -> 'c array
 
 val to_list_map : ('a -> 'b option) -> 'a array -> 'b list 
 
+val to_list_map_acc : 
+  ('a -> 'b option) -> 
+  'a array -> 
+  'b list -> 
+  'b list 
+
 val of_list_map : ('a -> 'b) -> 'a list -> 'b array 
 
 val rfind_with_index : 'a array -> ('a -> 'b -> bool) -> 'b -> int
@@ -1414,15 +1420,20 @@ let map2i f a b =
   else
     (* 0 *) Array.mapi (fun i a -> (* 0 *) f i  a ( Array.unsafe_get b i )) a 
 
-let to_list_map f a =
-  (* 0 *) let rec tolist i res =
-    (* 0 *) if i < 0 then (* 0 *) res else
-      (* 0 *) let v = Array.unsafe_get a i in
-      tolist (i - 1)
+
+ let rec tolist_aux a f  i res =
+    (* 14 *) if i < 0 then (* 2 *) res else
+      (* 12 *) let v = Array.unsafe_get a i in
+      tolist_aux a f  (i - 1)
         (match f v with
-         | Some v -> (* 0 *) v :: res
-         | None -> (* 0 *) res) in
-  tolist (Array.length a - 1) []
+         | Some v -> (* 6 *) v :: res
+         | None -> (* 6 *) res) 
+
+let to_list_map f a = 
+  (* 0 *) tolist_aux a f (Array.length a - 1) []
+
+let to_list_map_acc f a acc = 
+  (* 2 *) tolist_aux a f (Array.length a - 1) acc
 
 
 (* TODO: What would happen if [f] raise, memory leak? *)
@@ -2262,7 +2273,19 @@ let suites =
         (* 1 *) Ext_array.of_list_map succ [] =~ [||];
         Ext_array.of_list_map succ [1]  =~ [|2|];
         Ext_array.of_list_map succ [1;2;3]  =~ [|2;3;4|];
-    end
+    end; 
+    __LOC__ >:: begin fun _ -> 
+        (* 1 *) Ext_array.to_list_map_acc
+        (fun x -> (* 6 *) if x mod 2 = 0 then (* 3 *) Some x else (* 3 *) None )
+        [|1;2;3;4;5;6|] [1;2;3]
+        =~ [2;4;6;1;2;3]
+    end;
+    __LOC__ >:: begin fun _ -> 
+        (* 1 *) Ext_array.to_list_map_acc
+        (fun x -> (* 6 *) if x mod 2 = 0 then (* 3 *) Some x else (* 3 *) None )
+        [|1;2;3;4;5;6|] []
+        =~ [2;4;6]
+    end;
     ]
 end
 module Ounit_tests_util
@@ -3539,6 +3562,7 @@ val commonjs : string
 val amdjs : string 
 val goog : string 
 val es6 : string 
+val es6_global : string
 val unused_attribute : string 
 end = struct
 #1 "literals.ml"
@@ -3639,7 +3663,7 @@ let commonjs = "commonjs"
 let amdjs = "amdjs"
 let goog = "goog"
 let es6 = "es6"
-
+let es6_global = "es6-global"
 let unused_attribute = "Unused attribute " 
 end
 module Ounit_cmd_util : sig 

--- a/jscomp/bin/bsdep.ml
+++ b/jscomp/bin/bsdep.ml
@@ -24774,8 +24774,12 @@ module Js_config : sig
 
 
 type module_system = 
-  | NodeJS | AmdJS | Goog  (* This will be serliazed *)
+  | NodeJS 
+  | AmdJS
+  | Goog  (* This will be serliazed *)
   | Es6
+  | Es6_global
+  | AmdJS_global
 
 type package_info = 
  (module_system * string )
@@ -24945,11 +24949,14 @@ end = struct
 
 
 type path = string
+
 type module_system =
   | NodeJS 
   | AmdJS 
   | Goog
   | Es6
+  | Es6_global (* ignore node_modules, just calcluating relative path *)
+  | AmdJS_global (* see ^ *)
 
 type package_info =
  ( module_system * string )
@@ -25000,6 +25007,8 @@ let set_npm_package_path s =
          | "amdjs" -> AmdJS
          | "goog" -> Goog
          | "es6" -> Es6
+         | "es6-global" -> Es6_global
+         | "amdjs-global" -> AmdJS_global
          | _ ->
            Ext_pervasives.bad_argf "invalid module system %s" package_name), path
       | [path] ->
@@ -25034,13 +25043,25 @@ type info_query =
   | Found of package_name * string
   | NotFound 
 
+(* ocamlopt could not optimize such simple case..*)
+let compatible exist query =
+  match query with 
+  | NodeJS -> exist = NodeJS 
+  | AmdJS -> exist = AmdJS
+  | Goog -> exist = Goog
+  | Es6  -> exist = Es6
+  | Es6_global  
+    -> exist = Es6_global || exist = Es6
+  | AmdJS_global 
+    -> exist = AmdJS_global || exist = AmdJS
+   (* As a dependency Leaf Node, it is the same either [global] or [not] *)
 
 let query_package_infos (package_infos : packages_info) module_system =
   match package_infos with
   | Empty -> Empty
   | NonBrowser (name, []) -> Package_script name
   | NonBrowser (name, paths) ->
-    begin match List.find (fun (k, _) -> k = module_system) paths with
+    begin match List.find (fun (k, _) -> compatible k  module_system) paths with
       | (_, x) -> Found (name, x)
       | exception _ -> NotFound
     end
@@ -25061,7 +25082,7 @@ let get_output_dir ~pkg_dir module_system filename =
     else
       Filename.dirname filename
   | NonBrowser (_,  modules) ->
-    begin match List.find (fun (k,_) -> k = module_system) modules with
+    begin match List.find (fun (k,_) -> compatible k  module_system) modules with
       | (_, _path) -> pkg_dir // _path
       |  exception _ -> assert false
     end

--- a/jscomp/common/js_config.ml
+++ b/jscomp/common/js_config.ml
@@ -24,11 +24,14 @@
 
 
 type path = string
+
 type module_system =
   | NodeJS 
   | AmdJS 
   | Goog
   | Es6
+  | Es6_global (* ignore node_modules, just calcluating relative path *)
+  | AmdJS_global (* see ^ *)
 
 type package_info =
  ( module_system * string )
@@ -79,6 +82,8 @@ let set_npm_package_path s =
          | "amdjs" -> AmdJS
          | "goog" -> Goog
          | "es6" -> Es6
+         | "es6-global" -> Es6_global
+         | "amdjs-global" -> AmdJS_global
          | _ ->
            Ext_pervasives.bad_argf "invalid module system %s" package_name), path
       | [path] ->
@@ -113,13 +118,25 @@ type info_query =
   | Found of package_name * string
   | NotFound 
 
+(* ocamlopt could not optimize such simple case..*)
+let compatible exist query =
+  match query with 
+  | NodeJS -> exist = NodeJS 
+  | AmdJS -> exist = AmdJS
+  | Goog -> exist = Goog
+  | Es6  -> exist = Es6
+  | Es6_global  
+    -> exist = Es6_global || exist = Es6
+  | AmdJS_global 
+    -> exist = AmdJS_global || exist = AmdJS
+   (* As a dependency Leaf Node, it is the same either [global] or [not] *)
 
 let query_package_infos (package_infos : packages_info) module_system =
   match package_infos with
   | Empty -> Empty
   | NonBrowser (name, []) -> Package_script name
   | NonBrowser (name, paths) ->
-    begin match List.find (fun (k, _) -> k = module_system) paths with
+    begin match List.find (fun (k, _) -> compatible k  module_system) paths with
       | (_, x) -> Found (name, x)
       | exception _ -> NotFound
     end
@@ -140,7 +157,7 @@ let get_output_dir ~pkg_dir module_system filename =
     else
       Filename.dirname filename
   | NonBrowser (_,  modules) ->
-    begin match List.find (fun (k,_) -> k = module_system) modules with
+    begin match List.find (fun (k,_) -> compatible k  module_system) modules with
       | (_, _path) -> pkg_dir // _path
       |  exception _ -> assert false
     end

--- a/jscomp/common/js_config.mli
+++ b/jscomp/common/js_config.mli
@@ -24,8 +24,12 @@
 
 
 type module_system = 
-  | NodeJS | AmdJS | Goog  (* This will be serliazed *)
+  | NodeJS 
+  | AmdJS
+  | Goog  (* This will be serliazed *)
   | Es6
+  | Es6_global
+  | AmdJS_global
 
 type package_info = 
  (module_system * string )

--- a/jscomp/core/config_util.ml
+++ b/jscomp/core/config_util.ml
@@ -56,7 +56,7 @@ let find_cmj file =
   match find_opt file with
   | Some f
     -> 
-    Js_cmj_format.from_file f             
+    f, Js_cmj_format.from_file f             
   | None -> 
     (* ONLY read the stored cmj data in browser environment *)
 #if BS_COMPILER_IN_BROWSER then     

--- a/jscomp/core/config_util.mli
+++ b/jscomp/core/config_util.mli
@@ -37,5 +37,5 @@
 val find_opt : string -> string option
 (** [find filename] Input is a file name, output is absolute path *)
 
-
-val find_cmj : string -> Js_cmj_format.t
+(** return path and meta data *)
+val find_cmj : string -> string * Js_cmj_format.t

--- a/jscomp/core/js_dump.ml
+++ b/jscomp/core/js_dump.ml
@@ -1766,7 +1766,7 @@ let node_program ~output_prefix f ( x : J.deps_program) =
   program f cxt x.program  
 
 
-let amd_program ~output_prefix f (  x : J.deps_program) = 
+let amd_program ~output_prefix kind f (  x : J.deps_program) = 
   P.newline f ; 
   let cxt = Ext_pp_scope.empty in
   P.vgroup f 1 @@ fun _ -> 
@@ -1775,7 +1775,7 @@ let amd_program ~output_prefix f (  x : J.deps_program) =
   P.string f (Printf.sprintf "%S" L.exports);
 
   List.iter (fun x ->
-      let s = Js_program_loader.string_of_module_id ~output_prefix AmdJS x in
+      let s = Js_program_loader.string_of_module_id ~output_prefix kind x in
       P.string f L.comma ;
       P.space f; 
       pp_string f ~utf:true ~quote:(best_string_quote s) s;
@@ -1804,7 +1804,7 @@ let amd_program ~output_prefix f (  x : J.deps_program) =
   v
 
 
-let es6_program ~output_prefix f (  x : J.deps_program) = 
+let es6_program  ~output_prefix fmt f (  x : J.deps_program) = 
   let cxt = 
      imports
       Ext_pp_scope.empty
@@ -1814,7 +1814,7 @@ let es6_program ~output_prefix f (  x : J.deps_program) =
             Lam_module_ident.id x,
             Js_program_loader.string_of_module_id
               ~output_prefix
-              Es6 x)
+              fmt x)
          x.modules)
   in
   let () = P.force_newline f in 
@@ -1844,10 +1844,10 @@ let pp_deps_program
     P.string f L.strict_directive; 
     P.newline f ;    
     ignore (match kind with 
-        | Es6 -> 
-          es6_program ~output_prefix f program
-        | AmdJS -> 
-          amd_program ~output_prefix f program
+        | Es6 | Es6_global -> 
+          es6_program ~output_prefix kind f program
+        | AmdJS | AmdJS_global -> 
+          amd_program ~output_prefix kind f program
         | NodeJS -> 
           node_program ~output_prefix f program
         | Goog  -> 

--- a/jscomp/core/js_program_loader.ml
+++ b/jscomp/core/js_program_loader.ml
@@ -90,7 +90,7 @@ let string_of_module_id ~output_prefix
             `Dir (Js_config.get_output_dir ~pkg_dir:package_dir module_system output_prefix) in
           Ext_filename.node_relative_path  different_package current_unit_dir dep 
         in 
-        let dependency_pkg_info = 
+        let cmj_path, dependency_pkg_info = 
           Lam_compile_env.get_package_path_from_cmj module_system x 
         in
         let current_pkg_info = 
@@ -106,7 +106,7 @@ let string_of_module_id ~output_prefix
             Ext_pervasives.failwithf ~loc:__LOC__ 
               " @[%s was not compiled with goog support  in search path - while compiling %s @] "
               js_file !Location.input_name 
-          | (AmdJS | NodeJS | Es6),
+          | (AmdJS | NodeJS | Es6 | Es6_global | AmdJS_global),
             ( Empty | Package_script _) ,
             Found _  -> 
             Ext_pervasives.failwithf ~loc:__LOC__
@@ -114,18 +114,36 @@ let string_of_module_id ~output_prefix
               js_file !Location.input_name              
           | Goog , Found (package_name, x), _  -> 
             package_name  ^ "." ^  String.uncapitalize id.name
-          | (AmdJS | NodeJS| Es6), (Empty | Package_script _ | Found _ ), NotFound -> assert false
+          | (AmdJS | NodeJS| Es6 | Es6_global|AmdJS_global),
+           (Empty | Package_script _ | Found _ ), NotFound -> assert false
 
-          | (AmdJS | NodeJS | Es6), 
+          | (AmdJS | NodeJS | Es6 | Es6_global|AmdJS_global), 
             Found(package_name, x),
             Found(current_package, path) -> 
             if  current_package = package_name then 
               let package_dir = Lazy.force Ext_filename.package_dir in
               rebase false package_dir (`File (package_dir // x // modulename)) 
             else 
-              package_name // x // modulename
-          
-          | (AmdJS | NodeJS | Es6), Found(package_name, x), 
+              begin match module_system with 
+              | AmdJS | NodeJS | Es6 -> 
+                package_name // x // modulename
+              | Goog -> assert false (* see above *)
+              | Es6_global 
+              | AmdJS_global -> 
+               (** lib/ocaml/xx.cmj --               
+                HACKING: FIXME
+                maybe we can caching relative package path calculation or employ package map *)
+                (* assert false  *)
+                
+                begin 
+                  Ext_filename.rel_normalized_absolute_path              
+                    (Js_config.get_output_dir ~pkg_dir:(Lazy.force Ext_filename.package_dir)
+                       module_system output_prefix)
+                    ((Filename.dirname 
+                        (Filename.dirname (Filename.dirname cmj_path))) // x // modulename)              
+                end
+              end
+          | (AmdJS | NodeJS | Es6 | AmdJS_global | Es6_global), Found(package_name, x), 
             Package_script(current_package)
             ->    
             if current_package = package_name then 
@@ -134,9 +152,10 @@ let string_of_module_id ~output_prefix
                   package_dir // x // modulename)) 
             else 
               package_name // x // modulename
-          | (AmdJS | NodeJS | Es6), Found(package_name, x), Empty 
+          | (AmdJS | NodeJS | Es6 | AmdJS_global | Es6_global), 
+            Found(package_name, x), Empty 
             ->    package_name // x // modulename
-          |  (AmdJS | NodeJS | Es6), 
+          |  (AmdJS | NodeJS | Es6 | AmdJS_global | Es6_global), 
              (Empty | Package_script _) , 
              (Empty  | Package_script _)
             -> 
@@ -149,7 +168,15 @@ let string_of_module_id ~output_prefix
             end
           
         end
-      | External name -> name in 
+      | External name -> name 
+        (** This may not be enough, 
+          1. For cross packages, we may need settle 
+            down a single js package
+          2. We may need es6 path for dead code elimination
+             But frankly, very few JS packages have no dependency, 
+             so having plugin may sound not that bad   
+        *)
+      in 
     if Ext_sys.is_windows_or_cygwin then Ext_string.replace_backward_slash result 
     else result 
 #end

--- a/jscomp/core/lam_compile_env.mli
+++ b/jscomp/core/lam_compile_env.mli
@@ -42,7 +42,7 @@ type key =
   *)
   (** we need register which global variable is an dependency *)
 
-
+type path = string 
 type ident_info = {
   id : Ident.t;
   name : string;
@@ -57,7 +57,7 @@ type module_info = {
 }
 
 type _ t = 
-  | No_env :  Js_cmj_format.t t 
+  | No_env :  (path * Js_cmj_format.t) t 
   | Has_env : Env.t  -> module_info t 
 
 val find_and_add_if_not_exist : 
@@ -94,7 +94,8 @@ val is_pure_module : Lam_module_ident.t -> bool
 
 val get_package_path_from_cmj : 
   Lam_module_ident.system -> Lam_module_ident.t -> 
-  Js_config.info_query
+  string * Js_config.info_query
+  (*FIXME when the latter is [NotFound], the former is meaningless*)
 
 
 (* The second argument is mostly from [runtime] modules 


### PR DESCRIPTION
This commit introduces two package format, amdjs-global and es6-global, which will use relative path so that for some bundlers like rollup or google closure, it does not need have knowledge of node_modules path resolution
couple of design issues:
1. how to know the path of external JS library, currently we leave it as it
Implementation details:
we might need have a global view of dependencies and pass a package map unlike current implementation which did lots of path calculation
