### PR TITLE
rebuild if version mismatches

### DIFF
--- a/jscomp/all.depend
+++ b/jscomp/all.depend
@@ -573,8 +573,8 @@ core/bspp_main.cmx : core/bspp_main.cmi
 core/js_cmi_datasets.cmx : ext/string_map.cmx core/js_cmi_datasets.cmi
 core/js_main.cmx : core/ocaml_parse.cmx core/ocaml_options.cmx \
     core/ocaml_batch_compile.cmx core/js_implementation.cmx \
-    common/js_config.cmx ext/ext_string.cmx core/bs_conditional_initial.cmx \
-    core/js_main.cmi
+    common/js_config.cmx ext/ext_string.cmx common/bs_version.cmx \
+    core/bs_conditional_initial.cmx core/js_main.cmi
 ounit/oUnit.cmi :
 ounit/oUnitDiff.cmi :
 ounit/oUnit.cmx : ounit/oUnitUtils.cmx ounit/oUnitTypes.cmx \

--- a/jscomp/bin/bsb.ml
+++ b/jscomp/bin/bsb.ml
@@ -7308,6 +7308,7 @@ let get_package_name () = !package_name
 *)  
 (** *)
 let bsc_flags = ref [
+    "-bs-check-version" ; Bs_version.version ; 
     "-w"; "-40+6+7+27+32..39+44+45"
 
   ]

--- a/jscomp/bin/whole_compiler.ml
+++ b/jscomp/bin/whole_compiler.ml
@@ -106222,7 +106222,14 @@ let set_eval_string s =
     raise (Arg.Bad ("-bs-main conflicts with -bs-eval")) else 
   eval_string :=  s 
 
-
+let check_version version =
+  if not @@ Ext_string.equal version Bs_version.version then 
+    raise (Arg.Bad 
+    ( "Compiler version " ^ 
+      Bs_version.version ^ 
+      " does not mattch with passed version " ^ 
+      version
+    ))
 
 
 let (//) = Filename.concat
@@ -106286,6 +106293,10 @@ let buckle_script_flags =
   ::
   ("-bs-D", Arg.String define_variable,
      " Define conditional variable e.g, -D DEBUG=true"
+  )
+  ::
+  ("-bs-check-version", Arg.String check_version,
+    " Check the passed version matches the compiler version"
   )
   ::
   ("-bs-list-conditionals",

--- a/jscomp/bsb/bsb_default.ml
+++ b/jscomp/bsb/bsb_default.ml
@@ -57,6 +57,7 @@ let get_package_name () = !package_name
 *)  
 (** *)
 let bsc_flags = ref [
+    "-bs-check-version" ; Bs_version.version ; 
     "-w"; "-40+6+7+27+32..39+44+45"
 
   ]

--- a/jscomp/core/js_main.ml
+++ b/jscomp/core/js_main.ml
@@ -64,7 +64,14 @@ let set_eval_string s =
     raise (Arg.Bad ("-bs-main conflicts with -bs-eval")) else 
   eval_string :=  s 
 
-
+let check_version version =
+  if not @@ Ext_string.equal version Bs_version.version then 
+    raise (Arg.Bad 
+    ( "Compiler version " ^ 
+      Bs_version.version ^ 
+      " does not mattch with passed version " ^ 
+      version
+    ))
 
 
 let (//) = Filename.concat
@@ -128,6 +135,10 @@ let buckle_script_flags =
   ::
   ("-bs-D", Arg.String define_variable,
      " Define conditional variable e.g, -D DEBUG=true"
+  )
+  ::
+  ("-bs-check-version", Arg.String check_version,
+    " Check the passed version matches the compiler version"
   )
   ::
   ("-bs-list-conditionals",


### PR DESCRIPTION
address #1162 

Note that the trick there would still hit some corner cases: that when our build system is incorrect, suppose A.cmj depends on B.cmj but not specified in the build then A.cmj would still pick up B.cmj.
A more defensive approach would be just do a clean up when finding mismatched versions