### PR TITLE
Additions to js_string and js_array

### DIFF
--- a/jscomp/others/js_array.ml
+++ b/jscomp/others/js_array.ml
@@ -1,5 +1,5 @@
 (* Copyright (C) 2015-2016 Bloomberg Finance L.P.
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
@@ -17,61 +17,122 @@
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
 
-
 type 'a t = 'a array
+type 'a array_like
+type 'a array_iter = 'a array_like (* don't think this is very useful to implement wihtout language support *)
 
-external toString : unit -> string  = "" [@@bs.send.pipe: 'a t as 'this]
-external toLocaleString : unit -> string  = "" [@@bs.send.pipe: 'a t as 'this]
-external concat : 'this -> 'this  = "" [@@bs.send.pipe: 'a t as 'this]
+external make : int -> unit Js.undefined array = "Array" [@@bs.new]
+
+external from : 'a array_like -> 'b array = "Array.from" [@@bs.val] (* es2015 *)
+external unsafeFrom : 'a -> 'b array = "Array.from" [@@bs.val] (* es2015 *)
+external fromMap : 'a array_like -> ('a -> 'b [@bs]) -> 'b array = "Array.from" [@@bs.val] (* es2015 *)
+external unsafeFromMap : 'a -> ('b -> 'c [@bs]) -> 'c array = "Array.from" [@@bs.val] (* es2015 *)
+external isArray : 'a -> Js.boolean = "Array.isArray" [@@bs.val] (* es2015 *)
+(* Array.of: seems pointless unless you can bind *) (* es2015 *)
+
+external length : 'a array -> int = "" [@@bs.get]
+
+
+(* Mutator functions
+*)
+external copyWithin : to_:int -> 'this = "" [@@bs.send.pipe: 'a t as 'this] (* es2015 *)
+external copyWithinFrom : to_:int -> from:int -> 'this = "copyWithin" [@@bs.send.pipe: 'a t as 'this] (* es2015 *)
+external copyWithinFromRange : to_:int -> start:int -> end_:int -> 'this = "copyWithin" [@@bs.send.pipe: 'a t as 'this] (* es2015 *)
+
+external fill : 'a -> 'this = "" [@@bs.send.pipe: 'a t as 'this] (* es2015 *)
+external fillFrom : 'a -> from:int -> 'this = "fill" [@@bs.send.pipe: 'a t as 'this] (* es2015 *)
+external fillRange : 'a -> start:int -> end_:int -> 'this = "fill" [@@bs.send.pipe: 'a t as 'this] (* es2015 *)
+
+(** https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/push *)
+external pop : 'a Js.undefined = "" [@@bs.send.pipe: 'a t as 'this]
+external push : 'a -> int = "" [@@bs.send.pipe: 'a t as 'this]
+external pushMany : 'a array -> int = "push" [@@bs.send.pipe: 'a t as 'this] [@@bs.splice]
+
+external reverse : 'this = "" [@@bs.send.pipe: 'a t as 'this]
+
+external shift : 'a Js.undefined = "" [@@bs.send.pipe: 'a t as 'this]
+
+external sort : 'this = "" [@@bs.send.pipe: 'a t as 'this]
+external sortWith : ('a -> 'a -> int [@bs]) -> 'this = "sort" [@@bs.send.pipe: 'a t as 'this]
+
+external splice : pos:int -> remove:int -> add:('a array) -> 'this = "" [@@bs.send.pipe: 'a t as 'this] [@@bs.splice]
+external removeFrom : pos:int -> 'this = "splice" [@@bs.send.pipe: 'a t as 'this]
+external removeCount : pos:int -> count:int -> 'this = "splice" [@@bs.send.pipe: 'a t as 'this]
+(* screwy naming, but screwy function *)
+
+external unshift : 'a -> int = "" [@@bs.send.pipe: 'a t as 'this]
+external unshiftMany : 'a array -> int = "unshift" [@@bs.send.pipe: 'a t as 'this] [@@bs.splice]
+
+
+(* Accessor functions
+*)
 external append : 'a -> 'this = "concat" [@@bs.send.pipe: 'a t as 'this]
-
-external slice : int -> int -> 'this = "" [@@bs.send.pipe: 'a t as 'this]
-external slice_copy : unit -> 'this = "slice"[@@bs.send.pipe: 'a t as 'this]
-external slice_start : int -> 'this = "slice"[@@bs.send.pipe: 'a t as 'this]
-
-external indexOf : 'a  -> int = "" [@@bs.send.pipe: 'a t as 'this]
-external indexOfFrom : 'a -> int ->  int = "indexOf" [@@bs.send.pipe: 'a t as 'this]
+external concat : 'this -> 'this = "" [@@bs.send.pipe: 'a t as 'this]
+external concatMany : 'this array -> 'this = "concat" [@@bs.send.pipe: 'a t as 'this] [@@bs.splice]
 
 (* TODO: Not available in Node V4  *)
-external includes : 'a -> Js.boolean = "" [@@bs.send.pipe: 'a t as 'this]
+external includes : 'a -> Js.boolean = "" [@@bs.send.pipe: 'a t as 'this] (* es2016 *)
 
-external lastIndexOf : 'a -> int -> int = "" [@@bs.send.pipe: 'a t as 'this]
-external lastIndexOf_start : 'a -> int  = "lastIndex" [@@bs.send.pipe: 'a t as 'this]
+external indexOf : 'a  -> int = "" [@@bs.send.pipe: 'a t as 'this]
+external indexOfFrom : 'a -> from:int -> int = "indexOf" [@@bs.send.pipe: 'a t as 'this]
+
+external join : string = "" [@@bs.send.pipe: 'a t as 'this]
+external joinWith : string -> string = "join" [@@bs.send.pipe: 'a t as 'this]
+
+external lastIndexOf : 'a -> int = "" [@@bs.send.pipe: 'a t as 'this]
+external lastIndexOfFrom : 'a -> from:int -> int = "lastIndexOf" [@@bs.send.pipe: 'a t as 'this]
+external lastIndexOf_start : 'a -> int = "lastIndexOf" [@@bs.send.pipe: 'a t as 'this]
+[@@ocaml.deprecated "Please use `lastIndexOf"]
+
+external slice : start:int -> end_:int -> 'this = "" [@@bs.send.pipe: 'a t as 'this]
+external copy : 'this = "slice" [@@bs.send.pipe: 'a t as 'this]
+external slice_copy : unit -> 'this = "slice" [@@bs.send.pipe: 'a t as 'this]
+[@@ocaml.deprecated "Please use `copy`"]
+external sliceFrom : int -> 'this = "slice" [@@bs.send.pipe: 'a t as 'this]
+external slice_start : int -> 'this = "slice" [@@bs.send.pipe: 'a t as 'this]
+[@@ocaml.deprecated "Please use `sliceFrom`"]
+
+external toString : string = "" [@@bs.send.pipe: 'a t as 'this]
+external toLocaleString : string = "" [@@bs.send.pipe: 'a t as 'this]
+
+
+(* Iteration functions
+*)
+external entries : (int * 'a) array_iter = "" [@@bs.send.pipe: 'a t as 'this] (* es2015 *)
 
 external every : ('a  -> Js.boolean [@bs]) -> Js.boolean = "" [@@bs.send.pipe: 'a t as 'this]
 external everyi : ('a -> int -> Js.boolean [@bs]) -> Js.boolean = "every" [@@bs.send.pipe: 'a t as 'this]
 
+(** should we use [bool] or [boolan] seems they are intechangeable here *)
+external filter : ('a -> bool [@bs]) -> 'this = "" [@@bs.send.pipe: 'a t as 'this]
+external filteri : ('a -> int  -> Js.boolean[@bs]) -> 'this = "filter" [@@bs.send.pipe: 'a t as 'this]
+
+external find : ('a -> bool [@bs]) -> 'a Js.undefined = "" [@@bs.send.pipe: 'a t as 'this] (* es2015 *)
+external findi : ('a -> int -> bool [@bs]) -> 'a Js.undefined  = "find" [@@bs.send.pipe: 'a t as 'this] (* es2015 *)
+
+external findIndex : ('a -> bool [@bs]) -> int = "" [@@bs.send.pipe: 'a t as 'this] (* es2015 *)
+external findIndexi : ('a -> int -> bool [@bs]) -> int = "findIndex" [@@bs.send.pipe: 'a t as 'this] (* es2015 *)
+
+external forEach : ('a -> unit [@bs]) -> unit = "" [@@bs.send.pipe: 'a t as 'this]
+external forEachi : ('a -> int -> unit [@bs]) -> unit  = "forEach" [@@bs.send.pipe: 'a t as 'this]
+
+external keys : int array_iter = "" [@@bs.send.pipe: 'a t as 'this] (* es2015 *)
+
+external map : ('a  -> 'b [@bs]) -> 'b t = "" [@@bs.send.pipe: 'a t as 'this]
+external mapi : ('a -> int ->  'b [@bs]) -> 'b t = "map" [@@bs.send.pipe: 'a t as 'this]
+
+external reduce :  ('b -> 'a  -> 'b [@bs]) -> 'b -> 'b = "" [@@bs.send.pipe: 'a t as 'this]
+external reducei : ('b -> 'a -> int -> 'b [@bs]) -> 'b -> 'b = "reduce" [@@bs.send.pipe: 'a t as 'this]
+
+external reduceRight :  ('b -> 'a  -> 'b [@bs]) -> 'b -> 'b = "" [@@bs.send.pipe: 'a t as 'this]
+external reduceRighti : ('b -> 'a -> int -> 'b [@bs]) -> 'b -> 'b = "reduceRight" [@@bs.send.pipe: 'a t as 'this]
+
 external some : ('a  -> Js.boolean [@bs]) -> Js.boolean = "" [@@bs.send.pipe: 'a t as 'this]
 external somei : ('a  -> int -> Js.boolean [@bs]) -> Js.boolean = "some" [@@bs.send.pipe: 'a t as 'this]
 
-
-external forEach : ('a -> unit [@bs]) -> unit  = "" [@@bs.send.pipe: 'a t as 'this]
-external forEachi : ('a -> int -> unit [@bs]) -> unit  = "forEach" [@@bs.send.pipe: 'a t as 'this]
-
-external map : ('a  ->  'b [@bs]) -> 'b t  = "" [@@bs.send.pipe: 'a t as 'this]
-external mapi : ('a -> int ->  'b [@bs]) -> 'b t = "map" [@@bs.send.pipe: 'a t as 'this]
-
-(** should we use [bool] or [boolan] seems they are intechangeable here *)
-external filter : ('a  -> bool [@bs]) -> 'this = "" [@@bs.send.pipe: 'a t as 'this]
-external filteri : ('a -> int  -> Js.boolean[@bs]) -> 'this = "filter" [@@bs.send.pipe: 'a t as 'this]
-
-external reducei : ('a -> 'a -> int -> 'a [@bs]) ->  'a -> 'a = "reduce" [@@bs.send.pipe: 'a t as 'this]
-external reduce :  ('a -> 'a  -> 'a [@bs]) ->  'a -> 'a = "reduce" [@@bs.send.pipe: 'a t as 'this]
-
-external isArray : 'a -> Js.boolean = "Array.isArray" [@@bs.val]
-
-(** https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/push *)    
-external push : 'a array  -> 'a -> int = ""
-[@@bs.send]
-
-external pop : 'a array -> 'a Js.undefined = ""
-[@@bs.send]
-   
-external length : 'a array -> int = ""
-[@@bs.get]
-   
+external values : 'a array_iter = "" [@@bs.send.pipe: 'a t as 'this] (* es2015 *)

--- a/jscomp/others/js_array.ml
+++ b/jscomp/others/js_array.ml
@@ -24,45 +24,44 @@
 
 type 'a t = 'a array
 type 'a array_like
-type 'a array_iter = 'a array_like (* don't think this is very useful to implement wihtout language support *)
 
-external make : int -> unit Js.undefined array = "Array" [@@bs.new]
+(* commented out until bs has a plan for iterators
+type 'a array_iter = 'a array_like
+*)
 
-external from : 'a array_like -> 'b array = "Array.from" [@@bs.val] (* es2015 *)
-external unsafeFrom : 'a -> 'b array = "Array.from" [@@bs.val] (* es2015 *)
-external fromMap : 'a array_like -> ('a -> 'b [@bs]) -> 'b array = "Array.from" [@@bs.val] (* es2015 *)
-external unsafeFromMap : 'a -> ('b -> 'c [@bs]) -> 'c array = "Array.from" [@@bs.val] (* es2015 *)
-external isArray : 'a -> Js.boolean = "Array.isArray" [@@bs.val] (* es2015 *)
-(* Array.of: seems pointless unless you can bind *) (* es2015 *)
+external from : 'a array_like -> 'b array = "Array.from" [@@bs.val] (** ES2015 *)
+external fromMap : 'a array_like -> ('a -> 'b [@bs]) -> 'b array = "Array.from" [@@bs.val] (** ES2015 *)
+external isArray : 'a -> Js.boolean = "Array.isArray" [@@bs.val] (** ES2015 *)
+(* Array.of: seems pointless unless you can bind *) (** ES2015 *)
 
 external length : 'a array -> int = "" [@@bs.get]
 
 
 (* Mutator functions
 *)
-external copyWithin : to_:int -> 'this = "" [@@bs.send.pipe: 'a t as 'this] (* es2015 *)
-external copyWithinFrom : to_:int -> from:int -> 'this = "copyWithin" [@@bs.send.pipe: 'a t as 'this] (* es2015 *)
-external copyWithinFromRange : to_:int -> start:int -> end_:int -> 'this = "copyWithin" [@@bs.send.pipe: 'a t as 'this] (* es2015 *)
+external copyWithin : to_:int -> 'this = "" [@@bs.send.pipe: 'a t as 'this] (** ES2015 *)
+external copyWithinFrom : to_:int -> from:int -> 'this = "copyWithin" [@@bs.send.pipe: 'a t as 'this] (** ES2015 *)
+external copyWithinFromRange : to_:int -> start:int -> end_:int -> 'this = "copyWithin" [@@bs.send.pipe: 'a t as 'this] (** ES2015 *)
 
-external fill : 'a -> 'this = "" [@@bs.send.pipe: 'a t as 'this] (* es2015 *)
-external fillFrom : 'a -> from:int -> 'this = "fill" [@@bs.send.pipe: 'a t as 'this] (* es2015 *)
-external fillRange : 'a -> start:int -> end_:int -> 'this = "fill" [@@bs.send.pipe: 'a t as 'this] (* es2015 *)
+external fillInPlace : 'a -> 'this = "fill" [@@bs.send.pipe: 'a t as 'this] (** ES2015 *)
+external fillFromInPlace : 'a -> from:int -> 'this = "fill" [@@bs.send.pipe: 'a t as 'this] (** ES2015 *)
+external fillRangeInPlace : 'a -> start:int -> end_:int -> 'this = "fill" [@@bs.send.pipe: 'a t as 'this] (** ES2015 *)
 
 (** https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/push *)
 external pop : 'a Js.undefined = "" [@@bs.send.pipe: 'a t as 'this]
 external push : 'a -> int = "" [@@bs.send.pipe: 'a t as 'this]
 external pushMany : 'a array -> int = "push" [@@bs.send.pipe: 'a t as 'this] [@@bs.splice]
 
-external reverse : 'this = "" [@@bs.send.pipe: 'a t as 'this]
+external reverseInPlace : 'this = "reverse" [@@bs.send.pipe: 'a t as 'this]
 
 external shift : 'a Js.undefined = "" [@@bs.send.pipe: 'a t as 'this]
 
-external sort : 'this = "" [@@bs.send.pipe: 'a t as 'this]
-external sortWith : ('a -> 'a -> int [@bs]) -> 'this = "sort" [@@bs.send.pipe: 'a t as 'this]
+external sortInPlace : 'this = "sort" [@@bs.send.pipe: 'a t as 'this]
+external sortInPlaceWith : ('a -> 'a -> int [@bs]) -> 'this = "sort" [@@bs.send.pipe: 'a t as 'this]
 
-external splice : pos:int -> remove:int -> add:('a array) -> 'this = "" [@@bs.send.pipe: 'a t as 'this] [@@bs.splice]
-external removeFrom : pos:int -> 'this = "splice" [@@bs.send.pipe: 'a t as 'this]
-external removeCount : pos:int -> count:int -> 'this = "splice" [@@bs.send.pipe: 'a t as 'this]
+external spliceInPlace : pos:int -> remove:int -> add:('a array) -> 'this = "splice" [@@bs.send.pipe: 'a t as 'this] [@@bs.splice]
+external removeFromInPlace : pos:int -> 'this = "splice" [@@bs.send.pipe: 'a t as 'this]
+external removeCountInPlace : pos:int -> count:int -> 'this = "splice" [@@bs.send.pipe: 'a t as 'this]
 (* screwy naming, but screwy function *)
 
 external unshift : 'a -> int = "" [@@bs.send.pipe: 'a t as 'this]
@@ -76,7 +75,7 @@ external concat : 'this -> 'this = "" [@@bs.send.pipe: 'a t as 'this]
 external concatMany : 'this array -> 'this = "concat" [@@bs.send.pipe: 'a t as 'this] [@@bs.splice]
 
 (* TODO: Not available in Node V4  *)
-external includes : 'a -> Js.boolean = "" [@@bs.send.pipe: 'a t as 'this] (* es2016 *)
+external includes : 'a -> Js.boolean = "" [@@bs.send.pipe: 'a t as 'this] (** ES2016 *)
 
 external indexOf : 'a  -> int = "" [@@bs.send.pipe: 'a t as 'this]
 external indexOfFrom : 'a -> from:int -> int = "indexOf" [@@bs.send.pipe: 'a t as 'this]
@@ -103,7 +102,9 @@ external toLocaleString : string = "" [@@bs.send.pipe: 'a t as 'this]
 
 (* Iteration functions
 *)
-external entries : (int * 'a) array_iter = "" [@@bs.send.pipe: 'a t as 'this] (* es2015 *)
+(* commented out until bs has a plan for iterators
+external entries : (int * 'a) array_iter = "" [@@bs.send.pipe: 'a t as 'this] (** ES2015 *)
+*)
 
 external every : ('a  -> Js.boolean [@bs]) -> Js.boolean = "" [@@bs.send.pipe: 'a t as 'this]
 external everyi : ('a -> int -> Js.boolean [@bs]) -> Js.boolean = "every" [@@bs.send.pipe: 'a t as 'this]
@@ -112,16 +113,18 @@ external everyi : ('a -> int -> Js.boolean [@bs]) -> Js.boolean = "every" [@@bs.
 external filter : ('a -> bool [@bs]) -> 'this = "" [@@bs.send.pipe: 'a t as 'this]
 external filteri : ('a -> int  -> Js.boolean[@bs]) -> 'this = "filter" [@@bs.send.pipe: 'a t as 'this]
 
-external find : ('a -> bool [@bs]) -> 'a Js.undefined = "" [@@bs.send.pipe: 'a t as 'this] (* es2015 *)
-external findi : ('a -> int -> bool [@bs]) -> 'a Js.undefined  = "find" [@@bs.send.pipe: 'a t as 'this] (* es2015 *)
+external find : ('a -> bool [@bs]) -> 'a Js.undefined = "" [@@bs.send.pipe: 'a t as 'this] (** ES2015 *)
+external findi : ('a -> int -> bool [@bs]) -> 'a Js.undefined  = "find" [@@bs.send.pipe: 'a t as 'this] (** ES2015 *)
 
-external findIndex : ('a -> bool [@bs]) -> int = "" [@@bs.send.pipe: 'a t as 'this] (* es2015 *)
-external findIndexi : ('a -> int -> bool [@bs]) -> int = "findIndex" [@@bs.send.pipe: 'a t as 'this] (* es2015 *)
+external findIndex : ('a -> bool [@bs]) -> int = "" [@@bs.send.pipe: 'a t as 'this] (** ES2015 *)
+external findIndexi : ('a -> int -> bool [@bs]) -> int = "findIndex" [@@bs.send.pipe: 'a t as 'this] (** ES2015 *)
 
 external forEach : ('a -> unit [@bs]) -> unit = "" [@@bs.send.pipe: 'a t as 'this]
 external forEachi : ('a -> int -> unit [@bs]) -> unit  = "forEach" [@@bs.send.pipe: 'a t as 'this]
 
-external keys : int array_iter = "" [@@bs.send.pipe: 'a t as 'this] (* es2015 *)
+(* commented out until bs has a plan for iterators
+external keys : int array_iter = "" [@@bs.send.pipe: 'a t as 'this] (** ES2015 *)
+*)
 
 external map : ('a  -> 'b [@bs]) -> 'b t = "" [@@bs.send.pipe: 'a t as 'this]
 external mapi : ('a -> int ->  'b [@bs]) -> 'b t = "map" [@@bs.send.pipe: 'a t as 'this]
@@ -135,4 +138,6 @@ external reduceRighti : ('b -> 'a -> int -> 'b [@bs]) -> 'b -> 'b = "reduceRight
 external some : ('a  -> Js.boolean [@bs]) -> Js.boolean = "" [@@bs.send.pipe: 'a t as 'this]
 external somei : ('a  -> int -> Js.boolean [@bs]) -> Js.boolean = "some" [@@bs.send.pipe: 'a t as 'this]
 
-external values : 'a array_iter = "" [@@bs.send.pipe: 'a t as 'this] (* es2015 *)
+(* commented out until bs has a plan for iterators
+external values : 'a array_iter = "" [@@bs.send.pipe: 'a t as 'this] (** ES2015 *)
+*)

--- a/jscomp/others/js_string.ml
+++ b/jscomp/others/js_string.ml
@@ -1,5 +1,5 @@
 (* Copyright (C) 2015-2016 Bloomberg Finance L.P.
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
@@ -17,69 +17,87 @@
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
-(* Copyright (C) 2015-2016 Bloomberg Finance L.P.
- * 
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
  *
- * In addition to the permissions granted to you by the LGPL, you may combine
- * or link a "work that uses the Library" with a publicly distributed version
- * of this file to produce a combined library or application, then distribute
- * that combined work under the terms of your choosing, with no requirement
- * to comply with the obligations normally placed on you by section 4 of the
- * LGPL version 3 (or the corresponding section of a later version of the LGPL
- * should you choose to use a later version).
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
- * 
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
 
 type t = string
 
-external charAt : int ->  t = "" [@@bs.send.pipe: t]
+external make : 'a -> t = "String" [@@bs.new]
+external fromCharCode : int -> t = "String.fromCharCode" [@@bs.val]
+external fromCharCodeMany : int array -> t = "String.fromCharCode" [@@bs.val] [@@bs.splice]
+external fromCodePoint : int -> t = "String.fromCodePoint" [@@bs.val] (* es2015 *)
+external fromCodePointMany : int array -> t = "String.fromCodePoint" [@@bs.val] [@@bs.splice] (* es2015 *)
+(* String.raw: es2015, meant to be used with template strings, not directly *)
 
+external length : t -> int = "" [@@bs.get]
+external get : t -> int -> t = "" [@@bs.get_index]
+
+external charAt : int ->  t = "" [@@bs.send.pipe: t]
 external charCodeAt : int -> float  = "" [@@bs.send.pipe: t]
 (** type it as [float] due to that it may return NAN  *)
-external concat :  t array -> t = ""
-[@@bs.send.pipe: t] [@@bs.splice]
+external codePointAt : int -> int Js.undefined = "" [@@bs.send.pipe: t] (* es2015 *)
 
-external indexOf :  t -> int = "" [@@bs.send.pipe: t]
-external indexOfFrom :  t -> int -> int = "indexOf" [@@bs.send.pipe: t]
+external concat : t -> t = "" [@@bs.send.pipe: t]
+external concatMany : t array -> t = "concat" [@@bs.send.pipe: t] [@@bs.splice]
 
-external lastIndexOf :  t -> int = "" [@@bs.send.pipe: t]
-external lastIndexOfFrom :  t -> int -> int = "lastIndexOf" [@@bs.send.pipe: t]
+external endsWith : t -> Js.boolean = "" [@@bs.send.pipe: t] (* es2015 *)
+external endsWithFrom : t -> int -> Js.boolean = "endsWith" [@@bs.send.pipe: t] (* es2015 *)
+(* screwy name, but screwy function *)
 
-external localeCompare :  t -> float = "" [@@bs.send.pipe: t]
+external includes : t -> Js.boolean = "" [@@bs.send.pipe: t] (* es2015 *)
+external includesFrom : t -> int -> Js.boolean = "includes" [@@bs.send.pipe: t] (* es2015 *)
 
+external indexOf : t -> int = "" [@@bs.send.pipe: t]
+external indexOfFrom : t -> int -> int = "indexOf" [@@bs.send.pipe: t]
+
+external lastIndexOf : t -> int = "" [@@bs.send.pipe: t]
+external lastIndexOfFrom : t -> int -> int = "lastIndexOf" [@@bs.send.pipe: t]
+
+external localeCompare : t -> float = "" [@@bs.send.pipe: t]
+(* extended by ECMA-402 *)
+
+external match_ : Js_re.t -> t array Js.null = "match" [@@bs.send.pipe: t]
+
+external normalize : t = "" [@@bs.send.pipe: t] (* es2015 *)
+external normalizeByForm : t -> t = "normalize" [@@bs.send.pipe: t] (* es2015 *)
+
+external repeat : int -> t = "" [@@bs.send.pipe: t] (* es2015 *)
+
+external replace : t ->  t ->  t = "" [@@bs.send.pipe: t]
 external replaceByRe : Js_re.t ->  t ->  t = "replace" [@@bs.send.pipe: t]
-external replace :  t ->  t ->  t = "" [@@bs.send.pipe: t]
 
 external search : Js_re.t -> int = "" [@@bs.send.pipe: t]
-external slice : int -> int ->  t = "" [@@bs.send.pipe: t]
-external sliceToEnd : int ->  t = "slice" [@@bs.send.pipe: t]
 
-external split :  t -> t array  = "" [@@bs.send.pipe: t]
-external splitLimited :  t -> int -> t array = "split" [@@bs.send.pipe: t]
-external splitByRe : Js_re.t  ->  t array = "split" [@@bs.send.pipe: t]
+external slice : from:int -> to_:int ->  t = "" [@@bs.send.pipe: t]
+external sliceToEnd : from:int ->  t = "slice" [@@bs.send.pipe: t]
+
+external split : t -> t array  = "" [@@bs.send.pipe: t]
+external splitAtMost: t -> limit:int -> t array = "split" [@@bs.send.pipe: t]
+external splitLimited : t -> int -> t array = "split" [@@bs.send.pipe: t]
+[@@ocaml.deprecated "Please use splitAtMost"]
+external splitByRe : Js_re.t ->  t array = "split" [@@bs.send.pipe: t]
+external splitByReAtMost : Js_re.t -> limit:int ->  t array = "split" [@@bs.send.pipe: t]
 external splitRegexpLimited : Js_re.t -> int ->  t array = "" [@@bs.send.pipe: t]
+[@@ocaml.deprecated "Please use splitByReAtMost"]
 
-external substring : int -> int ->  t = "" [@@bs.send.pipe: t]
-external substringToEnd : int ->  t = "substring" [@@bs.send.pipe: t]
-external toLowerCase :  t = "" [@@bs.send.pipe: t]
-external toLocaleLowerCase :  t = "" [@@bs.send.pipe: t]
-external toUpperCase :  t = "" [@@bs.send.pipe: t]
-external toLocaleUpperCase :  t = "" [@@bs.send.pipe: t]
-external trim :  t = "" [@@bs.send.pipe: t]
+external startsWith : t -> Js.boolean = "" [@@bs.send.pipe: t] (* es2015 *)
+external startsWithFrom : t -> int -> Js.boolean = "startsWith" [@@bs.send.pipe: t] (* es2015 *)
 
-external startsWith : t -> Js.boolean = "" [@@bs.send.pipe:t]
+external substr : from:int -> t = "" [@@bs.send.pipe: t]
+external substrAtMost : from:int -> length:int -> t = "substr" [@@bs.send.pipe: t]
+
+external substring : from:int -> to_:int ->  t = "" [@@bs.send.pipe: t]
+external substringToEnd : from:int ->  t = "substring" [@@bs.send.pipe: t]
+
+external toLowerCase : t = "" [@@bs.send.pipe: t]
+external toLocaleLowerCase : t = "" [@@bs.send.pipe: t]
+external toUpperCase : t = "" [@@bs.send.pipe: t]
+external toLocaleUpperCase : t = "" [@@bs.send.pipe: t]
+
+external trim : t = "" [@@bs.send.pipe: t]
+
+(* HTML wrappers *)
+external anchor : t -> t = "" [@@bs.send.pipe: t] (* es2015 *)
+external link : t -> t = "" [@@bs.send.pipe: t] (* es2015 *)

--- a/jscomp/others/js_string.ml
+++ b/jscomp/others/js_string.ml
@@ -27,9 +27,9 @@ type t = string
 external make : 'a -> t = "String" [@@bs.new]
 external fromCharCode : int -> t = "String.fromCharCode" [@@bs.val]
 external fromCharCodeMany : int array -> t = "String.fromCharCode" [@@bs.val] [@@bs.splice]
-external fromCodePoint : int -> t = "String.fromCodePoint" [@@bs.val] (* es2015 *)
-external fromCodePointMany : int array -> t = "String.fromCodePoint" [@@bs.val] [@@bs.splice] (* es2015 *)
-(* String.raw: es2015, meant to be used with template strings, not directly *)
+external fromCodePoint : int -> t = "String.fromCodePoint" [@@bs.val] (** ES2015 *)
+external fromCodePointMany : int array -> t = "String.fromCodePoint" [@@bs.val] [@@bs.splice] (** ES2015 *)
+(* String.raw: ES2015, meant to be used with template strings, not directly *)
 
 external length : t -> int = "" [@@bs.get]
 external get : t -> int -> t = "" [@@bs.get_index]
@@ -37,17 +37,16 @@ external get : t -> int -> t = "" [@@bs.get_index]
 external charAt : int ->  t = "" [@@bs.send.pipe: t]
 external charCodeAt : int -> float  = "" [@@bs.send.pipe: t]
 (** type it as [float] due to that it may return NAN  *)
-external codePointAt : int -> int Js.undefined = "" [@@bs.send.pipe: t] (* es2015 *)
+external codePointAt : int -> int Js.undefined = "" [@@bs.send.pipe: t] (** ES2015 *)
 
 external concat : t -> t = "" [@@bs.send.pipe: t]
 external concatMany : t array -> t = "concat" [@@bs.send.pipe: t] [@@bs.splice]
 
-external endsWith : t -> Js.boolean = "" [@@bs.send.pipe: t] (* es2015 *)
-external endsWithFrom : t -> int -> Js.boolean = "endsWith" [@@bs.send.pipe: t] (* es2015 *)
-(* screwy name, but screwy function *)
+external endsWith : t -> Js.boolean = "" [@@bs.send.pipe: t] (** ES2015 *)
+external endsWithFrom : t -> int -> Js.boolean = "endsWith" [@@bs.send.pipe: t] (** ES2015 *)
 
-external includes : t -> Js.boolean = "" [@@bs.send.pipe: t] (* es2015 *)
-external includesFrom : t -> int -> Js.boolean = "includes" [@@bs.send.pipe: t] (* es2015 *)
+external includes : t -> Js.boolean = "" [@@bs.send.pipe: t] (** ES2015 *)
+external includesFrom : t -> int -> Js.boolean = "includes" [@@bs.send.pipe: t] (** ES2015 *)
 
 external indexOf : t -> int = "" [@@bs.send.pipe: t]
 external indexOfFrom : t -> int -> int = "indexOf" [@@bs.send.pipe: t]
@@ -60,10 +59,10 @@ external localeCompare : t -> float = "" [@@bs.send.pipe: t]
 
 external match_ : Js_re.t -> t array Js.null = "match" [@@bs.send.pipe: t]
 
-external normalize : t = "" [@@bs.send.pipe: t] (* es2015 *)
-external normalizeByForm : t -> t = "normalize" [@@bs.send.pipe: t] (* es2015 *)
+external normalize : t = "" [@@bs.send.pipe: t] (** ES2015 *)
+external normalizeByForm : t -> t = "normalize" [@@bs.send.pipe: t] (** ES2015 *)
 
-external repeat : int -> t = "" [@@bs.send.pipe: t] (* es2015 *)
+external repeat : int -> t = "" [@@bs.send.pipe: t] (** ES2015 *)
 
 external replace : t ->  t ->  t = "" [@@bs.send.pipe: t]
 external replaceByRe : Js_re.t ->  t ->  t = "replace" [@@bs.send.pipe: t]
@@ -82,8 +81,8 @@ external splitByReAtMost : Js_re.t -> limit:int ->  t array = "split" [@@bs.send
 external splitRegexpLimited : Js_re.t -> int ->  t array = "" [@@bs.send.pipe: t]
 [@@ocaml.deprecated "Please use splitByReAtMost"]
 
-external startsWith : t -> Js.boolean = "" [@@bs.send.pipe: t] (* es2015 *)
-external startsWithFrom : t -> int -> Js.boolean = "startsWith" [@@bs.send.pipe: t] (* es2015 *)
+external startsWith : t -> Js.boolean = "" [@@bs.send.pipe: t] (** ES2015 *)
+external startsWithFrom : t -> int -> Js.boolean = "startsWith" [@@bs.send.pipe: t] (** ES2015 *)
 
 external substr : from:int -> t = "" [@@bs.send.pipe: t]
 external substrAtMost : from:int -> length:int -> t = "substr" [@@bs.send.pipe: t]
@@ -99,5 +98,5 @@ external toLocaleUpperCase : t = "" [@@bs.send.pipe: t]
 external trim : t = "" [@@bs.send.pipe: t]
 
 (* HTML wrappers *)
-external anchor : t -> t = "" [@@bs.send.pipe: t] (* es2015 *)
-external link : t -> t = "" [@@bs.send.pipe: t] (* es2015 *)
+external anchor : t -> t = "" [@@bs.send.pipe: t] (** ES2015 *)
+external link : t -> t = "" [@@bs.send.pipe: t] (** ES2015 *)

--- a/jscomp/test/Makefile
+++ b/jscomp/test/Makefile
@@ -67,7 +67,7 @@ OTHERS := literals a test_ari test_export2 test_internalOO test_obj_simple_ffi t
 	ppx_this_obj_field single_module_alias \
 	sexpm sexpm_test sexp js_json_test array_subtle_test  \
 	bytes_split_gpr_743_test module_splice_test hello.foo \
-	ffi_splice_test node_path_test js_string_test string_unicode_test node_fs_test\
+	ffi_splice_test node_path_test js_string_test js_array_test string_unicode_test node_fs_test\
 	flow_parser_reg_test	utf8_decode_test stream_parser_test condition_compilation_test semver_test update_record_test installation_test app_root_finder derive_projector_test\
 	gpr_904_test gpr_858_unit2_test inner_unused \
 	set_gen bal_tree string_set string_set_test \

--- a/jscomp/test/array_subtle_test.ml
+++ b/jscomp/test/array_subtle_test.ml
@@ -1,29 +1,29 @@
 let suites :  Mt.pair_suites ref  = ref []
 let test_id = ref 0
-let eq loc (x, y) = 
-  incr test_id ; 
-  suites := 
+let eq loc (x, y) =
+  incr test_id ;
+  suites :=
     (loc ^" id " ^ (string_of_int !test_id), (fun _ -> Mt.Eq(x,y))) :: !suites
 
 let v  = [| 1 ; 2 ; 3; 3|]
 
 
-let () = 
+let () =
   eq __LOC__  (4,Array.length v)
 
-let () = 
-  eq __LOC__ (5,Js.Array.push v 3 ); (* in Js array length can be changing .. *)
+let () =
+  eq __LOC__ (5,Js.Array.push 3 v ); (* in Js array length can be changing .. *)
   eq __LOC__ (5, Array.length v );
   eq __LOC__ (5,Js.Array.length v )
 
 
-let () = 
+let () =
   eq __LOC__ (3, v.(2));
   v.(2)<-4;
   eq __LOC__ (4,v.(2)) (* should not inline *)
 
 let () =
-  while Js.Array.length v > 0 do 
+  while Js.Array.length v > 0 do
     ignore @@ Js.Array.pop v
   done;
   eq __LOC__ (0, Js.Array.length v )

--- a/jscomp/test/js_array_test.js
+++ b/jscomp/test/js_array_test.js
@@ -1,0 +1,837 @@
+'use strict';
+
+var Mt    = require("./mt");
+var Block = require("../../lib/js/block");
+
+var suites_000 = /* tuple */[
+  "make",
+  function () {
+    return /* Eq */Block.__(0, [
+              27,
+              new Array(27).length
+            ]);
+  }
+];
+
+var suites_001 = /* :: */[
+  /* tuple */[
+    "length",
+    function () {
+      return /* Eq */Block.__(0, [
+                3,
+                /* int array */[
+                  1,
+                  2,
+                  3
+                ].length
+              ]);
+    }
+  ],
+  /* :: */[
+    /* tuple */[
+      "pop",
+      function () {
+        return /* Eq */Block.__(0, [
+                  3,
+                  /* int array */[
+                      1,
+                      2,
+                      3
+                    ].pop()
+                ]);
+      }
+    ],
+    /* :: */[
+      /* tuple */[
+        "push",
+        function () {
+          return /* Eq */Block.__(0, [
+                    4,
+                    /* int array */[
+                        1,
+                        2,
+                        3
+                      ].push(4)
+                  ]);
+        }
+      ],
+      /* :: */[
+        /* tuple */[
+          "pushMany",
+          function () {
+            return /* Eq */Block.__(0, [
+                      5,
+                      /* int array */[
+                          1,
+                          2,
+                          3
+                        ].push(4, 5)
+                    ]);
+          }
+        ],
+        /* :: */[
+          /* tuple */[
+            "reverse",
+            function () {
+              return /* Eq */Block.__(0, [
+                        /* int array */[
+                          3,
+                          2,
+                          1
+                        ],
+                        /* int array */[
+                            1,
+                            2,
+                            3
+                          ].reverse()
+                      ]);
+            }
+          ],
+          /* :: */[
+            /* tuple */[
+              "shift",
+              function () {
+                return /* Eq */Block.__(0, [
+                          1,
+                          /* int array */[
+                              1,
+                              2,
+                              3
+                            ].shift()
+                        ]);
+              }
+            ],
+            /* :: */[
+              /* tuple */[
+                "sort",
+                function () {
+                  return /* Eq */Block.__(0, [
+                            /* int array */[
+                              1,
+                              2,
+                              3
+                            ],
+                            /* int array */[
+                                3,
+                                1,
+                                2
+                              ].sort()
+                          ]);
+                }
+              ],
+              /* :: */[
+                /* tuple */[
+                  "sortWith",
+                  function () {
+                    return /* Eq */Block.__(0, [
+                              /* int array */[
+                                3,
+                                2,
+                                1
+                              ],
+                              /* int array */[
+                                  3,
+                                  1,
+                                  2
+                                ].sort(function (a, b) {
+                                    return b - a | 0;
+                                  })
+                            ]);
+                  }
+                ],
+                /* :: */[
+                  /* tuple */[
+                    "splice",
+                    function () {
+                      var arr = /* int array */[
+                        1,
+                        2,
+                        3,
+                        4
+                      ];
+                      var removed = arr.splice(2, 0, 5);
+                      return /* Eq */Block.__(0, [
+                                /* tuple */[
+                                  /* array */[
+                                    1,
+                                    2,
+                                    5,
+                                    3,
+                                    4
+                                  ],
+                                  /* int array */[]
+                                ],
+                                /* tuple */[
+                                  arr,
+                                  removed
+                                ]
+                              ]);
+                    }
+                  ],
+                  /* :: */[
+                    /* tuple */[
+                      "removeFrom",
+                      function () {
+                        var arr = /* int array */[
+                          1,
+                          2,
+                          3,
+                          4
+                        ];
+                        var removed = arr.splice(2);
+                        return /* Eq */Block.__(0, [
+                                  /* tuple */[
+                                    /* int array */[
+                                      1,
+                                      2
+                                    ],
+                                    /* int array */[
+                                      3,
+                                      4
+                                    ]
+                                  ],
+                                  /* tuple */[
+                                    arr,
+                                    removed
+                                  ]
+                                ]);
+                      }
+                    ],
+                    /* :: */[
+                      /* tuple */[
+                        "removeCount",
+                        function () {
+                          var arr = /* int array */[
+                            1,
+                            2,
+                            3,
+                            4
+                          ];
+                          var removed = arr.splice(2, 1);
+                          return /* Eq */Block.__(0, [
+                                    /* tuple */[
+                                      /* int array */[
+                                        1,
+                                        2,
+                                        4
+                                      ],
+                                      /* int array */[3]
+                                    ],
+                                    /* tuple */[
+                                      arr,
+                                      removed
+                                    ]
+                                  ]);
+                        }
+                      ],
+                      /* :: */[
+                        /* tuple */[
+                          "unshift",
+                          function () {
+                            return /* Eq */Block.__(0, [
+                                      4,
+                                      /* int array */[
+                                          1,
+                                          2,
+                                          3
+                                        ].unshift(4)
+                                    ]);
+                          }
+                        ],
+                        /* :: */[
+                          /* tuple */[
+                            "unshiftMany",
+                            function () {
+                              return /* Eq */Block.__(0, [
+                                        5,
+                                        /* int array */[
+                                            1,
+                                            2,
+                                            3
+                                          ].unshift(4, 5)
+                                      ]);
+                            }
+                          ],
+                          /* :: */[
+                            /* tuple */[
+                              "append",
+                              function () {
+                                return /* Eq */Block.__(0, [
+                                          /* int array */[
+                                            1,
+                                            2,
+                                            3,
+                                            4
+                                          ],
+                                          /* int array */[
+                                              1,
+                                              2,
+                                              3
+                                            ].concat(4)
+                                        ]);
+                              }
+                            ],
+                            /* :: */[
+                              /* tuple */[
+                                "concat",
+                                function () {
+                                  return /* Eq */Block.__(0, [
+                                            /* array */[
+                                              1,
+                                              2,
+                                              3,
+                                              4,
+                                              5
+                                            ],
+                                            /* int array */[
+                                                1,
+                                                2,
+                                                3
+                                              ].concat(/* int array */[
+                                                  4,
+                                                  5
+                                                ])
+                                          ]);
+                                }
+                              ],
+                              /* :: */[
+                                /* tuple */[
+                                  "concatMany",
+                                  function () {
+                                    return /* Eq */Block.__(0, [
+                                              /* array */[
+                                                1,
+                                                2,
+                                                3,
+                                                4,
+                                                5,
+                                                6,
+                                                7
+                                              ],
+                                              /* int array */[
+                                                  1,
+                                                  2,
+                                                  3
+                                                ].concat(/* int array */[
+                                                    4,
+                                                    5
+                                                  ], /* int array */[
+                                                    6,
+                                                    7
+                                                  ])
+                                            ]);
+                                  }
+                                ],
+                                /* :: */[
+                                  /* tuple */[
+                                    "indexOf",
+                                    function () {
+                                      return /* Eq */Block.__(0, [
+                                                1,
+                                                /* int array */[
+                                                    1,
+                                                    2,
+                                                    3
+                                                  ].indexOf(2)
+                                              ]);
+                                    }
+                                  ],
+                                  /* :: */[
+                                    /* tuple */[
+                                      "indexOfFrom",
+                                      function () {
+                                        return /* Eq */Block.__(0, [
+                                                  3,
+                                                  /* int array */[
+                                                      1,
+                                                      2,
+                                                      3,
+                                                      2
+                                                    ].indexOf(2, 2)
+                                                ]);
+                                      }
+                                    ],
+                                    /* :: */[
+                                      /* tuple */[
+                                        "join",
+                                        function () {
+                                          return /* Eq */Block.__(0, [
+                                                    "1,2,3",
+                                                    /* int array */[
+                                                        1,
+                                                        2,
+                                                        3
+                                                      ].join()
+                                                  ]);
+                                        }
+                                      ],
+                                      /* :: */[
+                                        /* tuple */[
+                                          "joinWith",
+                                          function () {
+                                            return /* Eq */Block.__(0, [
+                                                      "1;2;3",
+                                                      /* int array */[
+                                                          1,
+                                                          2,
+                                                          3
+                                                        ].join(";")
+                                                    ]);
+                                          }
+                                        ],
+                                        /* :: */[
+                                          /* tuple */[
+                                            "lastIndexOf",
+                                            function () {
+                                              return /* Eq */Block.__(0, [
+                                                        1,
+                                                        /* int array */[
+                                                            1,
+                                                            2,
+                                                            3
+                                                          ].lastIndexOf(2)
+                                                      ]);
+                                            }
+                                          ],
+                                          /* :: */[
+                                            /* tuple */[
+                                              "lastIndexOfFrom",
+                                              function () {
+                                                return /* Eq */Block.__(0, [
+                                                          1,
+                                                          /* int array */[
+                                                              1,
+                                                              2,
+                                                              3,
+                                                              2
+                                                            ].lastIndexOf(2, 2)
+                                                        ]);
+                                              }
+                                            ],
+                                            /* :: */[
+                                              /* tuple */[
+                                                "slice",
+                                                function () {
+                                                  return /* Eq */Block.__(0, [
+                                                            /* int array */[
+                                                              2,
+                                                              3
+                                                            ],
+                                                            /* array */[
+                                                                1,
+                                                                2,
+                                                                3,
+                                                                4,
+                                                                5
+                                                              ].slice(1, 3)
+                                                          ]);
+                                                }
+                                              ],
+                                              /* :: */[
+                                                /* tuple */[
+                                                  "copy",
+                                                  function () {
+                                                    return /* Eq */Block.__(0, [
+                                                              /* array */[
+                                                                1,
+                                                                2,
+                                                                3,
+                                                                4,
+                                                                5
+                                                              ],
+                                                              /* array */[
+                                                                  1,
+                                                                  2,
+                                                                  3,
+                                                                  4,
+                                                                  5
+                                                                ].slice()
+                                                            ]);
+                                                  }
+                                                ],
+                                                /* :: */[
+                                                  /* tuple */[
+                                                    "sliceFrom",
+                                                    function () {
+                                                      return /* Eq */Block.__(0, [
+                                                                /* int array */[
+                                                                  3,
+                                                                  4,
+                                                                  5
+                                                                ],
+                                                                /* array */[
+                                                                    1,
+                                                                    2,
+                                                                    3,
+                                                                    4,
+                                                                    5
+                                                                  ].slice(2)
+                                                              ]);
+                                                    }
+                                                  ],
+                                                  /* :: */[
+                                                    /* tuple */[
+                                                      "toString",
+                                                      function () {
+                                                        return /* Eq */Block.__(0, [
+                                                                  "1,2,3",
+                                                                  /* int array */[
+                                                                      1,
+                                                                      2,
+                                                                      3
+                                                                    ].toString()
+                                                                ]);
+                                                      }
+                                                    ],
+                                                    /* :: */[
+                                                      /* tuple */[
+                                                        "toLocaleString",
+                                                        function () {
+                                                          return /* Eq */Block.__(0, [
+                                                                    "1,2,3",
+                                                                    /* int array */[
+                                                                        1,
+                                                                        2,
+                                                                        3
+                                                                      ].toLocaleString()
+                                                                  ]);
+                                                        }
+                                                      ],
+                                                      /* :: */[
+                                                        /* tuple */[
+                                                          "every",
+                                                          function () {
+                                                            return /* Eq */Block.__(0, [
+                                                                      true,
+                                                                      /* int array */[
+                                                                          1,
+                                                                          2,
+                                                                          3
+                                                                        ].every(function (n) {
+                                                                            var b = +(n > 0);
+                                                                            if (b) {
+                                                                              return true;
+                                                                            }
+                                                                            else {
+                                                                              return false;
+                                                                            }
+                                                                          })
+                                                                    ]);
+                                                          }
+                                                        ],
+                                                        /* :: */[
+                                                          /* tuple */[
+                                                            "everyi",
+                                                            function () {
+                                                              return /* Eq */Block.__(0, [
+                                                                        false,
+                                                                        /* int array */[
+                                                                            1,
+                                                                            2,
+                                                                            3
+                                                                          ].every(function (_, i) {
+                                                                              var b = +(i > 0);
+                                                                              if (b) {
+                                                                                return true;
+                                                                              }
+                                                                              else {
+                                                                                return false;
+                                                                              }
+                                                                            })
+                                                                      ]);
+                                                            }
+                                                          ],
+                                                          /* :: */[
+                                                            /* tuple */[
+                                                              "filter",
+                                                              function () {
+                                                                return /* Eq */Block.__(0, [
+                                                                          /* int array */[
+                                                                            2,
+                                                                            4
+                                                                          ],
+                                                                          /* int array */[
+                                                                              1,
+                                                                              2,
+                                                                              3,
+                                                                              4
+                                                                            ].filter(function (n) {
+                                                                                return +(n % 2 === 0);
+                                                                              })
+                                                                        ]);
+                                                              }
+                                                            ],
+                                                            /* :: */[
+                                                              /* tuple */[
+                                                                "filteri",
+                                                                function () {
+                                                                  return /* Eq */Block.__(0, [
+                                                                            /* int array */[
+                                                                              1,
+                                                                              3
+                                                                            ],
+                                                                            /* int array */[
+                                                                                1,
+                                                                                2,
+                                                                                3,
+                                                                                4
+                                                                              ].filter(function (_, i) {
+                                                                                  var b = +(i % 2 === 0);
+                                                                                  if (b) {
+                                                                                    return true;
+                                                                                  }
+                                                                                  else {
+                                                                                    return false;
+                                                                                  }
+                                                                                })
+                                                                          ]);
+                                                                }
+                                                              ],
+                                                              /* :: */[
+                                                                /* tuple */[
+                                                                  "forEach",
+                                                                  function () {
+                                                                    var sum = [0];
+                                                                    /* int array */[
+                                                                        1,
+                                                                        2,
+                                                                        3
+                                                                      ].forEach(function (n) {
+                                                                          sum[0] = sum[0] + n | 0;
+                                                                          return /* () */0;
+                                                                        });
+                                                                    return /* Eq */Block.__(0, [
+                                                                              6,
+                                                                              sum[0]
+                                                                            ]);
+                                                                  }
+                                                                ],
+                                                                /* :: */[
+                                                                  /* tuple */[
+                                                                    "forEachi",
+                                                                    function () {
+                                                                      var sum = [0];
+                                                                      /* int array */[
+                                                                          1,
+                                                                          2,
+                                                                          3
+                                                                        ].forEach(function (_, i) {
+                                                                            sum[0] = sum[0] + i | 0;
+                                                                            return /* () */0;
+                                                                          });
+                                                                      return /* Eq */Block.__(0, [
+                                                                                3,
+                                                                                sum[0]
+                                                                              ]);
+                                                                    }
+                                                                  ],
+                                                                  /* :: */[
+                                                                    /* tuple */[
+                                                                      "map",
+                                                                      function () {
+                                                                        return /* Eq */Block.__(0, [
+                                                                                  /* int array */[
+                                                                                    2,
+                                                                                    4,
+                                                                                    6,
+                                                                                    8
+                                                                                  ],
+                                                                                  /* int array */[
+                                                                                      1,
+                                                                                      2,
+                                                                                      3,
+                                                                                      4
+                                                                                    ].map(function (n) {
+                                                                                        return (n << 1);
+                                                                                      })
+                                                                                ]);
+                                                                      }
+                                                                    ],
+                                                                    /* :: */[
+                                                                      /* tuple */[
+                                                                        "map",
+                                                                        function () {
+                                                                          return /* Eq */Block.__(0, [
+                                                                                    /* int array */[
+                                                                                      0,
+                                                                                      2,
+                                                                                      4,
+                                                                                      6
+                                                                                    ],
+                                                                                    /* int array */[
+                                                                                        1,
+                                                                                        2,
+                                                                                        3,
+                                                                                        4
+                                                                                      ].map(function (_, i) {
+                                                                                          return (i << 1);
+                                                                                        })
+                                                                                  ]);
+                                                                        }
+                                                                      ],
+                                                                      /* :: */[
+                                                                        /* tuple */[
+                                                                          "reduce",
+                                                                          function () {
+                                                                            return /* Eq */Block.__(0, [
+                                                                                      -10,
+                                                                                      /* int array */[
+                                                                                          1,
+                                                                                          2,
+                                                                                          3,
+                                                                                          4
+                                                                                        ].reduce(function (acc, n) {
+                                                                                            return acc - n | 0;
+                                                                                          }, 0)
+                                                                                    ]);
+                                                                          }
+                                                                        ],
+                                                                        /* :: */[
+                                                                          /* tuple */[
+                                                                            "reducei",
+                                                                            function () {
+                                                                              return /* Eq */Block.__(0, [
+                                                                                        -6,
+                                                                                        /* int array */[
+                                                                                            1,
+                                                                                            2,
+                                                                                            3,
+                                                                                            4
+                                                                                          ].reduce(function (acc, _, i) {
+                                                                                              return acc - i | 0;
+                                                                                            }, 0)
+                                                                                      ]);
+                                                                            }
+                                                                          ],
+                                                                          /* :: */[
+                                                                            /* tuple */[
+                                                                              "reduceRight",
+                                                                              function () {
+                                                                                return /* Eq */Block.__(0, [
+                                                                                          -10,
+                                                                                          /* int array */[
+                                                                                              1,
+                                                                                              2,
+                                                                                              3,
+                                                                                              4
+                                                                                            ].reduceRight(function (acc, n) {
+                                                                                                return acc - n | 0;
+                                                                                              }, 0)
+                                                                                        ]);
+                                                                              }
+                                                                            ],
+                                                                            /* :: */[
+                                                                              /* tuple */[
+                                                                                "reduceRighti",
+                                                                                function () {
+                                                                                  return /* Eq */Block.__(0, [
+                                                                                            -6,
+                                                                                            /* int array */[
+                                                                                                1,
+                                                                                                2,
+                                                                                                3,
+                                                                                                4
+                                                                                              ].reduceRight(function (acc, _, i) {
+                                                                                                  return acc - i | 0;
+                                                                                                }, 0)
+                                                                                          ]);
+                                                                                }
+                                                                              ],
+                                                                              /* :: */[
+                                                                                /* tuple */[
+                                                                                  "some",
+                                                                                  function () {
+                                                                                    return /* Eq */Block.__(0, [
+                                                                                              false,
+                                                                                              /* int array */[
+                                                                                                  1,
+                                                                                                  2,
+                                                                                                  3,
+                                                                                                  4
+                                                                                                ].some(function (n) {
+                                                                                                    var b = +(n <= 0);
+                                                                                                    if (b) {
+                                                                                                      return true;
+                                                                                                    }
+                                                                                                    else {
+                                                                                                      return false;
+                                                                                                    }
+                                                                                                  })
+                                                                                            ]);
+                                                                                  }
+                                                                                ],
+                                                                                /* :: */[
+                                                                                  /* tuple */[
+                                                                                    "somei",
+                                                                                    function () {
+                                                                                      return /* Eq */Block.__(0, [
+                                                                                                true,
+                                                                                                /* int array */[
+                                                                                                    1,
+                                                                                                    2,
+                                                                                                    3,
+                                                                                                    4
+                                                                                                  ].some(function (_, i) {
+                                                                                                      var b = +(i <= 0);
+                                                                                                      if (b) {
+                                                                                                        return true;
+                                                                                                      }
+                                                                                                      else {
+                                                                                                        return false;
+                                                                                                      }
+                                                                                                    })
+                                                                                              ]);
+                                                                                    }
+                                                                                  ],
+                                                                                  /* [] */0
+                                                                                ]
+                                                                              ]
+                                                                            ]
+                                                                          ]
+                                                                        ]
+                                                                      ]
+                                                                    ]
+                                                                  ]
+                                                                ]
+                                                              ]
+                                                            ]
+                                                          ]
+                                                        ]
+                                                      ]
+                                                    ]
+                                                  ]
+                                                ]
+                                              ]
+                                            ]
+                                          ]
+                                        ]
+                                      ]
+                                    ]
+                                  ]
+                                ]
+                              ]
+                            ]
+                          ]
+                        ]
+                      ]
+                    ]
+                  ]
+                ]
+              ]
+            ]
+          ]
+        ]
+      ]
+    ]
+  ]
+];
+
+var suites = /* :: */[
+  suites_000,
+  suites_001
+];
+
+Mt.from_pair_suites("js_array_test.ml", suites);
+
+exports.suites = suites;
+/*  Not a pure module */

--- a/jscomp/test/js_array_test.js
+++ b/jscomp/test/js_array_test.js
@@ -4,144 +4,163 @@ var Mt    = require("./mt");
 var Block = require("../../lib/js/block");
 
 var suites_000 = /* tuple */[
-  "make",
+  "length",
   function () {
     return /* Eq */Block.__(0, [
-              27,
-              new Array(27).length
+              3,
+              /* int array */[
+                1,
+                2,
+                3
+              ].length
             ]);
   }
 ];
 
 var suites_001 = /* :: */[
   /* tuple */[
-    "length",
+    "pop",
     function () {
       return /* Eq */Block.__(0, [
                 3,
                 /* int array */[
-                  1,
-                  2,
-                  3
-                ].length
+                    1,
+                    2,
+                    3
+                  ].pop()
               ]);
     }
   ],
   /* :: */[
     /* tuple */[
-      "pop",
+      "push",
       function () {
         return /* Eq */Block.__(0, [
-                  3,
+                  4,
                   /* int array */[
                       1,
                       2,
                       3
-                    ].pop()
+                    ].push(4)
                 ]);
       }
     ],
     /* :: */[
       /* tuple */[
-        "push",
+        "pushMany",
         function () {
           return /* Eq */Block.__(0, [
-                    4,
+                    5,
                     /* int array */[
                         1,
                         2,
                         3
-                      ].push(4)
+                      ].push(4, 5)
                   ]);
         }
       ],
       /* :: */[
         /* tuple */[
-          "pushMany",
+          "reverseInPlace",
           function () {
             return /* Eq */Block.__(0, [
-                      5,
+                      /* int array */[
+                        3,
+                        2,
+                        1
+                      ],
                       /* int array */[
                           1,
                           2,
                           3
-                        ].push(4, 5)
+                        ].reverse()
                     ]);
           }
         ],
         /* :: */[
           /* tuple */[
-            "reverse",
+            "shift",
             function () {
               return /* Eq */Block.__(0, [
-                        /* int array */[
-                          3,
-                          2,
-                          1
-                        ],
+                        1,
                         /* int array */[
                             1,
                             2,
                             3
-                          ].reverse()
+                          ].shift()
                       ]);
             }
           ],
           /* :: */[
             /* tuple */[
-              "shift",
+              "sortInPlace",
               function () {
                 return /* Eq */Block.__(0, [
-                          1,
                           /* int array */[
+                            1,
+                            2,
+                            3
+                          ],
+                          /* int array */[
+                              3,
                               1,
-                              2,
-                              3
-                            ].shift()
+                              2
+                            ].sort()
                         ]);
               }
             ],
             /* :: */[
               /* tuple */[
-                "sort",
+                "sortInPlaceWith",
                 function () {
                   return /* Eq */Block.__(0, [
                             /* int array */[
-                              1,
+                              3,
                               2,
-                              3
+                              1
                             ],
                             /* int array */[
                                 3,
                                 1,
                                 2
-                              ].sort()
+                              ].sort(function (a, b) {
+                                  return b - a | 0;
+                                })
                           ]);
                 }
               ],
               /* :: */[
                 /* tuple */[
-                  "sortWith",
+                  "spliceInPlace",
                   function () {
+                    var arr = /* int array */[
+                      1,
+                      2,
+                      3,
+                      4
+                    ];
+                    var removed = arr.splice(2, 0, 5);
                     return /* Eq */Block.__(0, [
-                              /* int array */[
-                                3,
-                                2,
-                                1
-                              ],
-                              /* int array */[
-                                  3,
+                              /* tuple */[
+                                /* array */[
                                   1,
-                                  2
-                                ].sort(function (a, b) {
-                                    return b - a | 0;
-                                  })
+                                  2,
+                                  5,
+                                  3,
+                                  4
+                                ],
+                                /* int array */[]
+                              ],
+                              /* tuple */[
+                                arr,
+                                removed
+                              ]
                             ]);
                   }
                 ],
                 /* :: */[
                   /* tuple */[
-                    "splice",
+                    "removeFromInPlace",
                     function () {
                       var arr = /* int array */[
                         1,
@@ -149,17 +168,17 @@ var suites_001 = /* :: */[
                         3,
                         4
                       ];
-                      var removed = arr.splice(2, 0, 5);
+                      var removed = arr.splice(2);
                       return /* Eq */Block.__(0, [
                                 /* tuple */[
-                                  /* array */[
+                                  /* int array */[
                                     1,
-                                    2,
-                                    5,
+                                    2
+                                  ],
+                                  /* int array */[
                                     3,
                                     4
-                                  ],
-                                  /* int array */[]
+                                  ]
                                 ],
                                 /* tuple */[
                                   arr,
@@ -170,7 +189,7 @@ var suites_001 = /* :: */[
                   ],
                   /* :: */[
                     /* tuple */[
-                      "removeFrom",
+                      "removeCountInPlace",
                       function () {
                         var arr = /* int array */[
                           1,
@@ -178,17 +197,15 @@ var suites_001 = /* :: */[
                           3,
                           4
                         ];
-                        var removed = arr.splice(2);
+                        var removed = arr.splice(2, 1);
                         return /* Eq */Block.__(0, [
                                   /* tuple */[
                                     /* int array */[
                                       1,
-                                      2
-                                    ],
-                                    /* int array */[
-                                      3,
+                                      2,
                                       4
-                                    ]
+                                    ],
+                                    /* int array */[3]
                                   ],
                                   /* tuple */[
                                     arr,
@@ -199,81 +216,77 @@ var suites_001 = /* :: */[
                     ],
                     /* :: */[
                       /* tuple */[
-                        "removeCount",
+                        "unshift",
                         function () {
-                          var arr = /* int array */[
-                            1,
-                            2,
-                            3,
-                            4
-                          ];
-                          var removed = arr.splice(2, 1);
                           return /* Eq */Block.__(0, [
-                                    /* tuple */[
-                                      /* int array */[
+                                    4,
+                                    /* int array */[
                                         1,
                                         2,
-                                        4
-                                      ],
-                                      /* int array */[3]
-                                    ],
-                                    /* tuple */[
-                                      arr,
-                                      removed
-                                    ]
+                                        3
+                                      ].unshift(4)
                                   ]);
                         }
                       ],
                       /* :: */[
                         /* tuple */[
-                          "unshift",
+                          "unshiftMany",
                           function () {
                             return /* Eq */Block.__(0, [
-                                      4,
+                                      5,
                                       /* int array */[
                                           1,
                                           2,
                                           3
-                                        ].unshift(4)
+                                        ].unshift(4, 5)
                                     ]);
                           }
                         ],
                         /* :: */[
                           /* tuple */[
-                            "unshiftMany",
+                            "append",
                             function () {
                               return /* Eq */Block.__(0, [
-                                        5,
+                                        /* int array */[
+                                          1,
+                                          2,
+                                          3,
+                                          4
+                                        ],
                                         /* int array */[
                                             1,
                                             2,
                                             3
-                                          ].unshift(4, 5)
+                                          ].concat(4)
                                       ]);
                             }
                           ],
                           /* :: */[
                             /* tuple */[
-                              "append",
+                              "concat",
                               function () {
                                 return /* Eq */Block.__(0, [
-                                          /* int array */[
+                                          /* array */[
                                             1,
                                             2,
                                             3,
-                                            4
+                                            4,
+                                            5
                                           ],
                                           /* int array */[
                                               1,
                                               2,
                                               3
-                                            ].concat(4)
+                                            ].concat(/* int array */[
+                                                4,
+                                                5
+                                              ])
                                         ]);
                               }
                             ],
                             /* :: */[
                               /* tuple */[
-                                "concat",
+                                "concatMany",
                                 function () {
                                   return /* Eq */Block.__(0, [
                                             /* array */[
@@ -281,7 +294,9 @@ var suites_001 = /* :: */[
                                               2,
                                               3,
                                               4,
-                                              5
+                                              5,
+                                              6,
+                                              7
                                             ],
                                             /* int array */[
                                                 1,
@@ -290,132 +305,129 @@ var suites_001 = /* :: */[
                                               ].concat(/* int array */[
                                                   4,
                                                   5
+                                                ], /* int array */[
+                                                  6,
+                                                  7
                                                 ])
                                           ]);
                                 }
                               ],
                               /* :: */[
                                 /* tuple */[
-                                  "concatMany",
+                                  "indexOf",
                                   function () {
                                     return /* Eq */Block.__(0, [
-                                              /* array */[
-                                                1,
-                                                2,
-                                                3,
-                                                4,
-                                                5,
-                                                6,
-                                                7
-                                              ],
+                                              1,
                                               /* int array */[
                                                   1,
                                                   2,
                                                   3
-                                                ].concat(/* int array */[
-                                                    4,
-                                                    5
-                                                  ], /* int array */[
-                                                    6,
-                                                    7
-                                                  ])
+                                                ].indexOf(2)
                                             ]);
                                   }
                                 ],
                                 /* :: */[
                                   /* tuple */[
-                                    "indexOf",
+                                    "indexOfFrom",
                                     function () {
                                       return /* Eq */Block.__(0, [
-                                                1,
+                                                3,
                                                 /* int array */[
                                                     1,
                                                     2,
-                                                    3
-                                                  ].indexOf(2)
+                                                    3,
+                                                    2
+                                                  ].indexOf(2, 2)
                                               ]);
                                     }
                                   ],
                                   /* :: */[
                                     /* tuple */[
-                                      "indexOfFrom",
+                                      "join",
                                       function () {
                                         return /* Eq */Block.__(0, [
-                                                  3,
+                                                  "1,2,3",
                                                   /* int array */[
                                                       1,
                                                       2,
-                                                      3,
-                                                      2
-                                                    ].indexOf(2, 2)
+                                                      3
+                                                    ].join()
                                                 ]);
                                       }
                                     ],
                                     /* :: */[
                                       /* tuple */[
-                                        "join",
+                                        "joinWith",
                                         function () {
                                           return /* Eq */Block.__(0, [
-                                                    "1,2,3",
+                                                    "1;2;3",
                                                     /* int array */[
                                                         1,
                                                         2,
                                                         3
-                                                      ].join()
+                                                      ].join(";")
                                                   ]);
                                         }
                                       ],
                                       /* :: */[
                                         /* tuple */[
-                                          "joinWith",
+                                          "lastIndexOf",
                                           function () {
                                             return /* Eq */Block.__(0, [
-                                                      "1;2;3",
+                                                      1,
                                                       /* int array */[
                                                           1,
                                                           2,
                                                           3
-                                                        ].join(";")
+                                                        ].lastIndexOf(2)
                                                     ]);
                                           }
                                         ],
                                         /* :: */[
                                           /* tuple */[
-                                            "lastIndexOf",
+                                            "lastIndexOfFrom",
                                             function () {
                                               return /* Eq */Block.__(0, [
                                                         1,
                                                         /* int array */[
                                                             1,
                                                             2,
-                                                            3
-                                                          ].lastIndexOf(2)
+                                                            3,
+                                                            2
+                                                          ].lastIndexOf(2, 2)
                                                       ]);
                                             }
                                           ],
                                           /* :: */[
                                             /* tuple */[
-                                              "lastIndexOfFrom",
+                                              "slice",
                                               function () {
                                                 return /* Eq */Block.__(0, [
-                                                          1,
                                                           /* int array */[
+                                                            2,
+                                                            3
+                                                          ],
+                                                          /* array */[
                                                               1,
                                                               2,
                                                               3,
-                                                              2
-                                                            ].lastIndexOf(2, 2)
+                                                              4,
+                                                              5
+                                                            ].slice(1, 3)
                                                         ]);
                                               }
                                             ],
                                             /* :: */[
                                               /* tuple */[
-                                                "slice",
+                                                "copy",
                                                 function () {
                                                   return /* Eq */Block.__(0, [
-                                                            /* int array */[
+                                                            /* array */[
+                                                              1,
                                                               2,
-                                                              3
+                                                              3,
+                                                              4,
+                                                              5
                                                             ],
                                                             /* array */[
                                                                 1,
@@ -423,18 +435,16 @@ var suites_001 = /* :: */[
                                                                 3,
                                                                 4,
                                                                 5
-                                                              ].slice(1, 3)
+                                                              ].slice()
                                                           ]);
                                                 }
                                               ],
                                               /* :: */[
                                                 /* tuple */[
-                                                  "copy",
+                                                  "sliceFrom",
                                                   function () {
                                                     return /* Eq */Block.__(0, [
-                                                              /* array */[
-                                                                1,
-                                                                2,
+                                                              /* int array */[
                                                                 3,
                                                                 4,
                                                                 5
@@ -445,33 +455,27 @@ var suites_001 = /* :: */[
                                                                   3,
                                                                   4,
                                                                   5
-                                                                ].slice()
+                                                                ].slice(2)
                                                             ]);
                                                   }
                                                 ],
                                                 /* :: */[
                                                   /* tuple */[
-                                                    "sliceFrom",
+                                                    "toString",
                                                     function () {
                                                       return /* Eq */Block.__(0, [
+                                                                "1,2,3",
                                                                 /* int array */[
-                                                                  3,
-                                                                  4,
-                                                                  5
-                                                                ],
-                                                                /* array */[
                                                                     1,
                                                                     2,
-                                                                    3,
-                                                                    4,
-                                                                    5
-                                                                  ].slice(2)
+                                                                    3
+                                                                  ].toString()
                                                               ]);
                                                     }
                                                   ],
                                                   /* :: */[
                                                     /* tuple */[
-                                                      "toString",
+                                                      "toLocaleString",
                                                       function () {
                                                         return /* Eq */Block.__(0, [
                                                                   "1,2,3",
@@ -479,36 +483,44 @@ var suites_001 = /* :: */[
                                                                       1,
                                                                       2,
                                                                       3
-                                                                    ].toString()
+                                                                    ].toLocaleString()
                                                                 ]);
                                                       }
                                                     ],
                                                     /* :: */[
                                                       /* tuple */[
-                                                        "toLocaleString",
+                                                        "every",
                                                         function () {
                                                           return /* Eq */Block.__(0, [
-                                                                    "1,2,3",
+                                                                    true,
                                                                     /* int array */[
                                                                         1,
                                                                         2,
                                                                         3
-                                                                      ].toLocaleString()
+                                                                      ].every(function (n) {
+                                                                          var b = +(n > 0);
+                                                                          if (b) {
+                                                                            return true;
+                                                                          }
+                                                                          else {
+                                                                            return false;
+                                                                          }
+                                                                        })
                                                                   ]);
                                                         }
                                                       ],
                                                       /* :: */[
                                                         /* tuple */[
-                                                          "every",
+                                                          "everyi",
                                                           function () {
                                                             return /* Eq */Block.__(0, [
-                                                                      true,
+                                                                      false,
                                                                       /* int array */[
                                                                           1,
                                                                           2,
                                                                           3
-                                                                        ].every(function (n) {
-                                                                            var b = +(n > 0);
+                                                                        ].every(function (_, i) {
+                                                                            var b = +(i > 0);
                                                                             if (b) {
                                                                               return true;
                                                                             }
@@ -521,107 +533,107 @@ var suites_001 = /* :: */[
                                                         ],
                                                         /* :: */[
                                                           /* tuple */[
-                                                            "everyi",
+                                                            "filter",
                                                             function () {
                                                               return /* Eq */Block.__(0, [
-                                                                        false,
+                                                                        /* int array */[
+                                                                          2,
+                                                                          4
+                                                                        ],
                                                                         /* int array */[
                                                                             1,
                                                                             2,
-                                                                            3
-                                                                          ].every(function (_, i) {
-                                                                              var b = +(i > 0);
-                                                                              if (b) {
-                                                                                return true;
-                                                                              }
-                                                                              else {
-                                                                                return false;
-                                                                              }
+                                                                            3,
+                                                                            4
+                                                                          ].filter(function (n) {
+                                                                              return +(n % 2 === 0);
                                                                             })
                                                                       ]);
                                                             }
                                                           ],
                                                           /* :: */[
                                                             /* tuple */[
-                                                              "filter",
+                                                              "filteri",
                                                               function () {
                                                                 return /* Eq */Block.__(0, [
                                                                           /* int array */[
-                                                                            2,
-                                                                            4
+                                                                            1,
+                                                                            3
                                                                           ],
                                                                           /* int array */[
                                                                               1,
                                                                               2,
                                                                               3,
                                                                               4
-                                                                            ].filter(function (n) {
-                                                                                return +(n % 2 === 0);
+                                                                            ].filter(function (_, i) {
+                                                                                var b = +(i % 2 === 0);
+                                                                                if (b) {
+                                                                                  return true;
+                                                                                }
+                                                                                else {
+                                                                                  return false;
+                                                                                }
                                                                               })
                                                                         ]);
                                                               }
                                                             ],
                                                             /* :: */[
                                                               /* tuple */[
-                                                                "filteri",
+                                                                "forEach",
                                                                 function () {
+                                                                  var sum = [0];
+                                                                  /* int array */[
+                                                                      1,
+                                                                      2,
+                                                                      3
+                                                                    ].forEach(function (n) {
+                                                                        sum[0] = sum[0] + n | 0;
+                                                                        return /* () */0;
+                                                                      });
                                                                   return /* Eq */Block.__(0, [
-                                                                            /* int array */[
-                                                                              1,
-                                                                              3
-                                                                            ],
-                                                                            /* int array */[
-                                                                                1,
-                                                                                2,
-                                                                                3,
-                                                                                4
-                                                                              ].filter(function (_, i) {
-                                                                                  var b = +(i % 2 === 0);
-                                                                                  if (b) {
-                                                                                    return true;
-                                                                                  }
-                                                                                  else {
-                                                                                    return false;
-                                                                                  }
-                                                                                })
+                                                                            6,
+                                                                            sum[0]
                                                                           ]);
                                                                 }
                                                               ],
                                                               /* :: */[
                                                                 /* tuple */[
-                                                                  "forEach",
+                                                                  "forEachi",
                                                                   function () {
                                                                     var sum = [0];
                                                                     /* int array */[
                                                                         1,
                                                                         2,
                                                                         3
-                                                                      ].forEach(function (n) {
-                                                                          sum[0] = sum[0] + n | 0;
+                                                                      ].forEach(function (_, i) {
+                                                                          sum[0] = sum[0] + i | 0;
                                                                           return /* () */0;
                                                                         });
                                                                     return /* Eq */Block.__(0, [
-                                                                              6,
+                                                                              3,
                                                                               sum[0]
                                                                             ]);
                                                                   }
                                                                 ],
                                                                 /* :: */[
                                                                   /* tuple */[
-                                                                    "forEachi",
+                                                                    "map",
                                                                     function () {
-                                                                      var sum = [0];
-                                                                      /* int array */[
-                                                                          1,
-                                                                          2,
-                                                                          3
-                                                                        ].forEach(function (_, i) {
-                                                                            sum[0] = sum[0] + i | 0;
-                                                                            return /* () */0;
-                                                                          });
                                                                       return /* Eq */Block.__(0, [
-                                                                                3,
-                                                                                sum[0]
+                                                                                /* int array */[
+                                                                                  2,
+                                                                                  4,
+                                                                                  6,
+                                                                                  8
+                                                                                ],
+                                                                                /* int array */[
+                                                                                    1,
+                                                                                    2,
+                                                                                    3,
+                                                                                    4
+                                                                                  ].map(function (n) {
+                                                                                      return (n << 1);
+                                                                                    })
                                                                               ]);
                                                                     }
                                                                   ],
@@ -631,125 +643,126 @@ var suites_001 = /* :: */[
                                                                       function () {
                                                                         return /* Eq */Block.__(0, [
                                                                                   /* int array */[
+                                                                                    0,
                                                                                     2,
                                                                                     4,
-                                                                                    6,
-                                                                                    8
+                                                                                    6
                                                                                   ],
                                                                                   /* int array */[
                                                                                       1,
                                                                                       2,
                                                                                       3,
                                                                                       4
-                                                                                    ].map(function (n) {
-                                                                                        return (n << 1);
+                                                                                    ].map(function (_, i) {
+                                                                                        return (i << 1);
                                                                                       })
                                                                                 ]);
                                                                       }
                                                                     ],
                                                                     /* :: */[
                                                                       /* tuple */[
-                                                                        "map",
+                                                                        "reduce",
                                                                         function () {
                                                                           return /* Eq */Block.__(0, [
-                                                                                    /* int array */[
-                                                                                      0,
-                                                                                      2,
-                                                                                      4,
-                                                                                      6
-                                                                                    ],
+                                                                                    -10,
                                                                                     /* int array */[
                                                                                         1,
                                                                                         2,
                                                                                         3,
                                                                                         4
-                                                                                      ].map(function (_, i) {
-                                                                                          return (i << 1);
-                                                                                        })
+                                                                                      ].reduce(function (acc, n) {
+                                                                                          return acc - n | 0;
+                                                                                        }, 0)
                                                                                   ]);
                                                                         }
                                                                       ],
                                                                       /* :: */[
                                                                         /* tuple */[
-                                                                          "reduce",
+                                                                          "reducei",
                                                                           function () {
                                                                             return /* Eq */Block.__(0, [
-                                                                                      -10,
+                                                                                      -6,
                                                                                       /* int array */[
                                                                                           1,
                                                                                           2,
                                                                                           3,
                                                                                           4
-                                                                                        ].reduce(function (acc, n) {
-                                                                                            return acc - n | 0;
+                                                                                        ].reduce(function (acc, _, i) {
+                                                                                            return acc - i | 0;
                                                                                           }, 0)
                                                                                     ]);
                                                                           }
                                                                         ],
                                                                         /* :: */[
                                                                           /* tuple */[
-                                                                            "reducei",
+                                                                            "reduceRight",
                                                                             function () {
                                                                               return /* Eq */Block.__(0, [
-                                                                                        -6,
+                                                                                        -10,
                                                                                         /* int array */[
                                                                                             1,
                                                                                             2,
                                                                                             3,
                                                                                             4
-                                                                                          ].reduce(function (acc, _, i) {
-                                                                                              return acc - i | 0;
+                                                                                          ].reduceRight(function (acc, n) {
+                                                                                              return acc - n | 0;
                                                                                             }, 0)
                                                                                       ]);
                                                                             }
                                                                           ],
                                                                           /* :: */[
                                                                             /* tuple */[
-                                                                              "reduceRight",
+                                                                              "reduceRighti",
                                                                               function () {
                                                                                 return /* Eq */Block.__(0, [
-                                                                                          -10,
+                                                                                          -6,
                                                                                           /* int array */[
                                                                                               1,
                                                                                               2,
                                                                                               3,
                                                                                               4
-                                                                                            ].reduceRight(function (acc, n) {
-                                                                                                return acc - n | 0;
+                                                                                            ].reduceRight(function (acc, _, i) {
+                                                                                                return acc - i | 0;
                                                                                               }, 0)
                                                                                         ]);
                                                                               }
                                                                             ],
                                                                             /* :: */[
                                                                               /* tuple */[
-                                                                                "reduceRighti",
+                                                                                "some",
                                                                                 function () {
                                                                                   return /* Eq */Block.__(0, [
-                                                                                            -6,
+                                                                                            false,
                                                                                             /* int array */[
                                                                                                 1,
                                                                                                 2,
                                                                                                 3,
                                                                                                 4
-                                                                                              ].reduceRight(function (acc, _, i) {
-                                                                                                  return acc - i | 0;
-                                                                                                }, 0)
+                                                                                              ].some(function (n) {
+                                                                                                  var b = +(n <= 0);
+                                                                                                  if (b) {
+                                                                                                    return true;
+                                                                                                  }
+                                                                                                  else {
+                                                                                                    return false;
+                                                                                                  }
+                                                                                                })
                                                                                           ]);
                                                                                 }
                                                                               ],
                                                                               /* :: */[
                                                                                 /* tuple */[
-                                                                                  "some",
+                                                                                  "somei",
                                                                                   function () {
                                                                                     return /* Eq */Block.__(0, [
-                                                                                              false,
+                                                                                              true,
                                                                                               /* int array */[
                                                                                                   1,
                                                                                                   2,
                                                                                                   3,
                                                                                                   4
-                                                                                                ].some(function (n) {
-                                                                                                    var b = +(n <= 0);
+                                                                                                ].some(function (_, i) {
+                                                                                                    var b = +(i <= 0);
                                                                                                     if (b) {
                                                                                                       return true;
                                                                                                     }
@@ -760,31 +773,7 @@ var suites_001 = /* :: */[
                                                                                             ]);
                                                                                   }
                                                                                 ],
-                                                                                /* :: */[
-                                                                                  /* tuple */[
-                                                                                    "somei",
-                                                                                    function () {
-                                                                                      return /* Eq */Block.__(0, [
-                                                                                                true,
-                                                                                                /* int array */[
-                                                                                                    1,
-                                                                                                    2,
-                                                                                                    3,
-                                                                                                    4
-                                                                                                  ].some(function (_, i) {
-                                                                                                      var b = +(i <= 0);
-                                                                                                      if (b) {
-                                                                                                        return true;
-                                                                                                      }
-                                                                                                      else {
-                                                                                                        return false;
-                                                                                                      }
-                                                                                                    })
-                                                                                              ]);
-                                                                                    }
-                                                                                  ],
-                                                                                  /* [] */0
-                                                                                ]
+                                                                                /* [] */0
                                                                               ]
                                                                             ]
                                                                           ]

--- a/jscomp/test/js_array_test.ml
+++ b/jscomp/test/js_array_test.ml
@@ -1,22 +1,11 @@
 
 
 let suites = Mt.[
-    "make", (fun _ ->
-      Eq(27, Js.Array.make 27 |> Js.Array.length)
-    );
-
     (* es2015
     "from", (fun _ ->
       Eq(
         [| 0; 1 |],
         [| "a"; "b" |] |> Js.Array.keys |> Js.Array.from)
-    );
-    "unsafeFrom", (fun arg ->
-      Eq(
-        [| [%bs.obj { arg }] |],
-        Js.Array.unsafeFrom [%bs.raw "arguments"]
-          |> Js.Array.map ((fun arg -> [%bs.obj { arg }]) [@bs])
-      )
     );
     *)
 
@@ -27,14 +16,6 @@ let suites = Mt.[
         Js.Array.fromMap
           ([| "a"; "b" |] |> Js.Array.keys)
           ((fun x -> x - 1) [@bs]))
-    );
-    "unsafeFromMap", (fun arg ->
-      Eq(
-        [| [%bs.obj { arg }] |],
-        Js.Array.unsafeFromMap
-          [%bs.raw "arguments"]
-          ((fun arg -> [%bs.obj { arg }]) [@bs])
-      )
     );
     *)
 
@@ -67,17 +48,17 @@ let suites = Mt.[
     *)
 
     (* es2015
-    "fill", (fun _ ->
+    "fillInPlace", (fun _ ->
       Eq([| 4; 4; 4 |],
-         [| 1; 2; 3 |] |> Js.Array.fill 4)
+         [| 1; 2; 3 |] |> Js.Array.fillInPlace 4)
     );
-    "fillFrom", (fun _ ->
+    "fillFromInPlace", (fun _ ->
       Eq([| 1; 4; 4 |],
-         [| 1; 2; 3 |] |> Js.Array.fillFrom 4 ~from:1)
+         [| 1; 2; 3 |] |> Js.Array.fillFromInPlace 4 ~from:1)
     );
-    "fillRange", (fun _ ->
+    "fillRangeInPlace", (fun _ ->
       Eq([| 1; 4; 3 |],
-         [| 1; 2; 3 |] |> Js.Array.fillRange 4 ~start:1 ~end_:2)
+         [| 1; 2; 3 |] |> Js.Array.fillRangeInPlace 4 ~start:1 ~end_:2)
     );
     *)
 
@@ -91,39 +72,39 @@ let suites = Mt.[
       Eq(5, [| 1; 2; 3 |] |> Js.Array.pushMany [| 4; 5 |])
     );
 
-    "reverse", (fun _ ->
+    "reverseInPlace", (fun _ ->
       Eq([| 3; 2; 1 |],
-         [| 1; 2; 3 |] |> Js.Array.reverse)
+         [| 1; 2; 3 |] |> Js.Array.reverseInPlace)
     );
 
     "shift", (fun _ ->
       Eq(Js.Undefined.return 1, [| 1; 2; 3 |] |> Js.Array.shift)
     );
 
-    "sort", (fun _ ->
+    "sortInPlace", (fun _ ->
       Eq([| 1; 2; 3 |],
-         [| 3; 1; 2 |] |> Js.Array.sort)
+         [| 3; 1; 2 |] |> Js.Array.sortInPlace)
     );
-    "sortWith", (fun _ ->
+    "sortInPlaceWith", (fun _ ->
       Eq([| 3; 2; 1 |],
-         [| 3; 1; 2 |] |> Js.Array.sortWith ((fun a b -> b - a) [@bs]))
+         [| 3; 1; 2 |] |> Js.Array.sortInPlaceWith ((fun a b -> b - a) [@bs]))
     );
 
-    "splice", (fun _ ->
+    "spliceInPlace", (fun _ ->
       let arr = [| 1; 2; 3; 4 |] in
-      let removed = arr |> Js.Array.splice ~pos:2 ~remove:0 ~add:[| 5 |] in
+      let removed = arr |> Js.Array.spliceInPlace ~pos:2 ~remove:0 ~add:[| 5 |] in
 
       Eq(([| 1; 2; 5; 3; 4 |], [||]), (arr, removed))
     );
-    "removeFrom", (fun _ ->
+    "removeFromInPlace", (fun _ ->
       let arr = [| 1; 2; 3; 4 |] in
-      let removed = arr |> Js.Array.removeFrom ~pos:2 in
+      let removed = arr |> Js.Array.removeFromInPlace ~pos:2 in
 
       Eq(([| 1; 2 |], [| 3; 4 |]), (arr, removed))
     );
-    "removeCount", (fun _ ->
+    "removeCountInPlace", (fun _ ->
       let arr = [| 1; 2; 3; 4 |] in
-      let removed = arr |> Js.Array.removeCount ~pos:2 ~count:1 in
+      let removed = arr |> Js.Array.removeCountInPlace ~pos:2 ~count:1 in
 
       Eq(([| 1; 2; 4 |], [| 3 |]), (arr, removed))
     );

--- a/jscomp/test/js_array_test.ml
+++ b/jscomp/test/js_array_test.ml
@@ -1,0 +1,299 @@
+
+
+let suites = Mt.[
+    "make", (fun _ ->
+      Eq(27, Js.Array.make 27 |> Js.Array.length)
+    );
+
+    (* es2015
+    "from", (fun _ ->
+      Eq(
+        [| 0; 1 |],
+        [| "a"; "b" |] |> Js.Array.keys |> Js.Array.from)
+    );
+    "unsafeFrom", (fun arg ->
+      Eq(
+        [| [%bs.obj { arg }] |],
+        Js.Array.unsafeFrom [%bs.raw "arguments"]
+          |> Js.Array.map ((fun arg -> [%bs.obj { arg }]) [@bs])
+      )
+    );
+    *)
+
+    (* es2015
+    "fromMap", (fun _ ->
+      Eq(
+        [| (-1); 0 |],
+        Js.Array.fromMap
+          ([| "a"; "b" |] |> Js.Array.keys)
+          ((fun x -> x - 1) [@bs]))
+    );
+    "unsafeFromMap", (fun arg ->
+      Eq(
+        [| [%bs.obj { arg }] |],
+        Js.Array.unsafeFromMap
+          [%bs.raw "arguments"]
+          ((fun arg -> [%bs.obj { arg }]) [@bs])
+      )
+    );
+    *)
+
+    (* es2015
+    "isArray_array", (fun _ ->
+      Eq(Js.true_, [||] |> Js.Array.isArray)
+    );
+    "isArray_int", (fun _ ->
+      Eq(Js.false_, 34 |> Js.Array.isArray)
+    );
+    *)
+
+    "length", (fun _ ->
+      Eq(3, [| 1; 2; 3 |] |> Js.Array.length)
+    );
+
+    (* es2015
+    "copyWithin", (fun _ ->
+      Eq([| 1; 2; 3; 1; 2 |],
+         [| 1; 2; 3; 4; 5 |] |> Js.Array.copyWithin ~to_:(-2))
+    );
+    "copyWithinFrom", (fun _ ->
+      Eq([| 4; 5; 3; 4; 5 |],
+         [| 1; 2; 3; 4; 5 |] |> Js.Array.copyWithinFrom ~to_:0 ~from:3)
+    );
+    "copyWithinFromRange", (fun _ ->
+      Eq([| 4; 2; 3; 4; 5 |],
+         [| 1; 2; 3; 4; 5 |] |> Js.Array.copyWithinFromRange ~to_:0 ~start:3 ~end_:4)
+    );
+    *)
+
+    (* es2015
+    "fill", (fun _ ->
+      Eq([| 4; 4; 4 |],
+         [| 1; 2; 3 |] |> Js.Array.fill 4)
+    );
+    "fillFrom", (fun _ ->
+      Eq([| 1; 4; 4 |],
+         [| 1; 2; 3 |] |> Js.Array.fillFrom 4 ~from:1)
+    );
+    "fillRange", (fun _ ->
+      Eq([| 1; 4; 3 |],
+         [| 1; 2; 3 |] |> Js.Array.fillRange 4 ~start:1 ~end_:2)
+    );
+    *)
+
+    "pop", (fun _ ->
+      Eq(Js.Undefined.return 3, [| 1; 2; 3 |] |> Js.Array.pop)
+    );
+    "push", (fun _ ->
+      Eq(4, [| 1; 2; 3 |] |> Js.Array.push 4)
+    );
+    "pushMany", (fun _ ->
+      Eq(5, [| 1; 2; 3 |] |> Js.Array.pushMany [| 4; 5 |])
+    );
+
+    "reverse", (fun _ ->
+      Eq([| 3; 2; 1 |],
+         [| 1; 2; 3 |] |> Js.Array.reverse)
+    );
+
+    "shift", (fun _ ->
+      Eq(Js.Undefined.return 1, [| 1; 2; 3 |] |> Js.Array.shift)
+    );
+
+    "sort", (fun _ ->
+      Eq([| 1; 2; 3 |],
+         [| 3; 1; 2 |] |> Js.Array.sort)
+    );
+    "sortWith", (fun _ ->
+      Eq([| 3; 2; 1 |],
+         [| 3; 1; 2 |] |> Js.Array.sortWith ((fun a b -> b - a) [@bs]))
+    );
+
+    "splice", (fun _ ->
+      let arr = [| 1; 2; 3; 4 |] in
+      let removed = arr |> Js.Array.splice ~pos:2 ~remove:0 ~add:[| 5 |] in
+
+      Eq(([| 1; 2; 5; 3; 4 |], [||]), (arr, removed))
+    );
+    "removeFrom", (fun _ ->
+      let arr = [| 1; 2; 3; 4 |] in
+      let removed = arr |> Js.Array.removeFrom ~pos:2 in
+
+      Eq(([| 1; 2 |], [| 3; 4 |]), (arr, removed))
+    );
+    "removeCount", (fun _ ->
+      let arr = [| 1; 2; 3; 4 |] in
+      let removed = arr |> Js.Array.removeCount ~pos:2 ~count:1 in
+
+      Eq(([| 1; 2; 4 |], [| 3 |]), (arr, removed))
+    );
+
+    "unshift", (fun _ ->
+      Eq(4, [| 1; 2; 3 |] |> Js.Array.unshift 4)
+    );
+    "unshiftMany", (fun _ ->
+      Eq(5, [| 1; 2; 3 |] |> Js.Array.unshiftMany [| 4; 5 |])
+    );
+
+    "append", (fun _ ->
+      Eq([| 1; 2; 3; 4 |],
+         [| 1; 2; 3 |] |> Js.Array.append 4)
+    );
+    "concat", (fun _ ->
+      Eq([| 1; 2; 3; 4; 5 |],
+         [| 1; 2; 3 |] |> Js.Array.concat [| 4; 5 |])
+    );
+    "concatMany", (fun _ ->
+      Eq([| 1; 2; 3; 4; 5; 6; 7 |],
+         [| 1; 2; 3 |] |> Js.Array.concatMany [| [| 4; 5; |]; [| 6; 7; |] |])
+    );
+
+    (* es2016
+    "includes", (fun _ ->
+      Eq(Js.true_, [| 1; 2; 3 |] |> Js.Array.includes 3)
+    );
+    *)
+
+    "indexOf", (fun _ ->
+      Eq(1, [| 1; 2; 3 |] |> Js.Array.indexOf 2)
+    );
+    "indexOfFrom", (fun _ ->
+      Eq(3, [| 1; 2; 3; 2 |] |> Js.Array.indexOfFrom 2 ~from:2)
+    );
+
+    "join", (fun _ ->
+      Eq("1,2,3", [| 1; 2; 3 |] |> Js.Array.join)
+    );
+    "joinWith", (fun _ ->
+      Eq("1;2;3", [| 1; 2; 3 |] |> Js.Array.joinWith ";")
+    );
+
+    "lastIndexOf", (fun _ ->
+      Eq(1, [| 1; 2; 3 |] |> Js.Array.lastIndexOf 2)
+    );
+    "lastIndexOfFrom", (fun _ ->
+      Eq(1, [| 1; 2; 3; 2 |] |> Js.Array.lastIndexOfFrom 2 ~from:2)
+    );
+
+    "slice", (fun _ ->
+      Eq([| 2; 3; |],
+         [| 1; 2; 3; 4; 5 |] |> Js.Array.slice ~start:1 ~end_:3)
+    );
+    "copy", (fun _ ->
+      Eq([| 1; 2; 3; 4; 5 |],
+         [| 1; 2; 3; 4; 5 |] |> Js.Array.copy)
+    );
+    "sliceFrom", (fun _ ->
+      Eq([| 3; 4; 5 |],
+         [| 1; 2; 3; 4; 5 |] |> Js.Array.sliceFrom 2)
+    );
+
+    "toString", (fun _ ->
+      Eq("1,2,3", [| 1; 2; 3 |] |> Js.Array.toString)
+    );
+    "toLocaleString", (fun _ ->
+      Eq("1,2,3", [| 1; 2; 3 |] |> Js.Array.toLocaleString)
+    );
+
+    (* es2015
+    "entries", (fun _ ->
+      Eq([| (0, "a"); (1, "b"); (2, "c") |],
+         [| "a"; "b"; "c" |] |> Js.Array.entries |> Js.Array.from)
+    );
+    *)
+
+    "every", (fun _ ->
+      Eq(Js.true_, [| 1; 2; 3 |] |> Js.Array.every ((fun n -> Js.Boolean.to_js_boolean (n > 0)) [@bs]))
+    );
+    "everyi", (fun _ ->
+      Eq(Js.false_, [| 1; 2; 3 |] |> Js.Array.everyi ((fun _ i -> Js.Boolean.to_js_boolean (i > 0)) [@bs]))
+    );
+
+    "filter", (fun _ ->
+      Eq([| 2; 4 |],
+         [| 1; 2; 3; 4 |] |> Js.Array.filter ((fun n -> n mod 2 = 0) [@bs]))
+    );
+    "filteri", (fun _ ->
+      Eq([| 1; 3 |],
+         [| 1; 2; 3; 4 |] |> Js.Array.filteri ((fun _ i -> Js.Boolean.to_js_boolean (i mod 2 = 0)) [@bs]))
+    );
+
+    (* es2015
+    "find", (fun _ ->
+      Eq(Js.Undefined.return 2, [| 1; 2; 3; 4 |] |> Js.Array.find ((fun n -> n mod 2 = 0) [@bs]))
+    );
+    "findi", (fun _ ->
+      Eq(Js.Undefined.return 1, [| 1; 2; 3; 4 |] |> Js.Array.findi ((fun _ i -> i mod 2 = 0) [@bs]))
+    );
+    *)
+
+    (* es2015
+    "findIndex", (fun _ ->
+      Eq(1, [| 1; 2; 3; 4 |] |> Js.Array.findIndex ((fun n -> n mod 2 = 0) [@bs]))
+    );
+    "findIndexi", (fun _ ->
+      Eq(0, [| 1; 2; 3; 4 |] |> Js.Array.findIndexi ((fun _ i -> i mod 2 = 0) [@bs]))
+    );
+    *)
+
+    "forEach", (fun _ ->
+      let sum = ref 0 in
+      let _ = [| 1; 2; 3; |] |> Js.Array.forEach ((fun n -> sum := !sum + n) [@bs]) in
+
+      Eq(6, !sum)
+    );
+    "forEachi", (fun _ ->
+      let sum = ref 0 in
+      let _ = [| 1; 2; 3; |] |> Js.Array.forEachi ((fun _ i -> sum := !sum + i) [@bs]) in
+
+      Eq(3, !sum)
+    );
+
+    (* es2015
+    "keys", (fun _ ->
+      Eq([| 0; 1; 2 |],
+         [| "a"; "b"; "c" |] |> Js.Array.keys |> Js.Array.from)
+    );
+    *)
+
+    "map", (fun _ ->
+      Eq([| 2; 4; 6; 8 |],
+         [| 1; 2; 3; 4 |] |> Js.Array.map ((fun n -> n * 2) [@bs]))
+    );
+    "map", (fun _ ->
+      Eq([| 0; 2; 4; 6 |],
+         [| 1; 2; 3; 4 |] |> Js.Array.mapi ((fun _ i -> i * 2) [@bs]))
+    );
+
+    "reduce", (fun _ ->
+      Eq(-10,
+         [| 1; 2; 3; 4 |] |> Js.Array.reduce ((fun acc n -> acc - n) [@bs]) 0)
+    );
+    "reducei", (fun _ ->
+      Eq(-6,
+         [| 1; 2; 3; 4 |] |> Js.Array.reducei ((fun acc _ i -> acc - i) [@bs]) 0)
+    );
+
+    "reduceRight", (fun _ ->
+      Eq(-10, [| 1; 2; 3; 4 |] |> Js.Array.reduceRight ((fun acc n -> acc - n) [@bs]) 0)
+    );
+    "reduceRighti", (fun _ ->
+      Eq(-6, [| 1; 2; 3; 4 |] |> Js.Array.reduceRighti ((fun acc _ i -> acc - i) [@bs]) 0)
+    );
+
+    "some", (fun _ ->
+      Eq(Js.false_, [| 1; 2; 3; 4 |] |> Js.Array.some ((fun n -> Js.Boolean.to_js_boolean (n <= 0)) [@bs]))
+    );
+    "somei", (fun _ ->
+      Eq(Js.true_, [| 1; 2; 3; 4 |] |> Js.Array.somei ((fun _ i -> Js.Boolean.to_js_boolean (i <= 0)) [@bs]))
+    );
+
+    (* es2015
+    "values", (fun _ ->
+      Eq([| "a"; "b"; "c" |],
+         [| "a"; "b"; "c" |] |> Js.Array.values |> Js.Array.from)
+    );
+    *)
+]
+
+;; Mt.from_pair_suites __FILE__ suites

--- a/jscomp/test/js_re_test.ml
+++ b/jscomp/test/js_re_test.ml
@@ -6,7 +6,7 @@ let suites = Mt.[
       |> Js.Re.exec "http://xxx.domain.com"
       |> Js.Re.matches in
 
-    Eq ("xxx", Array.get res 0 |> Js.String.substringToEnd 7)
+    Eq ("xxx", Array.get res 0 |> Js.String.substringToEnd ~from:7)
 
   );
   "test_str", (fun _ ->

--- a/jscomp/test/js_string_test.js
+++ b/jscomp/test/js_string_test.js
@@ -3,38 +3,393 @@
 var Mt    = require("./mt");
 var Block = require("../../lib/js/block");
 
-var suites = [/* [] */0];
+var suites_000 = /* tuple */[
+  "make",
+  function () {
+    return /* Eq */Block.__(0, [
+              "null",
+              new String(null).concat("")
+            ]);
+  }
+];
 
-var test_id = [0];
-
-function eq(loc, _z) {
-  var y = _z[1];
-  var x = _z[0];
-  console.log(_z);
-  test_id[0] = test_id[0] + 1 | 0;
-  suites[0] = /* :: */[
+var suites_001 = /* :: */[
+  /* tuple */[
+    "fromCharCode",
+    function () {
+      return /* Eq */Block.__(0, [
+                "a",
+                String.fromCharCode(97)
+              ]);
+    }
+  ],
+  /* :: */[
     /* tuple */[
-      loc + (" id " + test_id[0]),
+      "fromCharCodeMany",
       function () {
         return /* Eq */Block.__(0, [
-                  x,
-                  y
+                  "az",
+                  String.fromCharCode(97, 122)
                 ]);
       }
     ],
-    suites[0]
-  ];
-  return /* () */0;
-}
+    /* :: */[
+      /* tuple */[
+        "length",
+        function () {
+          return /* Eq */Block.__(0, [
+                    3,
+                    "foo".length
+                  ]);
+        }
+      ],
+      /* :: */[
+        /* tuple */[
+          "get",
+          function () {
+            return /* Eq */Block.__(0, [
+                      "a",
+                      "foobar"[4]
+                    ]);
+          }
+        ],
+        /* :: */[
+          /* tuple */[
+            "charAt",
+            function () {
+              return /* Eq */Block.__(0, [
+                        "a",
+                        "foobar".charAt(4)
+                      ]);
+            }
+          ],
+          /* :: */[
+            /* tuple */[
+              "charCodeAt",
+              function () {
+                return /* Eq */Block.__(0, [
+                          97,
+                          "foobar".charCodeAt(4)
+                        ]);
+              }
+            ],
+            /* :: */[
+              /* tuple */[
+                "concat",
+                function () {
+                  return /* Eq */Block.__(0, [
+                            "foobar",
+                            "foo".concat("bar")
+                          ]);
+                }
+              ],
+              /* :: */[
+                /* tuple */[
+                  "concatMany",
+                  function () {
+                    return /* Eq */Block.__(0, [
+                              "foobarbaz",
+                              "foo".concat("bar", "baz")
+                            ]);
+                  }
+                ],
+                /* :: */[
+                  /* tuple */[
+                    "indexOf",
+                    function () {
+                      return /* Eq */Block.__(0, [
+                                3,
+                                "foobarbaz".indexOf("bar")
+                              ]);
+                    }
+                  ],
+                  /* :: */[
+                    /* tuple */[
+                      "indexOfFrom",
+                      function () {
+                        return /* Eq */Block.__(0, [
+                                  -1,
+                                  "foobarbaz".indexOf("bar", 4)
+                                ]);
+                      }
+                    ],
+                    /* :: */[
+                      /* tuple */[
+                        "lastIndexOf",
+                        function () {
+                          return /* Eq */Block.__(0, [
+                                    3,
+                                    "foobarbaz".lastIndexOf("bar")
+                                  ]);
+                        }
+                      ],
+                      /* :: */[
+                        /* tuple */[
+                          "lastIndexOfFrom",
+                          function () {
+                            return /* Eq */Block.__(0, [
+                                      3,
+                                      "foobarbaz".lastIndexOf("bar", 4)
+                                    ]);
+                          }
+                        ],
+                        /* :: */[
+                          /* tuple */[
+                            "localeCompare",
+                            function () {
+                              return /* Eq */Block.__(0, [
+                                        0,
+                                        "foo".localeCompare("foo")
+                                      ]);
+                            }
+                          ],
+                          /* :: */[
+                            /* tuple */[
+                              "match",
+                              function () {
+                                return /* Eq */Block.__(0, [
+                                          /* array */[
+                                            "na",
+                                            "na"
+                                          ],
+                                          "banana".match((/na+/g))
+                                        ]);
+                              }
+                            ],
+                            /* :: */[
+                              /* tuple */[
+                                "replace",
+                                function () {
+                                  return /* Eq */Block.__(0, [
+                                            "fooBORKbaz",
+                                            "foobarbaz".replace("bar", "BORK")
+                                          ]);
+                                }
+                              ],
+                              /* :: */[
+                                /* tuple */[
+                                  "replaceByRe",
+                                  function () {
+                                    return /* Eq */Block.__(0, [
+                                              "fooBORKBORK",
+                                              "foobarbaz".replace((/ba./g), "BORK")
+                                            ]);
+                                  }
+                                ],
+                                /* :: */[
+                                  /* tuple */[
+                                    "search",
+                                    function () {
+                                      return /* Eq */Block.__(0, [
+                                                3,
+                                                "foobarbaz".search((/ba./g))
+                                              ]);
+                                    }
+                                  ],
+                                  /* :: */[
+                                    /* tuple */[
+                                      "slice",
+                                      function () {
+                                        return /* Eq */Block.__(0, [
+                                                  "bar",
+                                                  "foobarbaz".slice(3, 6)
+                                                ]);
+                                      }
+                                    ],
+                                    /* :: */[
+                                      /* tuple */[
+                                        "sliceToEnd",
+                                        function () {
+                                          return /* Eq */Block.__(0, [
+                                                    "barbaz",
+                                                    "foobarbaz".slice(3)
+                                                  ]);
+                                        }
+                                      ],
+                                      /* :: */[
+                                        /* tuple */[
+                                          "split",
+                                          function () {
+                                            return /* Eq */Block.__(0, [
+                                                      /* array */[
+                                                        "foo",
+                                                        "bar",
+                                                        "baz"
+                                                      ],
+                                                      "foo bar baz".split(" ")
+                                                    ]);
+                                          }
+                                        ],
+                                        /* :: */[
+                                          /* tuple */[
+                                            "splitAtMost",
+                                            function () {
+                                              return /* Eq */Block.__(0, [
+                                                        /* array */[
+                                                          "foo",
+                                                          "bar"
+                                                        ],
+                                                        "foo bar baz".split(" ", 2)
+                                                      ]);
+                                            }
+                                          ],
+                                          /* :: */[
+                                            /* tuple */[
+                                              "splitByRe",
+                                              function () {
+                                                return /* Eq */Block.__(0, [
+                                                          /* array */[
+                                                            "foo",
+                                                            "bar",
+                                                            "baz"
+                                                          ],
+                                                          "foo bar baz".split((/\s/))
+                                                        ]);
+                                              }
+                                            ],
+                                            /* :: */[
+                                              /* tuple */[
+                                                "splitByReAtMost",
+                                                function () {
+                                                  return /* Eq */Block.__(0, [
+                                                            /* array */[
+                                                              "foo",
+                                                              "bar"
+                                                            ],
+                                                            "foo bar baz".split((/\s/), 2)
+                                                          ]);
+                                                }
+                                              ],
+                                              /* :: */[
+                                                /* tuple */[
+                                                  "substr",
+                                                  function () {
+                                                    return /* Eq */Block.__(0, [
+                                                              "barbaz",
+                                                              "foobarbaz".substr(3)
+                                                            ]);
+                                                  }
+                                                ],
+                                                /* :: */[
+                                                  /* tuple */[
+                                                    "substrAtMost",
+                                                    function () {
+                                                      return /* Eq */Block.__(0, [
+                                                                "bar",
+                                                                "foobarbaz".substr(3, 3)
+                                                              ]);
+                                                    }
+                                                  ],
+                                                  /* :: */[
+                                                    /* tuple */[
+                                                      "substring",
+                                                      function () {
+                                                        return /* Eq */Block.__(0, [
+                                                                  "bar",
+                                                                  "foobarbaz".substring(3, 6)
+                                                                ]);
+                                                      }
+                                                    ],
+                                                    /* :: */[
+                                                      /* tuple */[
+                                                        "substringToEnd",
+                                                        function () {
+                                                          return /* Eq */Block.__(0, [
+                                                                    "barbaz",
+                                                                    "foobarbaz".substring(3)
+                                                                  ]);
+                                                        }
+                                                      ],
+                                                      /* :: */[
+                                                        /* tuple */[
+                                                          "toLowerCase",
+                                                          function () {
+                                                            return /* Eq */Block.__(0, [
+                                                                      "bork",
+                                                                      "BORK".toLowerCase()
+                                                                    ]);
+                                                          }
+                                                        ],
+                                                        /* :: */[
+                                                          /* tuple */[
+                                                            "toLocaleLowerCase",
+                                                            function () {
+                                                              return /* Eq */Block.__(0, [
+                                                                        "bork",
+                                                                        "BORK".toLocaleLowerCase()
+                                                                      ]);
+                                                            }
+                                                          ],
+                                                          /* :: */[
+                                                            /* tuple */[
+                                                              "toUpperCase",
+                                                              function () {
+                                                                return /* Eq */Block.__(0, [
+                                                                          "FUBAR",
+                                                                          "fubar".toUpperCase()
+                                                                        ]);
+                                                              }
+                                                            ],
+                                                            /* :: */[
+                                                              /* tuple */[
+                                                                "toLocaleUpperCase",
+                                                                function () {
+                                                                  return /* Eq */Block.__(0, [
+                                                                            "FUBAR",
+                                                                            "fubar".toLocaleUpperCase()
+                                                                          ]);
+                                                                }
+                                                              ],
+                                                              /* :: */[
+                                                                /* tuple */[
+                                                                  "trim",
+                                                                  function () {
+                                                                    return /* Eq */Block.__(0, [
+                                                                              "foo",
+                                                                              "  foo  ".trim()
+                                                                            ]);
+                                                                  }
+                                                                ],
+                                                                /* [] */0
+                                                              ]
+                                                            ]
+                                                          ]
+                                                        ]
+                                                      ]
+                                                    ]
+                                                  ]
+                                                ]
+                                              ]
+                                            ]
+                                          ]
+                                        ]
+                                      ]
+                                    ]
+                                  ]
+                                ]
+                              ]
+                            ]
+                          ]
+                        ]
+                      ]
+                    ]
+                  ]
+                ]
+              ]
+            ]
+          ]
+        ]
+      ]
+    ]
+  ]
+];
 
-eq('File "js_string_test.ml", line 13, characters 5-12', /* tuple */[
-      "012",
-      "0".concat("1", "2")
-    ]);
+var suites = /* :: */[
+  suites_000,
+  suites_001
+];
 
-Mt.from_pair_suites("js_string_test.ml", suites[0]);
+Mt.from_pair_suites("js_string_test.ml", suites);
 
-exports.suites  = suites;
-exports.test_id = test_id;
-exports.eq      = eq;
+exports.suites = suites;
 /*  Not a pure module */

--- a/jscomp/test/js_string_test.ml
+++ b/jscomp/test/js_string_test.ml
@@ -1,16 +1,186 @@
+let suites = Mt.[
+    "make", (fun _ ->
+      Eq("null", Js.String.make Js.null |> Js.String.concat "")
+    );
 
-let suites :  Mt.pair_suites ref  = ref []
-let test_id = ref 0
+    "fromCharCode", (fun _ ->
+      Eq("a", Js.String.fromCharCode 97)
+    );
+    "fromCharCodeMany", (fun _ ->
+      Eq("az", Js.String.fromCharCodeMany [| 97; 122 |])
+    );
 
-let eq loc ((x, y) as _z) =
-  Js.log _z;
-  incr test_id ; 
-  suites := 
-    (loc ^" id " ^ (string_of_int !test_id), (fun _ -> Mt.Eq(x,y))) :: !suites
+    (* es2015
+    "fromCodePoint", (fun _ ->
+      Eq("a", Js.String.fromCodePoint 0x61)
+    );
+    "fromCodePointMany", (fun _ ->
+      Eq("az", Js.String.fromCodePointMany [| 0x61; 0x7a |])
+    );
+    *)
 
+    "length", (fun _ ->
+      Eq(3, "foo" |> Js.String.length)
+    );
 
-let () =
-  eq __LOC__ ("012", "0" |> Js.String.concat  [|"1";"2"|])
+    "get", (fun _ ->
+      Eq("a", Js.String.get "foobar" 4)
+    );
 
-let () =
-  Mt.from_pair_suites __FILE__ !suites
+    "charAt", (fun _ ->
+      Eq("a", "foobar" |> Js.String.charAt 4)
+    );
+
+    "charCodeAt", (fun _ ->
+      Eq(97., "foobar" |> Js.String.charCodeAt 4)
+    );
+
+    (* es2015
+    "codePointAt", (fun _ ->
+      Eq(Js.Undefined.return 0x61, "foobar" |> Js.String.codePointAt 4)
+    );
+    *)
+
+    "concat", (fun _ ->
+      Eq("foobar", "foo" |> Js.String.concat "bar")
+    );
+    "concatMany", (fun _ ->
+      Eq("foobarbaz", "foo" |> Js.String.concatMany [| "bar"; "baz" |])
+    );
+
+    (* es2015
+    "endsWith", (fun _ ->
+      Eq(Js.true_, "foobar" |> Js.String.endsWith "bar")
+    );
+    "endsWithFrom", (fun _ ->
+      Eq(Js.false_, "foobar" |> Js.String.endsWithFrom "bar" 1)
+    );
+    *)
+
+    (* es2015
+    "includes", (fun _ ->
+      Eq(Js.true_, "foobarbaz" |> Js.String.includes "bar")
+    );
+    "includesFrom", (fun _ ->
+      Eq(Js.false_, "foobarbaz" |> Js.String.includesFrom "bar" 4)
+    );
+    *)
+
+    "indexOf", (fun _ ->
+      Eq(3, "foobarbaz" |> Js.String.indexOf "bar")
+    );
+    "indexOfFrom", (fun _ ->
+      Eq((-1), "foobarbaz" |> Js.String.indexOfFrom "bar" 4)
+    );
+
+    "lastIndexOf", (fun _ ->
+      Eq(3, "foobarbaz" |> Js.String.lastIndexOf "bar")
+    );
+    "lastIndexOfFrom", (fun _ ->
+      Eq(3, "foobarbaz" |> Js.String.lastIndexOfFrom "bar" 4)
+    );
+
+    "localeCompare", (fun _ ->
+      Eq(0., "foo" |> Js.String.localeCompare "foo")
+    );
+
+    "match", (fun _ ->
+      Eq(Js.Null.return [| "na"; "na" |], "banana" |> Js.String.match_ [%re "/na+/g"])
+    );
+
+    (* es2015
+    "normalize", (fun _ ->
+      Eq("foo", "foo" |> Js.String.normalize)
+    );
+    "normalizeByForm", (fun _ ->
+      Eq("foo", "foo" |> Js.String.normalizeByForm "NFKD")
+    );
+    *)
+
+    (* es2015
+    "repeat", (fun _ ->
+      Eq("foofoofoo", "foo" |> Js.String.repeat 3)
+    );
+    *)
+
+    "replace", (fun _ ->
+      Eq("fooBORKbaz", "foobarbaz" |> Js.String.replace "bar" "BORK")
+    );
+    "replaceByRe", (fun _ ->
+      Eq("fooBORKBORK", "foobarbaz" |> Js.String.replaceByRe [%re "/ba./g"] "BORK")
+    );
+
+    "search", (fun _ ->
+      Eq(3, "foobarbaz" |> Js.String.search [%re "/ba./g"])
+    );
+
+    "slice", (fun _ ->
+      Eq("bar", "foobarbaz" |> Js.String.slice ~from:3 ~to_:6)
+    );
+    "sliceToEnd", (fun _ ->
+      Eq("barbaz", "foobarbaz" |> Js.String.sliceToEnd ~from:3)
+    );
+
+    "split", (fun _ ->
+      Eq([| "foo"; "bar"; "baz" |], "foo bar baz" |> Js.String.split " ")
+    );
+    "splitAtMost", (fun _ ->
+      Eq([| "foo"; "bar" |], "foo bar baz" |> Js.String.splitAtMost " " ~limit:2)
+    );
+    "splitByRe", (fun _ ->
+      Eq([| "foo"; "bar"; "baz" |], "foo bar baz" |> Js.String.splitByRe [%re "/\\s/"])
+    );
+    "splitByReAtMost", (fun _ ->
+      Eq([| "foo"; "bar" |], "foo bar baz" |> Js.String.splitByReAtMost [%re "/\\s/"] ~limit:2)
+    );
+
+    (* es2015
+    "startsWith", (fun _ ->
+      Eq(Js.true_, "foobarbaz" |> Js.String.startsWith "foo")
+    );
+    "startsWithFrom", (fun _ ->
+      Eq(Js.false_, "foobarbaz" |> Js.String.startsWithFrom "foo" 1)
+    );
+    *)
+
+    "substr", (fun _ ->
+      Eq("barbaz", "foobarbaz" |> Js.String.substr ~from:3)
+    );
+    "substrAtMost", (fun _ ->
+      Eq("bar", "foobarbaz" |> Js.String.substrAtMost ~from:3 ~length:3)
+    );
+
+    "substring", (fun _ ->
+      Eq("bar", "foobarbaz" |> Js.String.substring ~from:3 ~to_:6)
+    );
+    "substringToEnd", (fun _ ->
+      Eq("barbaz", "foobarbaz" |> Js.String.substringToEnd ~from:3)
+    );
+
+    "toLowerCase", (fun _ ->
+      Eq("bork", "BORK" |> Js.String.toLowerCase)
+    );
+    "toLocaleLowerCase", (fun _ ->
+      Eq("bork", "BORK" |> Js.String.toLocaleLowerCase)
+    );
+    "toUpperCase", (fun _ ->
+      Eq("FUBAR", "fubar" |> Js.String.toUpperCase)
+    );
+    "toLocaleUpperCase", (fun _ ->
+      Eq("FUBAR", "fubar" |> Js.String.toLocaleUpperCase)
+    );
+
+    "trim", (fun _ ->
+      Eq("foo", "  foo  " |> Js.String.trim)
+    );
+
+    (* es2015
+    "anchor", (fun _ ->
+      Eq("<a name=\"bar\">foo</a>", "foo" |> Js.String.anchor "bar")
+    );
+    "link", (fun _ ->
+      Eq("<a href=\"https://reason.ml\">foo</a>", "foo" |> Js.String.link "https://reason.ml")
+    );
+    *)
+]
+;; Mt.from_pair_suites __FILE__ suites


### PR DESCRIPTION
This more or less brings js_array and js_string to es2015 compliance.

It has the following breaking changes:
* `Array.slice_copy` has been renamed `Array.sliceCopy`
* `Array.slice_start` has been renamed `Array.sliceFrom`
* `Array.lastIndexOf` has been renamed `Array.lastIndexOfFrom`
* `Array.lastIndexOf_start` has been renamed `Array.lastIndexOf`
* `String.concat` has been renamed `String.concatMany`
* A new non-spliced function has taken the place of the old `String.concat`
