### PR TITLE
Added Js_obj.empty + test

### DIFF
--- a/jscomp/others/js_obj.ml
+++ b/jscomp/others/js_obj.ml
@@ -1,5 +1,5 @@
 (* Copyright (C) 2015-2016 Bloomberg Finance L.P.
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
@@ -17,10 +17,11 @@
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
 
+external empty : unit -> < .. > Js.t = "" [@@bs.obj]
 
 external keys : _ Js.t -> string array = "Object.keys" [@@bs.val]

--- a/jscomp/test/js_obj_test.js
+++ b/jscomp/test/js_obj_test.js
@@ -70,7 +70,18 @@ var suites_001 = /* :: */[
                 ]);
       }
     ],
-    /* [] */0
+    /* :: */[
+      /* tuple */[
+        "empty",
+        function () {
+          return /* Eq */Block.__(0, [
+                    0,
+                    Object.keys({ }).length
+                  ]);
+        }
+      ],
+      /* [] */0
+    ]
   ]
 ];
 

--- a/jscomp/test/js_obj_test.ml
+++ b/jscomp/test/js_obj_test.ml
@@ -13,10 +13,10 @@ let f_js u = u#@say 32
 let suites = Mt.[
   "caml_obj", (fun _ -> Eq (33, f (object method say x = 1 + x end)));
   "js_obj", (fun _ ->
-  Eq(34, f_js [%bs.obj{ say = fun [@bs]  x -> x + 2 } ]));
-  "js_obj2",(fun _ -> 
-  Eq(34,  [%bs.obj { say = fun [@bs]  x -> x + 2 } #@say 32 ]));
-    
+    Eq(34, f_js [%bs.obj{ say = fun [@bs]  x -> x + 2 } ]));
+  "js_obj2", (fun _ ->
+    Eq(34,  [%bs.obj { say = fun [@bs]  x -> x + 2 } #@say 32 ]));
+  "empty", fun _ -> (Eq(0, Js_obj.empty () |> Js_obj.keys |> Array.length));
 ]
 
 ;; Mt.from_pair_suites __FILE__ suites


### PR DESCRIPTION
Just a suggestion. Although I see from #444 that this has been judged not very useful, I keep having to write `[%bs.raw "{}"]`, and would rather not.

Here's some instances of it being used "in the wild":
* https://github.com/reasonml/rehydrate/blob/master/src/reactRe.re#L488
* https://github.com/bloomberg/bucklescript/blob/master/jscomp/test/flow_parser_reg_test.ml#L13406