### PR TITLE
Adds Js.Global with a few safe basics

### DIFF
--- a/jscomp/others/Makefile
+++ b/jscomp/others/Makefile
@@ -6,7 +6,7 @@ MAP_FILES= node bs
 
 SOURCE_LIST= node_path node_fs node_process dict node_module js_array js_string \
 	js_re js_null_undefined node_buffer js_types js_json js_obj bs_dyn bs_dyn_lib \
-	node_child_process js_boolean js_math js_dict js_date
+	node_child_process js_boolean js_math js_dict js_date js_global
 
 $(addsuffix .cmj, $(SOURCE_LIST)): $(addsuffix .cmj, $(MAP_FILES))
 

--- a/jscomp/others/js_global.ml
+++ b/jscomp/others/js_global.ml
@@ -1,0 +1,8 @@
+type intervalId
+type timeoutId
+
+external clearInterval : intervalId -> unit = "" [@@bs.val]
+external clearTimeout : timeoutId -> unit = "" [@@bs.val]
+
+external setInterval : (unit -> unit) -> int -> intervalId = "" [@@bs.val]
+external setTimeout : (unit -> unit) -> int -> timeoutId = "" [@@bs.val]

--- a/jscomp/runtime/js.ml
+++ b/jscomp/runtime/js.ml
@@ -103,3 +103,4 @@ module Obj  = Js_obj
 module Boolean = Js_boolean
 module Math = Js_math
 module Date = Js_date
+module Global = Js_global

--- a/jscomp/test/Makefile
+++ b/jscomp/test/Makefile
@@ -109,9 +109,9 @@ OTHERS := literals a test_ari test_export2 test_internalOO test_obj_simple_ffi t
 	return_check\
 	bs_splice_partial\
 	gpr_return_type_unused_attribute\
-	gpr_return_type_unused_attribute\
 	test\
-	undef_regression2_test
+	undef_regression2_test\
+	js_global_test
 
 # bs_uncurry_test
 # needs Lam to get rid of Uncurry arity first

--- a/jscomp/test/js_global_test.js
+++ b/jscomp/test/js_global_test.js
@@ -1,0 +1,39 @@
+'use strict';
+
+var Mt    = require("./mt");
+var Block = require("../../lib/js/block");
+
+var suites_000 = /* tuple */[
+  "setTimeout/clearTimeout sanity check",
+  function () {
+    var handle = setTimeout(function () {
+          return /* () */0;
+        }, 0);
+    clearTimeout(handle);
+    return /* Ok */Block.__(2, [/* true */1]);
+  }
+];
+
+var suites_001 = /* :: */[
+  /* tuple */[
+    "setInerval/clearInterval sanity check",
+    function () {
+      var handle = setInterval(function () {
+            return /* () */0;
+          }, 0);
+      clearInterval(handle);
+      return /* Ok */Block.__(2, [/* true */1]);
+    }
+  ],
+  /* [] */0
+];
+
+var suites = /* :: */[
+  suites_000,
+  suites_001
+];
+
+Mt.from_pair_suites("js_global_test.ml", suites);
+
+exports.suites = suites;
+/*  Not a pure module */

--- a/jscomp/test/js_global_test.ml
+++ b/jscomp/test/js_global_test.ml
@@ -1,0 +1,16 @@
+open Js_global
+
+let suites = Mt.[
+  ("setTimeout/clearTimeout sanity check", (fun _ -> 
+    let handle = setTimeout (fun () -> ()) 0 in
+    clearTimeout handle;
+    Ok true
+  ));
+  ("setInerval/clearInterval sanity check", (fun _ -> 
+    let handle = setInterval (fun () -> ()) 0 in
+    clearInterval handle;
+    Ok true
+  ));
+]
+
+;; Mt.from_pair_suites __FILE__ suites

--- a/lib/js/js_global.js
+++ b/lib/js/js_global.js
@@ -1,0 +1,5 @@
+'use strict';
+
+
+
+/* No side effect */


### PR DESCRIPTION
There's lots of open questions about how to handle all the different global scopes and the complex APIs they open up, but this seems like a fairly safe beginning. But even this isn't open and shut, as I discovered `atob` and `btoa` aren't supported on node, and likely won't be.