### PR TITLE
Fix `to_float` so it can be compiled on 32-bit systems.

### DIFF
--- a/jscomp/runtime/caml_int64.ml
+++ b/jscomp/runtime/caml_int64.ml
@@ -259,9 +259,8 @@ let gt x y =
 let le x y = Pervasives.not (gt x y)
 
 
-let to_float ({lo; hi } : t) : float =
-  let x = Nativeint.to_float 0x1_0000n in (* trick to allow compilation on 32-bit systems *)
-    Nativeint.to_float hi *. x *. x +. Nativeint.to_float lo
+let to_float ({hi; lo} : t) = 
+  Nativeint.to_float ( hi *~ [%raw{|0x100000000|}] +~ lo)
 
 
 

--- a/jscomp/runtime/caml_int64.ml
+++ b/jscomp/runtime/caml_int64.ml
@@ -260,7 +260,8 @@ let le x y = Pervasives.not (gt x y)
 
 
 let to_float ({lo; hi } : t) : float =
-  Nativeint.to_float ( hi *~   0x1_0000_0000n +~  lo)
+  let x = Nativeint.to_float 0x1_0000n in (* trick to allow compilation on 32-bit systems *)
+    Nativeint.to_float hi *. x *. x +. Nativeint.to_float lo
 
 
 


### PR DESCRIPTION
Fixes #1088 by leveraging float multiplication.