### PR TITLE
Add unsafe JSON calls

### DIFF
--- a/jscomp/others/js_json.ml
+++ b/jscomp/others/js_json.ml
@@ -62,4 +62,5 @@ let test (type a) (x : 'a) (v : a kind) : bool =
 
 
 external parse : string -> t = "JSON.parse" [@@bs.val]
+external stringifyAny : 'a -> string option = "JSON.stringify" [@@bs.val] [@@bs.return undefined_to_opt]
 (* TODO: more docs when parse error happens or stringify non-stringfy value *)

--- a/jscomp/others/js_json.mli
+++ b/jscomp/others/js_json.mli
@@ -39,3 +39,4 @@ val reify_type : 'a -> 'b kind * 'b
 val test : 'a  -> 'b kind -> bool
 
 external parse : string -> t = "JSON.parse" [@@bs.val]
+external stringifyAny : 'a -> string option = "JSON.stringify" [@@bs.val] [@@bs.return undefined_to_opt]

--- a/jscomp/test/.depend
+++ b/jscomp/test/.depend
@@ -255,8 +255,7 @@ js_math_test.cmj : mt.cmj ../runtime/js.cmj
 js_null_test.cmj : mt.cmj ../runtime/js_null.cmj
 js_null_undefined_test.cmj : mt.cmj ../others/js_null_undefined.cmj
 js_obj_test.cmj : mt.cmj ../others/js_obj.cmj ../stdlib/array.cmj
-js_re_test.cmj : mt.cmj ../runtime/js_null.cmj ../runtime/js.cmj \
-    ../stdlib/array.cmj
+js_re_test.cmj : mt.cmj ../runtime/js.cmj ../stdlib/array.cmj
 js_string_test.cmj : mt.cmj ../runtime/js.cmj
 js_undefined_test.cmj : mt.cmj ../runtime/js_undefined.cmj
 js_val.cmj :

--- a/jscomp/test/js_json_test.js
+++ b/jscomp/test/js_json_test.js
@@ -3,6 +3,7 @@
 var Mt                      = require("./mt");
 var Block                   = require("../../lib/js/block");
 var Js_json                 = require("../../lib/js/js_json");
+var Js_primitive            = require("../../lib/js/js_primitive");
 var Caml_builtin_exceptions = require("../../lib/js/caml_builtin_exceptions");
 
 var suites = [/* [] */0];
@@ -87,6 +88,24 @@ else {
 }
 
 eq('File "js_json_test.ml", line 37, characters 5-12', Js_json.test(v, /* Object */2), /* true */1);
+
+eq('File "js_json_test.ml", line 40, characters 12-19', Js_primitive.undefined_to_opt(JSON.stringify(/* int array */[
+              1,
+              2,
+              3
+            ])), /* Some */["[1,2,3]"]);
+
+eq('File "js_json_test.ml", line 44, characters 2-9', Js_primitive.undefined_to_opt(JSON.stringify({
+              foo: 1,
+              bar: "hello",
+              baz: {
+                baaz: 10
+              }
+            })), /* Some */['{"foo":1,"bar":"hello","baz":{"baaz":10}}']);
+
+eq('File "js_json_test.ml", line 48, characters 12-19', Js_primitive.undefined_to_opt(JSON.stringify(null)), /* Some */["null"]);
+
+eq('File "js_json_test.ml", line 50, characters 12-19', Js_primitive.undefined_to_opt(JSON.stringify(undefined)), /* None */0);
 
 Mt.from_pair_suites("js_json_test.ml", suites[0]);
 

--- a/jscomp/test/js_json_test.ml
+++ b/jscomp/test/js_json_test.ml
@@ -32,8 +32,22 @@ let () =
     end
   | _ -> assert false
 
-
-let () = 
+(* parse & reify tests *)
+let () =
   eq __LOC__  (Js.Json.test v Object) true
+
+(* stringifyAny tests *)
+let () = eq __LOC__ (Js.Json.stringifyAny [|1; 2; 3|]) (Some "[1,2,3]")
+
+let () =
+  eq
+  __LOC__
+  (Js.Json.stringifyAny [%bs.obj {foo = 1; bar = "hello"; baz = [%bs.obj {baaz = 10}]}])
+  (Some {|{"foo":1,"bar":"hello","baz":{"baaz":10}}|})
+
+let () = eq __LOC__ (Js.Json.stringifyAny Js.Null.empty) (Some "null")
+
+let () = eq __LOC__ (Js.Json.stringifyAny Js.Undefined.empty) None
+
 
 let () = Mt.from_pair_suites __FILE__ !suites


### PR DESCRIPTION
Partially because it'd be nice to have JSON.stringify, partially because we haven't figured out a newcomer-friendly way of parsing & stringifying JSON data (including ocaml data structures) yet.