### PR TITLE
Show usage info when `bsb` is given unknown args

### DIFF
--- a/jscomp/bin/bsb.ml
+++ b/jscomp/bin/bsb.ml
@@ -9308,7 +9308,6 @@ let (//) = Ext_filename.combine
 
 let force_regenerate = ref false
 let exec = ref false
-let targets = String_vec.make 5
 
 let cwd = Sys.getcwd ()
 
@@ -9346,9 +9345,6 @@ let build_bs_deps package_specs   =
             cwd = cwd;
             args  =
               [| bsb_exe ; internal_install ; no_dev; internal_package_specs; package_specs; regen; separator |]})
-
-let annoymous filename =
-  String_vec.push  filename targets
 
 let watch_mode = ref false
 let make_world = ref false
@@ -9520,13 +9516,14 @@ let ninja_command_exit (type t) vendor_ninja ninja_args  config : t =
    What will happen, some flags are really not good
    ninja -C _build
 *)
-let usage = "Usage : bsb.exe <bsb-options> <files> -- <ninja_options>\n\
+let usage = "Usage : bsb.exe <bsb-options> -- <ninja_options>\n\
              For ninja options, try ninja -h \n\
              ninja will be loaded either by just running `bsb.exe' or `bsb.exe .. -- ..`\n\
              It is always recommended to run ninja via bsb.exe \n\
              Bsb options are:"
 
-
+let handle_anonymous_arg arg =
+  raise (Arg.Bad ("Unknown arg \"" ^ arg ^ "\""))
 
 let make_world_deps (config : Bsb_config_types.t option) =
   print_endline "\nMaking the dependency world!";
@@ -9559,7 +9556,7 @@ let () =
       | `No_split
         ->
         begin
-          Arg.parse bsb_main_flags annoymous usage;
+          Arg.parse bsb_main_flags handle_anonymous_arg usage;
           (* [-make-world] should never be combined with [-package-specs] *)
           begin match !make_world, !force_regenerate with
             | false, false -> 
@@ -9593,7 +9590,7 @@ let () =
       | `Split (bsb_args,ninja_args)
         -> (* -make-world all dependencies fall into this category *)
         begin
-          Arg.parse_argv bsb_args bsb_main_flags annoymous usage ;
+          Arg.parse_argv bsb_args bsb_main_flags handle_anonymous_arg usage ;
           let config_opt = regenerate_ninja cwd bsc_dir !force_regenerate in
           (* [-make-world] should never be combined with [-package-specs] *)
           if !make_world then

--- a/jscomp/bsb/bsb_main.ml
+++ b/jscomp/bsb/bsb_main.ml
@@ -32,7 +32,6 @@ let (//) = Ext_filename.combine
 
 let force_regenerate = ref false
 let exec = ref false
-let targets = String_vec.make 5
 
 let cwd = Sys.getcwd ()
 
@@ -70,9 +69,6 @@ let build_bs_deps package_specs   =
             cwd = cwd;
             args  =
               [| bsb_exe ; internal_install ; no_dev; internal_package_specs; package_specs; regen; separator |]})
-
-let annoymous filename =
-  String_vec.push  filename targets
 
 let watch_mode = ref false
 let make_world = ref false

--- a/jscomp/bsb/bsb_main.ml
+++ b/jscomp/bsb/bsb_main.ml
@@ -250,7 +250,8 @@ let usage = "Usage : bsb.exe <bsb-options> <files> -- <ninja_options>\n\
              It is always recommended to run ninja via bsb.exe \n\
              Bsb options are:"
 
-
+let handle_anonymous_arg arg =
+  Arg.usage bsb_main_flags usage
 
 let make_world_deps (config : Bsb_config_types.t option) =
   print_endline "\nMaking the dependency world!";
@@ -283,7 +284,7 @@ let () =
       | `No_split
         ->
         begin
-          Arg.parse bsb_main_flags annoymous usage;
+          Arg.parse bsb_main_flags handle_anonymous_arg usage;
           (* [-make-world] should never be combined with [-package-specs] *)
           begin match !make_world, !force_regenerate with
             | false, false -> 
@@ -317,7 +318,7 @@ let () =
       | `Split (bsb_args,ninja_args)
         -> (* -make-world all dependencies fall into this category *)
         begin
-          Arg.parse_argv bsb_args bsb_main_flags annoymous usage ;
+          Arg.parse_argv bsb_args bsb_main_flags handle_anonymous_arg usage ;
           let config_opt = regenerate_ninja cwd bsc_dir !force_regenerate in
           (* [-make-world] should never be combined with [-package-specs] *)
           if !make_world then

--- a/jscomp/bsb/bsb_main.ml
+++ b/jscomp/bsb/bsb_main.ml
@@ -240,7 +240,7 @@ let ninja_command_exit (type t) vendor_ninja ninja_args  config : t =
    What will happen, some flags are really not good
    ninja -C _build
 *)
-let usage = "Usage : bsb.exe <bsb-options> <files> -- <ninja_options>\n\
+let usage = "Usage : bsb.exe <bsb-options> -- <ninja_options>\n\
              For ninja options, try ninja -h \n\
              ninja will be loaded either by just running `bsb.exe' or `bsb.exe .. -- ..`\n\
              It is always recommended to run ninja via bsb.exe \n\

--- a/jscomp/bsb/bsb_main.ml
+++ b/jscomp/bsb/bsb_main.ml
@@ -247,7 +247,7 @@ let usage = "Usage : bsb.exe <bsb-options> -- <ninja_options>\n\
              Bsb options are:"
 
 let handle_anonymous_arg arg =
-  Arg.usage bsb_main_flags usage
+  raise (Arg.Bad ("Unknown arg \"" ^ arg ^ "\""))
 
 let make_world_deps (config : Bsb_config_types.t option) =
   print_endline "\nMaking the dependency world!";


### PR DESCRIPTION
👋 

Thanks for the `GOOD FIRST TASK` label 👍 

`bsb` will now print the usage text and exit when given an anonymous arg.

<img width="649" alt="screen shot 2017-03-16 at 10 02 07 pm" src="https://cloud.githubusercontent.com/assets/13760/24025964/45438614-0a94-11e7-922e-763dce785a55.png">
