### PR TITLE
Add js cast

### DIFF
--- a/jscomp/others/Makefile
+++ b/jscomp/others/Makefile
@@ -6,7 +6,7 @@ MAP_FILES= node bs
 
 SOURCE_LIST= node_path node_fs node_process dict node_module js_array js_string \
 	js_re js_null_undefined node_buffer js_types js_json js_obj bs_dyn bs_dyn_lib \
-	node_child_process js_boolean js_math js_dict js_date js_global
+	node_child_process js_boolean js_math js_dict js_date js_global js_cast
 
 $(addsuffix .cmj, $(SOURCE_LIST)): $(addsuffix .cmj, $(MAP_FILES))
 

--- a/jscomp/others/js_cast.ml
+++ b/jscomp/others/js_cast.ml
@@ -25,7 +25,3 @@
 external intOfBool : bool -> int = "%identity"  
 
 external floatOfInt : int -> float = "%identity"  
-
-external floatOfIntArray : int array -> float array = "%identity"
-
-external intOfBoolArray : bool array -> int array = "%identity"

--- a/jscomp/others/js_cast.ml
+++ b/jscomp/others/js_cast.ml
@@ -1,0 +1,31 @@
+(* Copyright (C) 2015-2016 Bloomberg Finance L.P.
+ * 
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In addition to the permissions granted to you by the LGPL, you may combine
+ * or link a "work that uses the Library" with a publicly distributed version
+ * of this file to produce a combined library or application, then distribute
+ * that combined work under the terms of your choosing, with no requirement
+ * to comply with the obligations normally placed on you by section 4 of the
+ * LGPL version 3 (or the corresponding section of a later version of the LGPL
+ * should you choose to use a later version).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
+
+external intOfBool : bool -> int = "%identity"  
+
+external floatOfInt : int -> float = "%identity"  
+
+external floatOfIntArray : int array -> float array = "%identity"
+
+external intOfBoolArray : bool array -> int array = "%identity"

--- a/jscomp/others/js_cast.mli
+++ b/jscomp/others/js_cast.mli
@@ -1,0 +1,50 @@
+(* Copyright (C) 2015-2016 Bloomberg Finance L.P.
+ * 
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In addition to the permissions granted to you by the LGPL, you may combine
+ * or link a "work that uses the Library" with a publicly distributed version
+ * of this file to produce a combined library or application, then distribute
+ * that combined work under the terms of your choosing, with no requirement
+ * to comply with the obligations normally placed on you by section 4 of the
+ * LGPL version 3 (or the corresponding section of a later version of the LGPL
+ * should you choose to use a later version).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
+
+(** Safe cast between OCaml values which share the same 
+    runtime representation
+
+
+    Different OCaml types might share the same represention in the 
+    BuckleScript runtime; while this is a compiler internal knowledge,
+    applications might benefit from having a safe and zero cost 
+    conversion between those types. 
+    
+    This modules acts as the {b single place} for such conversion. 
+    
+    If for any reason, the runtime representation changes, those function 
+    will be modified accordingly. *)
+
+external intOfBool : bool -> int = "%identity"  
+(** [intOfBool b] returns [1] for when [b] is [true] and [0] when [b] is 
+    [false] *)
+
+external floatOfInt : int -> float = "%identity"  
+(** [floatOfInt i] returns the float value of [i] *)
+
+external floatOfIntArray : int array -> float array = "%identity"
+(** [floatOfIntArray a] returns the float array of [a] *) 
+
+external intOfBoolArray : bool array -> int array = "%identity"
+(** [intOfBoolArray a] returns the int array of [a] *)

--- a/jscomp/others/js_cast.mli
+++ b/jscomp/others/js_cast.mli
@@ -42,9 +42,3 @@ external intOfBool : bool -> int = "%identity"
 
 external floatOfInt : int -> float = "%identity"  
 (** [floatOfInt i] returns the float value of [i] *)
-
-external floatOfIntArray : int array -> float array = "%identity"
-(** [floatOfIntArray a] returns the float array of [a] *) 
-
-external intOfBoolArray : bool array -> int array = "%identity"
-(** [intOfBoolArray a] returns the int array of [a] *)

--- a/jscomp/test/Makefile
+++ b/jscomp/test/Makefile
@@ -115,7 +115,8 @@ OTHERS := literals a test_ari test_export2 test_internalOO test_obj_simple_ffi t
 	js_float_test\
 	js_int_test\
 	bang_primitive\
-	compare_test
+	compare_test\
+	js_cast_test
 
 
 # bs_uncurry_test

--- a/jscomp/test/js_cast_test.js
+++ b/jscomp/test/js_cast_test.js
@@ -39,30 +39,6 @@ eq('File "js_cast_test.ml", line 19, characters 12-19', 1, 1.0);
 
 eq('File "js_cast_test.ml", line 21, characters 12-19', 123456789, 123456789.0);
 
-eq('File "js_cast_test.ml", line 23, characters 12-19', /* int array */[
-      /* true */1,
-      /* false */0,
-      /* true */1
-    ], /* int array */[
-      1,
-      0,
-      1
-    ]);
-
-eq('File "js_cast_test.ml", line 27, characters 12-19', /* array */[
-      -123,
-      0,
-      1,
-      123,
-      123456789
-    ], /* float array */[
-      -123.0,
-      0.0,
-      1.0,
-      123.0,
-      123456789.0
-    ]);
-
 Mt.from_pair_suites("js_cast_test.ml", suites[0]);
 
 exports.suites   = suites;

--- a/jscomp/test/js_cast_test.js
+++ b/jscomp/test/js_cast_test.js
@@ -1,0 +1,71 @@
+'use strict';
+
+var Mt    = require("./mt");
+var Block = require("../../lib/js/block");
+
+var suites = [/* [] */0];
+
+var counter = [0];
+
+function add_test(loc, test) {
+  counter[0] = counter[0] + 1 | 0;
+  var id = loc + (" id " + counter[0]);
+  suites[0] = /* :: */[
+    /* tuple */[
+      id,
+      test
+    ],
+    suites[0]
+  ];
+  return /* () */0;
+}
+
+function eq(loc, x, y) {
+  return add_test(loc, function () {
+              return /* Eq */Block.__(0, [
+                        x,
+                        y
+                      ]);
+            });
+}
+
+eq('File "js_cast_test.ml", line 13, characters 12-19', /* true */1, 1);
+
+eq('File "js_cast_test.ml", line 15, characters 12-19', /* false */0, 0);
+
+eq('File "js_cast_test.ml", line 17, characters 12-19', 0, 0.0);
+
+eq('File "js_cast_test.ml", line 19, characters 12-19', 1, 1.0);
+
+eq('File "js_cast_test.ml", line 21, characters 12-19', 123456789, 123456789.0);
+
+eq('File "js_cast_test.ml", line 23, characters 12-19', /* int array */[
+      /* true */1,
+      /* false */0,
+      /* true */1
+    ], /* int array */[
+      1,
+      0,
+      1
+    ]);
+
+eq('File "js_cast_test.ml", line 27, characters 12-19', /* array */[
+      -123,
+      0,
+      1,
+      123,
+      123456789
+    ], /* float array */[
+      -123.0,
+      0.0,
+      1.0,
+      123.0,
+      123456789.0
+    ]);
+
+Mt.from_pair_suites("js_cast_test.ml", suites[0]);
+
+exports.suites   = suites;
+exports.add_test = add_test;
+exports.eq       = eq;
+/*  Not a pure module */

--- a/jscomp/test/js_cast_test.ml
+++ b/jscomp/test/js_cast_test.ml
@@ -20,12 +20,4 @@ let () = eq __LOC__ (Js_cast.floatOfInt 1) 1.0
 
 let () = eq __LOC__ (Js_cast.floatOfInt 123456789) 123456789.0
 
-let () = eq __LOC__ 
- (Js_cast.intOfBoolArray [| true; false; true |]) 
- [|1; 0; 1|]
-
-let () = eq __LOC__ 
- (Js_cast.floatOfIntArray [| -123; 0; 1; 123; 123456789|]) 
- [|-. 123.0; 0.0; 1.0; 123.0; 123456789.0|]
-
 let () = Mt.from_pair_suites __FILE__ !suites

--- a/jscomp/test/js_cast_test.ml
+++ b/jscomp/test/js_cast_test.ml
@@ -1,0 +1,31 @@
+let suites :  Mt.pair_suites ref  = ref []
+
+let add_test = 
+  let counter = ref 0 in
+  fun loc test -> 
+    incr counter; 
+    let id = (loc ^ " id " ^ (string_of_int !counter)) in 
+    suites := (id, test) :: ! suites
+
+let eq loc x y = 
+  add_test loc (fun _ -> Mt.Eq (x, y)) 
+
+let () = eq __LOC__ (Js_cast.intOfBool true) 1
+
+let () = eq __LOC__ (Js_cast.intOfBool false) 0
+
+let () = eq __LOC__ (Js_cast.floatOfInt 0) 0.0
+
+let () = eq __LOC__ (Js_cast.floatOfInt 1) 1.0 
+
+let () = eq __LOC__ (Js_cast.floatOfInt 123456789) 123456789.0
+
+let () = eq __LOC__ 
+ (Js_cast.intOfBoolArray [| true; false; true |]) 
+ [|1; 0; 1|]
+
+let () = eq __LOC__ 
+ (Js_cast.floatOfIntArray [| -123; 0; 1; 123; 123456789|]) 
+ [|-. 123.0; 0.0; 1.0; 123.0; 123456789.0|]
+
+let () = Mt.from_pair_suites __FILE__ !suites

--- a/lib/js/js_cast.js
+++ b/lib/js/js_cast.js
@@ -1,0 +1,5 @@
+'use strict';
+
+
+
+/* No side effect */


### PR DESCRIPTION
Add Js_cast module to safely cast between OCaml types which shares the same runtime representation.