### PR TITLE
Add Js_json.*OfJson functions

### DIFF
--- a/jscomp/others/js_json.ml
+++ b/jscomp/others/js_json.ml
@@ -61,6 +61,12 @@ let test (type a) (x : 'a) (v : a kind) : bool =
   | Array -> Js_array.isArray x 
   | Object -> (Obj.magic x) != Js.null && Js.typeof x = "object" && not (Js_array.isArray x )
 
+let stringOfJson json = 
+  let ty, x = reifyType json in 
+  match ty with
+  | String -> Some x 
+  | _ -> None
+
 external parse : string -> t = "JSON.parse" [@@bs.val]
 external stringifyAny : 'a -> string option = "JSON.stringify" [@@bs.val] [@@bs.return undefined_to_opt]
 (* TODO: more docs when parse error happens or stringify non-stringfy value *)

--- a/jscomp/others/js_json.ml
+++ b/jscomp/others/js_json.ml
@@ -61,11 +61,37 @@ let test (type a) (x : 'a) (v : a kind) : bool =
   | Array -> Js_array.isArray x 
   | Object -> (Obj.magic x) != Js.null && Js.typeof x = "object" && not (Js_array.isArray x )
 
-let stringOfJson json = 
-  let ty, x = reifyType json in 
-  match ty with
-  | String -> Some x 
-  | _ -> None
+let stringOfJSON json = 
+  if Js.typeof json = "string" 
+  then Some (Obj.magic (json:t) : string)
+  else None 
+
+let numberOfJSON json = 
+  if Js.typeof json = "number" 
+  then Some (Obj.magic (json:t) : float)
+  else None 
+
+let objectOfJSON json = 
+  if  Js.typeof json = "object" && 
+      not (Js_array.isArray json) && 
+      not ((Obj.magic json : 'a Js.null) == Js.null)
+  then Some (Obj.magic (json:t) : t Js_dict.t)
+  else None 
+
+let arrayOfJSON json = 
+  if Js_array.isArray json
+  then Some (Obj.magic (json:t) : t array)
+  else None 
+
+let booleanOfJSON json = 
+  if Js.typeof json = "boolean"
+  then Some (Obj.magic (json:t) : Js.boolean)
+  else None 
+
+let nullOfJSON json = 
+  if (Obj.magic json : 'a Js.null) == Js.null
+  then Some Js.null
+  else None 
 
 external parse : string -> t = "JSON.parse" [@@bs.val]
 external stringifyAny : 'a -> string option = "JSON.stringify" [@@bs.val] [@@bs.return undefined_to_opt]

--- a/jscomp/others/js_json.mli
+++ b/jscomp/others/js_json.mli
@@ -49,6 +49,10 @@ val reifyType : t -> 'b kind * 'b
 val test : 'a  -> 'b kind -> bool
 (** [test v kind] returns true if [v] is of [kind] *)
 
+val stringOfJson : t -> Js_string.t option
+(** [string_of_json json] returns [Some s] if [json] is a string, [None]
+    otherwise *)
+
 (** {2 Construtors} *)
 
 (** Those functions allows the construction of an arbitrary complex 

--- a/jscomp/others/js_json.mli
+++ b/jscomp/others/js_json.mli
@@ -49,8 +49,28 @@ val reifyType : t -> 'b kind * 'b
 val test : 'a  -> 'b kind -> bool
 (** [test v kind] returns true if [v] is of [kind] *)
 
-val stringOfJson : t -> Js_string.t option
-(** [string_of_json json] returns [Some s] if [json] is a string, [None]
+val stringOfJSON : t -> Js_string.t option
+(** [stringOfJSON json] returns [Some s] if [json] is a string, [None]
+    otherwise *)
+
+val numberOfJSON : t -> float option
+(** [numberOfJSON json] returns [Some n] if [json] is a number, [None]
+    otherwise *)
+
+val objectOfJSON : t -> t Js_dict.t option
+(** [objectOfJSON json] returns [Some o] if [json] is an object, [None]
+    otherwise *)
+
+val arrayOfJSON : t -> t array option
+(** [arrayOfJSON json] returns [Some a] if [json] is an array, [None]
+    otherwise *)
+
+val booleanOfJSON : t -> Js.boolean option
+(** [booleanOfJSON json] returns [Some b] if [json] is a boolean, [None]
+    otherwise *)
+
+val nullOfJSON : t -> 'a Js_null.t option
+(** [nullOfJSON json] returns [Some null] if [json] is a null, [None]
     otherwise *)
 
 (** {2 Construtors} *)

--- a/jscomp/test/js_json_test.js
+++ b/jscomp/test/js_json_test.js
@@ -393,6 +393,10 @@ eq('File "js_json_test.ml", line 275, characters 12-19', Js_primitive.undefined_
 
 eq('File "js_json_test.ml", line 277, characters 12-19', Js_primitive.undefined_to_opt(JSON.stringify(undefined)), /* None */0);
 
+eq('File "js_json_test.ml", line 280, characters 5-12', Js_json.stringOfJson("test"), /* Some */["test"]);
+
+eq('File "js_json_test.ml", line 282, characters 5-12', Js_json.stringOfJson(1.23), /* None */0);
+
 Mt.from_pair_suites("js_json_test.ml", suites[0]);
 
 exports.suites     = suites;

--- a/jscomp/test/js_json_test.js
+++ b/jscomp/test/js_json_test.js
@@ -393,9 +393,77 @@ eq('File "js_json_test.ml", line 275, characters 12-19', Js_primitive.undefined_
 
 eq('File "js_json_test.ml", line 277, characters 12-19', Js_primitive.undefined_to_opt(JSON.stringify(undefined)), /* None */0);
 
-eq('File "js_json_test.ml", line 280, characters 5-12', Js_json.stringOfJson("test"), /* Some */["test"]);
+eq('File "js_json_test.ml", line 280, characters 5-12', Js_json.stringOfJSON("test"), /* Some */["test"]);
 
-eq('File "js_json_test.ml", line 282, characters 5-12', Js_json.stringOfJson(1.23), /* None */0);
+eq('File "js_json_test.ml", line 282, characters 5-12', Js_json.stringOfJSON(true), /* None */0);
+
+eq('File "js_json_test.ml", line 284, characters 5-12', Js_json.stringOfJSON(/* array */[]), /* None */0);
+
+eq('File "js_json_test.ml", line 286, characters 5-12', Js_json.stringOfJSON(null), /* None */0);
+
+eq('File "js_json_test.ml", line 288, characters 5-12', Js_json.stringOfJSON({ }), /* None */0);
+
+eq('File "js_json_test.ml", line 290, characters 5-12', Js_json.stringOfJSON(1.23), /* None */0);
+
+eq('File "js_json_test.ml", line 294, characters 5-12', Js_json.numberOfJSON("test"), /* None */0);
+
+eq('File "js_json_test.ml", line 296, characters 5-12', Js_json.numberOfJSON(true), /* None */0);
+
+eq('File "js_json_test.ml", line 298, characters 5-12', Js_json.numberOfJSON(/* array */[]), /* None */0);
+
+eq('File "js_json_test.ml", line 300, characters 5-12', Js_json.numberOfJSON(null), /* None */0);
+
+eq('File "js_json_test.ml", line 302, characters 5-12', Js_json.numberOfJSON({ }), /* None */0);
+
+eq('File "js_json_test.ml", line 304, characters 5-12', Js_json.numberOfJSON(1.23), /* Some */[1.23]);
+
+eq('File "js_json_test.ml", line 308, characters 5-12', Js_json.objectOfJSON("test"), /* None */0);
+
+eq('File "js_json_test.ml", line 310, characters 5-12', Js_json.objectOfJSON(true), /* None */0);
+
+eq('File "js_json_test.ml", line 312, characters 5-12', Js_json.objectOfJSON(/* array */[]), /* None */0);
+
+eq('File "js_json_test.ml", line 314, characters 5-12', Js_json.objectOfJSON(null), /* None */0);
+
+eq('File "js_json_test.ml", line 316, characters 5-12', Js_json.objectOfJSON({ }), /* Some */[{ }]);
+
+eq('File "js_json_test.ml", line 319, characters 5-12', Js_json.objectOfJSON(1.23), /* None */0);
+
+eq('File "js_json_test.ml", line 323, characters 5-12', Js_json.arrayOfJSON("test"), /* None */0);
+
+eq('File "js_json_test.ml", line 325, characters 5-12', Js_json.arrayOfJSON(true), /* None */0);
+
+eq('File "js_json_test.ml", line 327, characters 5-12', Js_json.arrayOfJSON(/* array */[]), /* Some */[/* array */[]]);
+
+eq('File "js_json_test.ml", line 329, characters 5-12', Js_json.arrayOfJSON(null), /* None */0);
+
+eq('File "js_json_test.ml", line 331, characters 5-12', Js_json.arrayOfJSON({ }), /* None */0);
+
+eq('File "js_json_test.ml", line 333, characters 5-12', Js_json.arrayOfJSON(1.23), /* None */0);
+
+eq('File "js_json_test.ml", line 337, characters 5-12', Js_json.booleanOfJSON("test"), /* None */0);
+
+eq('File "js_json_test.ml", line 339, characters 5-12', Js_json.booleanOfJSON(true), /* Some */[true]);
+
+eq('File "js_json_test.ml", line 341, characters 5-12', Js_json.booleanOfJSON(/* array */[]), /* None */0);
+
+eq('File "js_json_test.ml", line 343, characters 5-12', Js_json.booleanOfJSON(null), /* None */0);
+
+eq('File "js_json_test.ml", line 345, characters 5-12', Js_json.booleanOfJSON({ }), /* None */0);
+
+eq('File "js_json_test.ml", line 347, characters 5-12', Js_json.booleanOfJSON(1.23), /* None */0);
+
+eq('File "js_json_test.ml", line 351, characters 5-12', Js_json.nullOfJSON("test"), /* None */0);
+
+eq('File "js_json_test.ml", line 353, characters 5-12', Js_json.nullOfJSON(true), /* None */0);
+
+eq('File "js_json_test.ml", line 355, characters 5-12', Js_json.nullOfJSON(/* array */[]), /* None */0);
+
+eq('File "js_json_test.ml", line 357, characters 5-12', Js_json.nullOfJSON(null), /* Some */[null]);
+
+eq('File "js_json_test.ml", line 359, characters 5-12', Js_json.nullOfJSON({ }), /* None */0);
+
+eq('File "js_json_test.ml", line 361, characters 5-12', Js_json.nullOfJSON(1.23), /* None */0);
 
 Mt.from_pair_suites("js_json_test.ml", suites[0]);
 

--- a/jscomp/test/js_json_test.ml
+++ b/jscomp/test/js_json_test.ml
@@ -276,4 +276,10 @@ let () = eq __LOC__ (Js.Json.stringifyAny Js.Null.empty) (Some "null")
 
 let () = eq __LOC__ (Js.Json.stringifyAny Js.Undefined.empty) None
 
+let () = 
+  eq __LOC__ 
+    (Js.Json.stringOfJson (Js.Json.string "test")) (Some "test");
+  eq __LOC__ 
+    (Js.Json.stringOfJson (Js.Json.number 1.23)) None
+
 let () = Mt.from_pair_suites __FILE__ !suites

--- a/jscomp/test/js_json_test.ml
+++ b/jscomp/test/js_json_test.ml
@@ -278,8 +278,87 @@ let () = eq __LOC__ (Js.Json.stringifyAny Js.Undefined.empty) None
 
 let () = 
   eq __LOC__ 
-    (Js.Json.stringOfJson (Js.Json.string "test")) (Some "test");
+    (Js.Json.stringOfJSON (Js.Json.string "test")) (Some "test");
   eq __LOC__ 
-    (Js.Json.stringOfJson (Js.Json.number 1.23)) None
+    (Js.Json.stringOfJSON (Js.Json.boolean Js.true_)) None;
+  eq __LOC__ 
+    (Js.Json.stringOfJSON (Js.Json.array_ [||])) None;
+  eq __LOC__ 
+    (Js.Json.stringOfJSON Js.Json.null) None;
+  eq __LOC__ 
+    (Js.Json.stringOfJSON (Js.Json.object_ @@ Js.Dict.empty ())) None;
+  eq __LOC__ 
+    (Js.Json.stringOfJSON (Js.Json.number 1.23)) None
+
+let () = 
+  eq __LOC__ 
+    (Js.Json.numberOfJSON (Js.Json.string "test")) None;
+  eq __LOC__ 
+    (Js.Json.numberOfJSON (Js.Json.boolean Js.true_)) None;
+  eq __LOC__ 
+    (Js.Json.numberOfJSON (Js.Json.array_ [||])) None;
+  eq __LOC__ 
+    (Js.Json.numberOfJSON Js.Json.null) None;
+  eq __LOC__ 
+    (Js.Json.numberOfJSON (Js.Json.object_ @@ Js.Dict.empty ())) None;
+  eq __LOC__ 
+    (Js.Json.numberOfJSON (Js.Json.number 1.23)) (Some 1.23)
+
+let () = 
+  eq __LOC__ 
+    (Js.Json.objectOfJSON (Js.Json.string "test")) None;
+  eq __LOC__ 
+    (Js.Json.objectOfJSON (Js.Json.boolean Js.true_)) None;
+  eq __LOC__ 
+    (Js.Json.objectOfJSON (Js.Json.array_ [||])) None;
+  eq __LOC__ 
+    (Js.Json.objectOfJSON Js.Json.null) None;
+  eq __LOC__ 
+    (Js.Json.objectOfJSON (Js.Json.object_ @@ Js.Dict.empty ())) 
+    (Some (Js.Dict.empty ()));
+  eq __LOC__ 
+    (Js.Json.objectOfJSON (Js.Json.number 1.23)) None
+
+let () = 
+  eq __LOC__ 
+    (Js.Json.arrayOfJSON (Js.Json.string "test")) None;
+  eq __LOC__ 
+    (Js.Json.arrayOfJSON (Js.Json.boolean Js.true_)) None;
+  eq __LOC__ 
+    (Js.Json.arrayOfJSON (Js.Json.array_ [||])) (Some [||]);
+  eq __LOC__ 
+    (Js.Json.arrayOfJSON Js.Json.null) None;
+  eq __LOC__ 
+    (Js.Json.arrayOfJSON (Js.Json.object_ @@ Js.Dict.empty ())) None;
+  eq __LOC__ 
+    (Js.Json.arrayOfJSON (Js.Json.number 1.23)) None
+
+let () = 
+  eq __LOC__ 
+    (Js.Json.booleanOfJSON (Js.Json.string "test")) None;
+  eq __LOC__ 
+    (Js.Json.booleanOfJSON (Js.Json.boolean Js.true_)) (Some Js.true_);
+  eq __LOC__ 
+    (Js.Json.booleanOfJSON (Js.Json.array_ [||])) None;
+  eq __LOC__ 
+    (Js.Json.booleanOfJSON Js.Json.null) None;
+  eq __LOC__ 
+    (Js.Json.booleanOfJSON (Js.Json.object_ @@ Js.Dict.empty ())) None;
+  eq __LOC__ 
+    (Js.Json.booleanOfJSON (Js.Json.number 1.23)) None
+
+let () = 
+  eq __LOC__ 
+    (Js.Json.nullOfJSON (Js.Json.string "test")) None;
+  eq __LOC__ 
+    (Js.Json.nullOfJSON (Js.Json.boolean Js.true_)) None;
+  eq __LOC__ 
+    (Js.Json.nullOfJSON (Js.Json.array_ [||])) None;
+  eq __LOC__ 
+    (Js.Json.nullOfJSON Js.Json.null) (Some Js.null);
+  eq __LOC__ 
+    (Js.Json.nullOfJSON (Js.Json.object_ @@ Js.Dict.empty ())) None;
+  eq __LOC__ 
+    (Js.Json.nullOfJSON (Js.Json.number 1.23)) None
 
 let () = Mt.from_pair_suites __FILE__ !suites

--- a/lib/js/js_json.js
+++ b/lib/js/js_json.js
@@ -39,9 +39,20 @@ function test(x, v) {
   }
 }
 
+function stringOfJson(json) {
+  var match = reify_type(json);
+  if (match[0] !== 0) {
+    return /* None */0;
+  }
+  else {
+    return /* Some */[match[1]];
+  }
+}
+
 var reifyType = reify_type;
 
-exports.reifyType  = reifyType;
-exports.test       = test;
-exports.reify_type = reify_type;
+exports.reifyType    = reifyType;
+exports.test         = test;
+exports.stringOfJson = stringOfJson;
+exports.reify_type   = reify_type;
 /* No side effect */

--- a/lib/js/js_json.js
+++ b/lib/js/js_json.js
@@ -39,20 +39,69 @@ function test(x, v) {
   }
 }
 
-function stringOfJson(json) {
-  var match = reify_type(json);
-  if (match[0] !== 0) {
-    return /* None */0;
+function stringOfJSON(json) {
+  if (typeof json === "string") {
+    return /* Some */[json];
   }
   else {
-    return /* Some */[match[1]];
+    return /* None */0;
+  }
+}
+
+function numberOfJSON(json) {
+  if (typeof json === "number") {
+    return /* Some */[json];
+  }
+  else {
+    return /* None */0;
+  }
+}
+
+function objectOfJSON(json) {
+  if (typeof json === "object" && !Array.isArray(json) && json !== null) {
+    return /* Some */[json];
+  }
+  else {
+    return /* None */0;
+  }
+}
+
+function arrayOfJSON(json) {
+  if (Array.isArray(json)) {
+    return /* Some */[json];
+  }
+  else {
+    return /* None */0;
+  }
+}
+
+function booleanOfJSON(json) {
+  if (typeof json === "boolean") {
+    return /* Some */[json];
+  }
+  else {
+    return /* None */0;
+  }
+}
+
+function nullOfJSON(json) {
+  if (json === null) {
+    return /* Some */[null];
+  }
+  else {
+    return /* None */0;
   }
 }
 
 var reifyType = reify_type;
 
-exports.reifyType    = reifyType;
-exports.test         = test;
-exports.stringOfJson = stringOfJson;
-exports.reify_type   = reify_type;
+exports.reifyType     = reifyType;
+exports.test          = test;
+exports.stringOfJSON  = stringOfJSON;
+exports.numberOfJSON  = numberOfJSON;
+exports.objectOfJSON  = objectOfJSON;
+exports.arrayOfJSON   = arrayOfJSON;
+exports.booleanOfJSON = booleanOfJSON;
+exports.nullOfJSON    = nullOfJSON;
+exports.reify_type    = reify_type;
 /* No side effect */

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
       "bsb" : "bin/bsb"
    },
   "scripts": {
-    "start": "cd jscomp && make libs && make -C test all && mocha './test/js_json_test.js'  -R spec",
     "test": "mocha './jscomp/test/**/*test.js' ",
     "wtest": "mocha './jscomp/test/**/*test.js'  -R spec -w",
     "cover": "istanbul cover --report html ./node_modules/.bin/_mocha --   ./jscomp/test/**/*test.js && open coverage/index.html",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
       "bsb" : "bin/bsb"
    },
   "scripts": {
+    "start": "cd jscomp && make libs && make -C test all && mocha './test/js_json_test.js'  -R spec",
     "test": "mocha './jscomp/test/**/*test.js' ",
     "wtest": "mocha './jscomp/test/**/*test.js'  -R spec -w",
     "cover": "istanbul cover --report html ./node_modules/.bin/_mocha --   ./jscomp/test/**/*test.js && open coverage/index.html",


### PR DESCRIPTION
In order to make it easier to read the a JSON object, this PR provides `*OfJson functions` for all JSON types. 

Note this is currently limited to `string` just to discuss the API before I got and make all the other types. 