### PR TITLE
Adds Js_dom module with dom types from reason-js

### DIFF
--- a/jscomp/all.depend
+++ b/jscomp/all.depend
@@ -423,9 +423,8 @@ core/lam_compile_const.cmx : core/lam_compile_util.cmx core/lam.cmx \
     core/lam_compile_const.cmi
 core/lam_inner.cmx : core/lam.cmx core/lam_inner.cmi
 core/lam_util.cmx : core/lam_stats.cmx core/lam_print.cmx \
-    core/lam_analysis.cmx core/lam.cmx common/js_config.cmx ext/ident_set.cmx \
-    ext/ident_map.cmx ext/ident_hashtbl.cmx common/ext_log.cmx \
-    ext/ext_filename.cmx ext/ext_array.cmx core/lam_util.cmi
+    core/lam_analysis.cmx core/lam.cmx ext/ident_set.cmx ext/ident_map.cmx \
+    ext/ident_hashtbl.cmx ext/ext_array.cmx core/lam_util.cmi
 core/lam_eta_conversion.cmx : ext/literals.cmx core/lam.cmx ext/ext_list.cmx \
     ext/ext_ident.cmx core/lam_eta_conversion.cmi
 core/lam_group.cmx : core/lam_print.cmx core/lam.cmx core/lam_group.cmi
@@ -488,9 +487,7 @@ core/js_dump.cmx : ext/literals.cmx core/lam_module_ident.cmx \
     core/js_exp_make.cmx common/js_config.cmx core/js_closure.cmx core/j.cmx \
     ext/ident_set.cmx ext/ext_string.cmx ext/ext_pp_scope.cmx ext/ext_pp.cmx \
     ext/ext_list.cmx ext/ext_ident.cmx common/bs_version.cmx core/js_dump.cmi
-core/js_pass_debug.cmx : core/js_dump.cmx common/js_config.cmx core/j.cmx \
-    ext/ext_pervasives.cmx common/ext_log.cmx ext/ext_filename.cmx \
-    core/js_pass_debug.cmi
+core/js_pass_debug.cmx : core/j.cmx core/js_pass_debug.cmi
 core/js_of_lam_option.cmx : core/js_exp_make.cmx common/js_config.cmx \
     core/js_analyzer.cmx core/j.cmx core/js_of_lam_option.cmi
 core/js_output.cmx : core/lam_compile_defs.cmx core/lam_analysis.cmx \
@@ -558,21 +555,20 @@ core/lam_pass_remove_alias.cmx : core/lam_util.cmx core/lam_stats.cmx \
 core/lam_coercion.cmx : ext/string_hash_set.cmx core/lam_group.cmx \
     core/lam_dce.cmx core/lam.cmx ext/ident_set.cmx ext/ident_map.cmx \
     depends/bs_exception.cmx core/lam_coercion.cmi
-core/lam_compile_group.cmx : core/lam_util.cmx core/lam_stats_util.cmx \
-    core/lam_stats_export.cmx core/lam_stats.cmx \
-    core/lam_pass_remove_alias.cmx core/lam_pass_lets_dce.cmx \
-    core/lam_pass_exits.cmx core/lam_pass_deep_flatten.cmx \
-    core/lam_pass_collect.cmx core/lam_pass_alpha_conversion.cmx \
-    core/lam_module_ident.cmx core/lam_group.cmx core/lam_compile_env.cmx \
-    core/lam_compile_defs.cmx core/lam_compile.cmx core/lam_coercion.cmx \
-    core/lam_analysis.cmx core/lam.cmx core/js_stmt_make.cmx \
-    core/js_shake.cmx core/js_program_loader.cmx \
-    core/js_pass_tailcall_inline.cmx core/js_pass_scope.cmx \
-    core/js_pass_flatten_and_mark_dead.cmx core/js_pass_flatten.cmx \
-    core/js_pass_debug.cmx core/js_output.cmx core/js_fold_basic.cmx \
-    core/js_exp_make.cmx core/js_dump.cmx common/js_config.cmx \
-    core/js_cmj_format.cmx core/j.cmx ext/ident_set.cmx ext/ext_string.cmx \
-    ext/ext_pervasives.cmx common/ext_log.cmx ext/ext_list.cmx \
+core/lam_compile_group.cmx : core/lam_util.cmx core/lam_stats_export.cmx \
+    core/lam_stats.cmx core/lam_pass_remove_alias.cmx \
+    core/lam_pass_lets_dce.cmx core/lam_pass_exits.cmx \
+    core/lam_pass_deep_flatten.cmx core/lam_pass_collect.cmx \
+    core/lam_pass_alpha_conversion.cmx core/lam_module_ident.cmx \
+    core/lam_group.cmx core/lam_compile_env.cmx core/lam_compile_defs.cmx \
+    core/lam_compile.cmx core/lam_coercion.cmx core/lam_analysis.cmx \
+    core/lam.cmx core/js_stmt_make.cmx core/js_shake.cmx \
+    core/js_program_loader.cmx core/js_pass_tailcall_inline.cmx \
+    core/js_pass_scope.cmx core/js_pass_flatten_and_mark_dead.cmx \
+    core/js_pass_flatten.cmx core/js_pass_debug.cmx core/js_output.cmx \
+    core/js_fold_basic.cmx core/js_exp_make.cmx core/js_dump.cmx \
+    common/js_config.cmx core/js_cmj_format.cmx core/j.cmx ext/ident_set.cmx \
+    ext/ext_string.cmx ext/ext_pervasives.cmx ext/ext_list.cmx \
     ext/ext_ident.cmx ext/ext_filename.cmx core/lam_compile_group.cmi
 core/js_implementation.cmx : core/ocaml_parse.cmx ext/literals.cmx \
     core/lam_compile_group.cmx core/lam_compile_env.cmx common/js_config.cmx \

--- a/jscomp/others/.depend
+++ b/jscomp/others/.depend
@@ -28,3 +28,4 @@ bs_dyn_lib.cmi : bs_dyn.cmi
 js_boolean.cmi :
 js_dict.cmi :
 js_cast.cmi :
+dom.cmi :

--- a/jscomp/others/Makefile
+++ b/jscomp/others/Makefile
@@ -6,7 +6,7 @@ MAP_FILES= node bs
 
 SOURCE_LIST= node_path node_fs node_process dict node_module js_array js_string \
 	js_re js_null_undefined node_buffer js_types js_json js_obj bs_dyn bs_dyn_lib \
-	node_child_process js_boolean js_math js_dict js_date js_global js_cast
+	node_child_process js_boolean js_math js_dict js_date js_global js_cast dom
 
 $(addsuffix .cmj, $(SOURCE_LIST)): $(addsuffix .cmj, $(MAP_FILES))
 

--- a/jscomp/others/dom.mli
+++ b/jscomp/others/dom.mli
@@ -1,0 +1,155 @@
+type _baseClass
+
+type animation (* Web Animations API *)
+
+(* TODO: Should we bother with this indirection?
+(* core *)
+type domString = string
+type domTimestamp = float
+*)
+
+(* css *)
+type cssStyleDeclaration
+type cssStyleSheet
+
+(* events (early) *)
+type 'a eventTarget_like
+type eventTarget = _baseClass eventTarget_like
+
+(* nodes *)
+type 'a _node
+type 'a node_like = 'a _node eventTarget_like
+type node = _baseClass node_like
+type _attr
+type attr = _attr node_like
+type 'a _characterData
+type 'a characterData_like = 'a _characterData node_like
+type characterData = _baseClass characterData_like
+type _cdataSection
+type cdataSection = _cdataSection characterData_like
+type _comment
+type comment = _comment characterData_like
+type 'a _document
+type 'a document_like = 'a _document node_like
+type document = _baseClass document_like
+type _documentFragment
+type documentFragment = _documentFragment node_like
+type _documentType
+type documentType = _documentType node_like
+type domImplementation
+type 'a _element
+type 'a element_like = 'a _element node_like
+type element = _baseClass element_like
+type htmlCollection
+type mutationObserver
+type mutationRecord
+type namedNodeMap
+type nodeList
+type processingInstruction
+type _shadowRoot
+type shadowRoot = _shadowRoot node_like
+type _text
+type text = _text characterData_like
+
+(* geometry *)
+type domRect
+
+(* html *)
+type dataTransfer (* Drag and Drop API *)
+type domStringMap
+type history
+type _htmlDocument
+type htmlDocument = _htmlDocument document_like
+type 'a _htmlElement
+type 'a htmlElement_like = 'a _htmlElement element_like
+type htmlElement = _baseClass htmlElement_like
+type _htmlSlotElement
+type htmlSlotElement = _htmlSlotElement htmlElement_like
+type location
+type window
+type _xmlDocument
+type xmlDocument = _xmlDocument document_like
+
+(* events *)
+type 'a event_like
+type event = _baseClass event_like
+type 'a _uiEvent
+type 'a uiEvent_like = 'a _uiEvent event_like
+type uiEvent = _baseClass uiEvent_like
+type _animationEvent
+type animationEvent = _animationEvent event_like
+type _beforeUnloadEvent
+type beforeUnloadEvent = _beforeUnloadEvent event_like
+type _clipboardEvent
+type clipboardEvent = _clipboardEvent event_like
+type _closeEvent
+type closeEvent = _closeEvent event_like
+type _compositionEvent
+type compositionEvent = _compositionEvent uiEvent_like
+type _customEvent
+type customEvent = _customEvent event_like
+type _dragEvent
+type dragEvent = _dragEvent event_like
+type _errorEvent
+type errorEvent = _errorEvent event_like
+type _focusEvent
+type focusEvent = _focusEvent uiEvent_like
+type _idbVersionChangeEvent
+type idbVersionChangeEvent = _idbVersionChangeEvent event_like
+type _inputEvent
+type inputEvent = _inputEvent uiEvent_like
+type _keyboardEvent
+type keyboardEvent = _keyboardEvent uiEvent_like
+type 'a _mouseEvent
+type 'a mouseEvent_like = 'a _mouseEvent uiEvent_like
+type mouseEvent = _baseClass mouseEvent_like
+type _pageTransitionEvent
+type pageTransitionEvent = _pageTransitionEvent event_like
+type _pointerEvent
+type pointerEvent = _pointerEvent mouseEvent_like
+type _popStateEvent
+type popStateEvent = _popStateEvent event_like
+type _progressEvent
+type progressEvent = _progressEvent event_like
+type _relatedEvent
+type relatedEvent = _relatedEvent event_like
+type _storageEvent
+type storageEvent = _storageEvent event_like
+type _svgZoomEvent
+type svgZoomEvent = _svgZoomEvent event_like
+type _timeEvent
+type timeEvent = _timeEvent event_like
+type _touchEvent
+type touchEvent = _touchEvent uiEvent_like
+type _trackEvent
+type trackEvent = _trackEvent event_like
+type _transitionEvent
+type transitionEvent = _transitionEvent event_like
+type _webGlContextEvent
+type webGlContextEvent = _webGlContextEvent event_like
+type _wheelEvent
+type wheelEvent = _wheelEvent uiEvent_like
+
+(* ranges *)
+type range
+
+(* selection (TODO: move out of dom?) *)
+type selection
+
+(* sets *)
+type domTokenList
+type domSettableTokenList
+
+(* traversal *)
+type nodeFilter = {
+  acceptNode: element -> int (* return type should be NodeFilter.action, but that would create a cycle *)
+}
+type nodeIterator
+type treeWalker
+
+(* SVG *)
+type svgRect
+type svgPoint
+
+(* special *)
+type eventPointerId


### PR DESCRIPTION
The rationale for standardizing this is to ease interop between different implementations, and to be able to deal with these types without having to pull in huge dependencies that otherwise won't be used.

This is very far from complete, but it's a good subset to start with. It's also not settled that this is the best way to do subtyping, but most users will only be concerned with the concrete types (e.g. `element`, not `element_like 'a`) and shouldn't be affected by implementation changes outside of having to recompile.