### PR TITLE
standard colorful error format reporting

### DIFF
--- a/jscomp/Makefile
+++ b/jscomp/Makefile
@@ -216,7 +216,9 @@ EXT_CMXS=$(addprefix ext/, $(addsuffix .cmx, $(EXT_SRCS)))
 EXT_CMOS=$(addprefix ext/, $(addsuffix .cmo, $(EXT_SRCS)))
 COMMON_SRCS= bs_version js_config  ext_log bs_loc  bs_warnings  lam_methname  binary_cache
 COMMON_CMXS= $(addprefix common/, $(addsuffix .cmx, $(COMMON_SRCS)))
-SYNTAX_SRCS= ast_utf8_string\
+SYNTAX_SRCS= \
+	bs_syntaxerr\
+	ast_utf8_string\
 	ast_derive_constructor \
 	ast_derive_util \
 	ast_exp \

--- a/jscomp/all.depend
+++ b/jscomp/all.depend
@@ -163,6 +163,7 @@ common/bs_loc.cmi :
 common/bs_warnings.cmi :
 common/lam_methname.cmi :
 common/binary_cache.cmi : ext/string_map.cmi
+syntax/bs_syntaxerr.cmx :
 syntax/ast_utf8_string.cmx : ext/ext_utf8.cmx ext/ext_char.cmx
 syntax/ast_derive_constructor.cmx :
 syntax/ast_derive_util.cmx :
@@ -179,14 +180,15 @@ syntax/bs_ast_iterator.cmx : syntax/bs_ast_iterator.cmi
 syntax/bs_ast_invariant.cmx : ext/literals.cmx ext/ext_string.cmx \
     common/bs_warnings.cmx syntax/bs_ast_iterator.cmx
 syntax/ast_derive.cmx : ext/string_map.cmx ext/literals.cmx \
-    ext/ext_string.cmx ext/ext_list.cmx syntax/ast_structure.cmx \
-    syntax/ast_signature.cmx syntax/ast_payload.cmx syntax/ast_derive.cmi
+    ext/ext_string.cmx ext/ext_list.cmx syntax/bs_syntaxerr.cmx \
+    syntax/ast_structure.cmx syntax/ast_signature.cmx syntax/ast_payload.cmx \
+    syntax/ast_derive.cmi
 syntax/ast_comb.cmx : ext/ext_list.cmx syntax/ast_literal.cmx \
     syntax/ast_comb.cmi
 syntax/ast_attributes.cmx : ext/ext_string.cmx common/bs_warnings.cmx \
-    syntax/ast_payload.cmx syntax/ast_attributes.cmi
-syntax/ast_core_type.cmx : ext/ext_list.cmx syntax/ast_comb.cmx \
-    syntax/ast_core_type.cmi
+    syntax/bs_syntaxerr.cmx syntax/ast_payload.cmx syntax/ast_attributes.cmi
+syntax/ast_core_type.cmx : ext/ext_list.cmx syntax/bs_syntaxerr.cmx \
+    syntax/ast_comb.cmx syntax/ast_core_type.cmi
 syntax/ast_derive_dyn.cmx : syntax/ast_structure.cmx \
     syntax/ast_derive_util.cmx syntax/ast_derive.cmx \
     syntax/ast_attributes.cmx syntax/ast_derive_dyn.cmi
@@ -197,9 +199,10 @@ syntax/ast_ffi_types.cmx : ext/ext_string.cmx ext/ext_pervasives.cmx \
     common/bs_version.cmx syntax/ast_core_type.cmx syntax/ast_ffi_types.cmi
 syntax/ast_external_attributes.cmx : common/lam_methname.cmx \
     ext/ext_string.cmx ext/ext_pervasives.cmx common/bs_warnings.cmx \
-    common/bs_loc.cmx syntax/ast_payload.cmx syntax/ast_literal.cmx \
-    syntax/ast_ffi_types.cmx syntax/ast_core_type.cmx syntax/ast_comb.cmx \
-    syntax/ast_attributes.cmx syntax/ast_external_attributes.cmi
+    syntax/bs_syntaxerr.cmx common/bs_loc.cmx syntax/ast_payload.cmx \
+    syntax/ast_literal.cmx syntax/ast_ffi_types.cmx syntax/ast_core_type.cmx \
+    syntax/ast_comb.cmx syntax/ast_attributes.cmx \
+    syntax/ast_external_attributes.cmi
 syntax/ast_util.cmx : ext/literals.cmx ext/ext_string.cmx ext/ext_list.cmx \
     syntax/ast_payload.cmx syntax/ast_pat.cmx syntax/ast_literal.cmx \
     syntax/ast_external_attributes.cmx syntax/ast_external.cmx \

--- a/jscomp/bin/bsdep.d
+++ b/jscomp/bin/bsdep.d
@@ -91,6 +91,7 @@ bin/bsdep.ml : stubs/bs_hash_stubs.ml
 bin/bsdep.ml : syntax/ast_external.ml
 bin/bsdep.ml : syntax/ast_literal.mli
 bin/bsdep.ml : syntax/ast_payload.mli
+bin/bsdep.ml : syntax/bs_syntaxerr.ml
 bin/bsdep.ml : common/lam_methname.mli
 bin/bsdep.ml : ext/string_hash_set.mli
 bin/bsdep.ml : syntax/ast_core_type.ml

--- a/jscomp/bin/bsdep.ml
+++ b/jscomp/bin/bsdep.ml
@@ -24570,6 +24570,104 @@ let table_dispatch table (action : action)
     end
 
 end
+module Bs_syntaxerr
+= struct
+#1 "bs_syntaxerr.ml"
+(* Copyright (C) 2015-2016 Bloomberg Finance L.P.
+ * 
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In addition to the permissions granted to you by the LGPL, you may combine
+ * or link a "work that uses the Library" with a publicly distributed version
+ * of this file to produce a combined library or application, then distribute
+ * that combined work under the terms of your choosing, with no requirement
+ * to comply with the obligations normally placed on you by section 4 of the
+ * LGPL version 3 (or the corresponding section of a later version of the LGPL
+ * should you choose to use a later version).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
+
+
+
+type error 
+  = Unsupported_predicates
+  | Conflict_bs_bs_this_bs_meth  
+  | Duplicated_bs_deriving
+  | Conflict_attributes
+
+  | Duplicated_bs_as 
+  | Expect_int_literal
+  | Expect_string_literal
+  | Expect_int_or_string_literal
+  | Unhandled_poly_type
+  | Unregistered of string 
+  | Invalid_underscore_type_in_external
+  | Invalid_bs_string_type 
+  | Invalid_bs_int_type 
+  | Conflict_ffi_attribute
+
+let pp_error fmt err =
+  Format.pp_print_string fmt @@ match err with 
+  | Unsupported_predicates 
+    ->
+     "unsupported predicates"
+  | Conflict_bs_bs_this_bs_meth -> 
+     "[@bs.this], [@bs], [@bs.meth] can not be applied at the same time"
+  | Duplicated_bs_deriving
+    -> "duplicated bs.deriving attribute"
+  | Conflict_attributes
+    -> "conflict attributes " 
+  | Expect_string_literal
+    -> "expect string literal "
+  | Duplicated_bs_as 
+    -> 
+    "duplicated bs.as "
+  | Expect_int_literal 
+    -> 
+    "expect int literal "
+  | Expect_int_or_string_literal
+    ->
+    "expect int or string literal "
+  | Unhandled_poly_type 
+    -> 
+    "Unhandled poly type"
+  | Unregistered str 
+    -> "Unregistered " ^ str 
+  | Invalid_underscore_type_in_external
+    ->
+    "_ is not allowed in combination with external optional type"
+  | Invalid_bs_string_type
+    -> 
+    "Not a valid  type for [@bs.string]"
+  | Invalid_bs_int_type 
+    -> 
+    "Not a valid  type for [@bs.int]"
+  | Conflict_ffi_attribute
+    ->
+    "conflict attributes found" 
+ 
+exception  Error of Location.t * error
+
+let () = 
+  Location.register_error_of_exn (function
+    | Error(loc,err) -> 
+      Some (Location.error_of_printer loc pp_error err)
+    | _ -> None
+    )
+
+let err loc error = raise (Error(loc, error))
+
+end
 module Ext_pervasives : sig 
 #1 "ext_pervasives.mli"
 (* Copyright (C) 2015-2016 Bloomberg Finance L.P.
@@ -26032,6 +26130,33 @@ let prerr_warning loc x =
   if not (!Js_config.no_warn_ffi_type ) then
     print_string_warning loc (to_string x) 
 
+
+type error = 
+  | Unused_attribute of string
+  | Uninterpreted_delimiters of string
+
+exception  Error of Location.t * error
+
+let pp_error fmt x =
+  match x with 
+  | Unused_attribute str ->
+    Format.pp_print_string fmt Literals.unused_attribute;
+    Format.pp_print_string fmt str
+  | Uninterpreted_delimiters str -> 
+    Format.pp_print_string fmt "Uninterpreted delimiters" ;
+    Format.pp_print_string fmt str
+
+
+
+let () = 
+  Location.register_error_of_exn (function 
+    | Error (loc,err) -> 
+      Some (Location.error_of_printer loc pp_error err)
+    | _ -> None
+    )
+
+
+
 let warn_unused_attribute loc txt =
   if !Js_config.no_error_unused_bs_attribute then 
     begin 
@@ -26039,11 +26164,41 @@ let warn_unused_attribute loc txt =
       Format.pp_print_flush warning_formatter ()
     end
   else 
-    Location.raise_errorf 
-      ~loc "%s%s \n" Literals.unused_attribute txt 
+    raise (Error(loc, Unused_attribute txt))
 
 let error_unescaped_delimiter loc txt = 
-  Location.raise_errorf ~loc "Uninterpreted delimiters %s \n" txt 
+  raise (Error(loc, Uninterpreted_delimiters txt))
+
+
+
+
+
+
+(**
+Note the standard way of reporting error in compiler:
+
+val Location.register_error_of_exn : (exn -> Location.error option) -> unit 
+val Location.error_of_printer : Location.t ->
+  (Format.formatter -> error -> unit) -> error -> Location.error
+
+Define an error type
+
+type error 
+exception Error of Location.t * error 
+
+Provide a printer to error
+
+{[
+  let () = 
+    Location.register_error_of_exn
+      (function 
+        | Error(loc,err) -> 
+          Some (Location.error_of_printer loc pp_error err)
+        | _ -> None
+      )
+]}
+*)
+
 end
 module Ast_attributes : sig 
 #1 "ast_attributes.mli"
@@ -26177,7 +26332,7 @@ let process_method_attributes_rev (attrs : t) =
                | Some e -> 
                  Ast_payload.assert_bool_lit e)
 
-            else Location.raise_errorf ~loc "unsupported predicates"
+            else Bs_syntaxerr.err loc Unsupported_predicates
           ) (false, false) (Ast_payload.as_config_record_and_process loc payload)  in 
 
         ({st with get = Some result}, acc  )
@@ -26194,7 +26349,7 @@ let process_method_attributes_rev (attrs : t) =
                 if Ast_payload.assert_bool_lit e then 
                   `No_get
                 else `Get
-            else Location.raise_errorf ~loc "unsupported predicates"
+            else Bs_syntaxerr.err loc Unsupported_predicates
           ) `Get (Ast_payload.as_config_record_and_process loc payload)  in 
         (* properties -- void 
               [@@bs.set{only}]
@@ -26217,9 +26372,7 @@ let process_attributes_rev (attrs : t) =
         -> `Method, acc
       | "bs", _
       | "bs.this", _
-        -> Location.raise_errorf 
-             ~loc
-             "[@bs.this], [@bs], [@bs.meth] can not be applied at the same time"
+        -> Bs_syntaxerr.err loc Conflict_bs_bs_this_bs_meth
       | _ , _ -> 
         st, attr::acc 
     ) ( `Nothing, []) attrs
@@ -26258,7 +26411,8 @@ let process_derive_type attrs =
              (Ast_payload.as_config_record_and_process loc payload)}, acc 
       | {bs_deriving = `Has_deriving _}, "bs.deriving"
         -> 
-        Location.raise_errorf ~loc "duplicated bs.deriving attribute"
+        Bs_syntaxerr.err loc Duplicated_bs_deriving
+
       | _ , _ ->
         let st = 
           if txt = "nonrec" then 
@@ -26291,7 +26445,7 @@ let process_bs_string_int_uncurry attrs =
       | "bs.string", _
       | "bs.ignore", _
         -> 
-        Location.raise_errorf ~loc "conflict attributes "
+        Bs_syntaxerr.err loc Conflict_attributes
       | _ , _ -> st, (attr :: attrs )
     ) (`Nothing, []) attrs
 
@@ -26304,12 +26458,12 @@ let process_bs_string_as  attrs =
         ->
         begin match Ast_payload.is_single_string payload with 
           | None -> 
-            Location.raise_errorf ~loc "expect string literal "
+            Bs_syntaxerr.err loc Expect_string_literal
           | Some  _ as v->  (v, attrs)  
         end
       | "bs.as",  _ 
         -> 
-          Location.raise_errorf ~loc "duplicated bs.as "
+          Bs_syntaxerr.err loc Duplicated_bs_as 
       | _ , _ -> (st, attr::attrs) 
     ) (None, []) attrs
 
@@ -26322,12 +26476,12 @@ let process_bs_int_as  attrs =
         ->
         begin match Ast_payload.is_single_int payload with 
           | None -> 
-            Location.raise_errorf ~loc "expect int literal "
+            Bs_syntaxerr.err loc Expect_int_literal
           | Some  _ as v->  (v, attrs)  
         end
       | "bs.as",  _ 
         -> 
-          Location.raise_errorf ~loc "duplicated bs.as "
+        Bs_syntaxerr.err loc Duplicated_bs_as
       | _ , _ -> (st, attr::attrs) 
     ) (None, []) attrs
 
@@ -26342,14 +26496,14 @@ let process_bs_string_or_int_as attrs =
           | None -> 
             begin match Ast_payload.is_single_string payload with 
             | None -> 
-              Location.raise_errorf ~loc "expect int or string literal "
+              Bs_syntaxerr.err loc Expect_int_or_string_literal
             | Some s -> (Some (`Str s), attrs)
             end
           | Some   v->  (Some (`Int v), attrs)  
         end
       | "bs.as",  _ 
         -> 
-          Location.raise_errorf ~loc "duplicated bs.as "
+        Bs_syntaxerr.err loc Duplicated_bs_as
       | _ , _ -> (st, attr::attrs) 
     ) (None, []) attrs
 
@@ -26367,6 +26521,7 @@ let warn_unused_attributes attrs =
     List.iter (fun (({txt; loc}, _) : Parsetree.attribute) -> 
         Bs_warnings.warn_unused_attribute loc txt 
       ) attrs
+
 end
 module Ast_literal : sig 
 #1 "ast_literal.mli"
@@ -27545,7 +27700,7 @@ let list_of_arrow (ty : t) =
     | Ptyp_arrow(label,t1,t2) -> 
       aux t2 ((label,t1,ty.ptyp_attributes,ty.ptyp_loc) ::acc)
     | Ptyp_poly(_, ty) -> (* should not happen? *)
-      Location.raise_errorf ~loc:ty.ptyp_loc "Unhandled poly type"
+      Bs_syntaxerr.err ty.ptyp_loc Unhandled_poly_type
     | return_type -> ty, List.rev acc
   in aux ty []
 
@@ -27813,7 +27968,9 @@ let dispatch_extension ({Asttypes.txt ; loc}) typ =
   let txt = Ext_string.tail_from txt (String.length Literals.bs_deriving_dot) in 
     match (Ast_payload.table_dispatch !derive_table 
             ({txt ; loc}, None)).expression_gen with 
-    | None -> Location.raise_errorf ~loc "%s is not registered" txt 
+    | None ->
+      Bs_syntaxerr.err loc (Unregistered txt)
+
     | Some f -> f typ
 
 end
@@ -29427,25 +29584,6 @@ let translate ?loc name =
   else if i = 0 then name 
   else  String.sub name 0 i 
 
-(*
-let translate ?loc name =
-  let i = Ext_string.rfind ~sub:"_" name  in
-  if name.[0] = '_' then
-    if i <= 0 then
-      let len = (String.length name - 1) in
-      if len = 0 then
-        Location.raise_errorf ?loc "invalid label %s" name
-      else String.sub name 1 len
-    else
-      let len = (i - 1) in
-      if len = 0 then
-        Location.raise_errorf ?loc "invalid label %s" name 
-      else
-        String.sub name 1 len
-  else if i > 0 then
-    String.sub name 0 i
-  else name
-*)
 
 end
 module Ast_external_attributes : sig 
@@ -29544,10 +29682,11 @@ let get_arg_type ~nolabel optional
   let ptyp = if optional then Ast_core_type.extract_option_type_exn ptyp else ptyp in 
   if Ast_core_type.is_any ptyp then (* (_[@bs.as ])*)
     if optional then 
-      Location.raise_errorf ~loc:ptyp.ptyp_loc "_ is not allowed in combination with external optional type"
+      Bs_syntaxerr.err ptyp.ptyp_loc Invalid_underscore_type_in_external
     else begin match Ast_attributes.process_bs_string_or_int_as ptyp.Parsetree.ptyp_attributes with 
       |  None, _ -> 
-        Location.raise_errorf ~loc:ptyp.ptyp_loc "_ is not allowed in external type unless in (_[@bs.as])"
+        Bs_syntaxerr.err ptyp.ptyp_loc Invalid_underscore_type_in_external
+
       | Some (`Int i), others -> 
         Ast_attributes.warn_unused_attributes others;
         Arg_int_lit i, Ast_literal.type_int ~loc:ptyp.ptyp_loc ()  
@@ -29584,17 +29723,18 @@ let get_arg_type ~nolabel optional
                    `NonNull, ((Ext_pervasives.hash_variant label, label) :: acc),
                    (tag :: row_fields)
                end
-             | _ -> Location.raise_errorf ~loc:ptyp.ptyp_loc "Not a valid string type"
+             | _ -> Bs_syntaxerr.err ptyp.ptyp_loc Invalid_bs_string_type
+
            ) row_fields (`Nothing, [], [])) in 
       (match case with 
-       | `Nothing -> Location.raise_errorf ~loc:ptyp.ptyp_loc "Not a valid string type"
+       | `Nothing -> Bs_syntaxerr.err ptyp.ptyp_loc Invalid_bs_string_type
        | `Null -> NullString result 
        | `NonNull -> NonNullString result) , 
       {ptyp with ptyp_desc = Ptyp_variant(row_fields, Closed, None);
                  ptyp_attributes ;
       }
-    | (`String, _),  _ -> Location.raise_errorf ~loc:ptyp.ptyp_loc "Not a valid string type"
-
+    | (`String, _),  _ ->
+      Bs_syntaxerr.err ptyp.ptyp_loc Invalid_bs_string_type
     | (`Ignore, ptyp_attributes), _  -> 
       (Ignore, {ptyp with ptyp_attributes})
     | (`Int , ptyp_attributes),  Ptyp_variant ( row_fields, Closed, None) -> 
@@ -29612,7 +29752,9 @@ let get_arg_type ~nolabel optional
                     i + 1 , ((Ext_pervasives.hash_variant label , i):: acc ), rtag::row_fields
                 end
 
-              | _ -> Location.raise_errorf ~loc:ptyp.ptyp_loc "Not a valid string type"
+              | _ -> 
+                Bs_syntaxerr.err ptyp.ptyp_loc Invalid_bs_int_type
+
            ) (0, [],[]) row_fields) in 
       Int (List.rev acc),
       {ptyp with 
@@ -29620,7 +29762,7 @@ let get_arg_type ~nolabel optional
        ptyp_attributes
       }
 
-    | (`Int, _), _ -> Location.raise_errorf ~loc:ptyp.ptyp_loc "Not a valid string type"
+    | (`Int, _), _ -> Bs_syntaxerr.err ptyp.ptyp_loc Invalid_bs_int_type
     | (`Uncurry opt_arity, ptyp_attributes), ptyp_desc -> 
       let real_arity =  Ast_core_type.get_uncurry_arity ptyp in 
       (begin match opt_arity, real_arity with 
@@ -30127,7 +30269,8 @@ let handle_attributes
 
       | {set_index = true; _}
         ->
-        Location.raise_errorf ~loc "conflict attributes found"        
+        Bs_syntaxerr.err loc Conflict_ffi_attribute
+
 
       | {get_index = true;
 
@@ -30153,7 +30296,10 @@ let handle_attributes
         else Location.raise_errorf ~loc "Ill defined attribute [@@bs.get_index] (arity of 2)"
 
       | {get_index = true; _}
-        -> Location.raise_errorf ~loc "conflict attributes found"        
+
+        -> 
+        Bs_syntaxerr.err loc Conflict_ffi_attribute
+
 
 
 
@@ -30178,7 +30324,8 @@ let handle_attributes
           | [], `Nm_na,  _ -> Js_module_as_var external_module_name
           | _, `Nm_na, _ -> Js_module_as_fn {splice; external_module_name }
           | _, #bundle_source, #bundle_source ->
-            Location.raise_errorf ~loc "conflict attributes found"
+            Bs_syntaxerr.err loc Conflict_ffi_attribute
+
           | _, (`Nm_val _ | `Nm_external _) , `Nm_na
             -> Js_module_as_class external_module_name
           | _, `Nm_payload _ , `Nm_na
@@ -30188,7 +30335,9 @@ let handle_attributes
 
         end
       | {module_as_val = Some _; _}
-        -> Location.raise_errorf ~loc "conflict attributes found" 
+        -> 
+        Bs_syntaxerr.err loc Conflict_ffi_attribute
+
       | {call_name = (`Nm_val name | `Nm_external name | `Nm_payload name) ;
          splice; 
          external_module_name;
@@ -30208,7 +30357,9 @@ let handle_attributes
         } -> 
         Js_call {splice; name; external_module_name}
       | {call_name = #bundle_source ; _ } 
-        -> Location.raise_errorf ~loc "conflict attributes found"
+        ->
+        Bs_syntaxerr.err loc Conflict_ffi_attribute
+
 
       | {val_name = (`Nm_val name | `Nm_external name | `Nm_payload name);
          external_module_name;
@@ -30229,7 +30380,9 @@ let handle_attributes
         -> 
         Js_global { name; external_module_name}
       | {val_name = #bundle_source ; _ }
-        -> Location.raise_errorf ~loc "conflict attributes found"
+        ->
+        Bs_syntaxerr.err loc Conflict_ffi_attribute
+
       | {splice ;
          external_module_name = (Some _ as external_module_name);
 
@@ -30315,7 +30468,9 @@ let handle_attributes
         } 
         -> Js_new {name; external_module_name; splice}
       | {new_name = #bundle_source ; _ }
-        -> Location.raise_errorf ~loc "conflict attributes found"
+        -> 
+        Bs_syntaxerr.err loc Conflict_ffi_attribute
+
 
       | {set_name = (`Nm_val name | `Nm_external name | `Nm_payload name);
 

--- a/jscomp/bin/bsppx.d
+++ b/jscomp/bin/bsppx.d
@@ -75,6 +75,7 @@ bin/bsppx.ml : stubs/bs_hash_stubs.ml
 bin/bsppx.ml : syntax/ast_external.ml
 bin/bsppx.ml : syntax/ast_literal.mli
 bin/bsppx.ml : syntax/ast_payload.mli
+bin/bsppx.ml : syntax/bs_syntaxerr.ml
 bin/bsppx.ml : common/lam_methname.mli
 bin/bsppx.ml : ext/string_hash_set.mli
 bin/bsppx.ml : syntax/ast_core_type.ml

--- a/jscomp/bin/whole_compiler.d
+++ b/jscomp/bin/whole_compiler.d
@@ -296,6 +296,7 @@ bin/whole_compiler.ml : stubs/bs_hash_stubs.ml
 bin/whole_compiler.ml : syntax/ast_external.ml
 bin/whole_compiler.ml : syntax/ast_literal.mli
 bin/whole_compiler.ml : syntax/ast_payload.mli
+bin/whole_compiler.ml : syntax/bs_syntaxerr.ml
 bin/whole_compiler.ml : ../ocaml/bytecomp/printlambda.ml
 bin/whole_compiler.ml : ../ocaml/bytecomp/translclass.ml
 bin/whole_compiler.ml : ../ocaml/bytecomp/translcore.mli

--- a/jscomp/bin/whole_compiler.ml
+++ b/jscomp/bin/whole_compiler.ml
@@ -26303,6 +26303,33 @@ let prerr_warning loc x =
   if not (!Js_config.no_warn_ffi_type ) then
     print_string_warning loc (to_string x) 
 
+
+type error = 
+  | Unused_attribute of string
+  | Uninterpreted_delimiters of string
+
+exception  Error of Location.t * error
+
+let pp_error fmt x =
+  match x with 
+  | Unused_attribute str ->
+    Format.pp_print_string fmt Literals.unused_attribute;
+    Format.pp_print_string fmt str
+  | Uninterpreted_delimiters str -> 
+    Format.pp_print_string fmt "Uninterpreted delimiters" ;
+    Format.pp_print_string fmt str
+
+
+
+let () = 
+  Location.register_error_of_exn (function 
+    | Error (loc,err) -> 
+      Some (Location.error_of_printer loc pp_error err)
+    | _ -> None
+    )
+
+
+
 let warn_unused_attribute loc txt =
   if !Js_config.no_error_unused_bs_attribute then 
     begin 
@@ -26310,11 +26337,41 @@ let warn_unused_attribute loc txt =
       Format.pp_print_flush warning_formatter ()
     end
   else 
-    Location.raise_errorf 
-      ~loc "%s%s \n" Literals.unused_attribute txt 
+    raise (Error(loc, Unused_attribute txt))
 
 let error_unescaped_delimiter loc txt = 
-  Location.raise_errorf ~loc "Uninterpreted delimiters %s \n" txt 
+  raise (Error(loc, Uninterpreted_delimiters txt))
+
+
+
+
+
+
+(**
+Note the standard way of reporting error in compiler:
+
+val Location.register_error_of_exn : (exn -> Location.error option) -> unit 
+val Location.error_of_printer : Location.t ->
+  (Format.formatter -> error -> unit) -> error -> Location.error
+
+Define an error type
+
+type error 
+exception Error of Location.t * error 
+
+Provide a printer to error
+
+{[
+  let () = 
+    Location.register_error_of_exn
+      (function 
+        | Error(loc,err) -> 
+          Some (Location.error_of_printer loc pp_error err)
+        | _ -> None
+      )
+]}
+*)
+
 end
 module Bs_ast_invariant
 = struct
@@ -57976,6 +58033,104 @@ let to_undefined_type loc x =
 
 
 end
+module Bs_syntaxerr
+= struct
+#1 "bs_syntaxerr.ml"
+(* Copyright (C) 2015-2016 Bloomberg Finance L.P.
+ * 
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In addition to the permissions granted to you by the LGPL, you may combine
+ * or link a "work that uses the Library" with a publicly distributed version
+ * of this file to produce a combined library or application, then distribute
+ * that combined work under the terms of your choosing, with no requirement
+ * to comply with the obligations normally placed on you by section 4 of the
+ * LGPL version 3 (or the corresponding section of a later version of the LGPL
+ * should you choose to use a later version).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
+
+
+
+type error 
+  = Unsupported_predicates
+  | Conflict_bs_bs_this_bs_meth  
+  | Duplicated_bs_deriving
+  | Conflict_attributes
+
+  | Duplicated_bs_as 
+  | Expect_int_literal
+  | Expect_string_literal
+  | Expect_int_or_string_literal
+  | Unhandled_poly_type
+  | Unregistered of string 
+  | Invalid_underscore_type_in_external
+  | Invalid_bs_string_type 
+  | Invalid_bs_int_type 
+  | Conflict_ffi_attribute
+
+let pp_error fmt err =
+  Format.pp_print_string fmt @@ match err with 
+  | Unsupported_predicates 
+    ->
+     "unsupported predicates"
+  | Conflict_bs_bs_this_bs_meth -> 
+     "[@bs.this], [@bs], [@bs.meth] can not be applied at the same time"
+  | Duplicated_bs_deriving
+    -> "duplicated bs.deriving attribute"
+  | Conflict_attributes
+    -> "conflict attributes " 
+  | Expect_string_literal
+    -> "expect string literal "
+  | Duplicated_bs_as 
+    -> 
+    "duplicated bs.as "
+  | Expect_int_literal 
+    -> 
+    "expect int literal "
+  | Expect_int_or_string_literal
+    ->
+    "expect int or string literal "
+  | Unhandled_poly_type 
+    -> 
+    "Unhandled poly type"
+  | Unregistered str 
+    -> "Unregistered " ^ str 
+  | Invalid_underscore_type_in_external
+    ->
+    "_ is not allowed in combination with external optional type"
+  | Invalid_bs_string_type
+    -> 
+    "Not a valid  type for [@bs.string]"
+  | Invalid_bs_int_type 
+    -> 
+    "Not a valid  type for [@bs.int]"
+  | Conflict_ffi_attribute
+    ->
+    "conflict attributes found" 
+ 
+exception  Error of Location.t * error
+
+let () = 
+  Location.register_error_of_exn (function
+    | Error(loc,err) -> 
+      Some (Location.error_of_printer loc pp_error err)
+    | _ -> None
+    )
+
+let err loc error = raise (Error(loc, error))
+
+end
 module Ast_core_type : sig 
 #1 "ast_core_type.mli"
 (* Copyright (C) 2015-2016 Bloomberg Finance L.P.
@@ -58260,7 +58415,7 @@ let list_of_arrow (ty : t) =
     | Ptyp_arrow(label,t1,t2) -> 
       aux t2 ((label,t1,ty.ptyp_attributes,ty.ptyp_loc) ::acc)
     | Ptyp_poly(_, ty) -> (* should not happen? *)
-      Location.raise_errorf ~loc:ty.ptyp_loc "Unhandled poly type"
+      Bs_syntaxerr.err ty.ptyp_loc Unhandled_poly_type
     | return_type -> ty, List.rev acc
   in aux ty []
 
@@ -66767,7 +66922,8 @@ let convert exports lam : _ * _  =
         | "#fn_mk" -> Pjs_fn_make (int_of_string p.prim_native_name)
         | "#fn_method" -> Pjs_fn_method (int_of_string p.prim_native_name)
         | "#unsafe_downgrade" -> Pjs_unsafe_downgrade (Ext_string.empty,loc)
-        | _ -> Location.raise_errorf ~loc "internal error, using unrecorgnized primitive %s" s 
+        | _ -> Location.raise_errorf ~loc
+                 "@{<error>Error:@} internal error, using unrecorgnized primitive %s" s 
       in
       prim ~primitive ~args loc 
   and aux_constant ( const : Lambda.structured_constant) : constant = 
@@ -90648,7 +90804,7 @@ let assemble_args_splice call_loc ffi  js_splice arg_types args : E.t list * E.t
                 ls @ accs, eff 
               | _ -> 
                 Location.raise_errorf ~loc:call_loc
-                  {|function call with %s  is a primitive with [@@bs.splice], it expects its `bs.splice` argument to be a syntactic array in the call site and  all arguments to be supplied|}
+                  {|@{<error>Error:@} function call with %s  is a primitive with [@@bs.splice], it expects its `bs.splice` argument to be a syntactic array in the call site and  all arguments to be supplied|}
                   (Ast_ffi_types.name_of_ffi ffi)
             end
           | _ -> assert false 
@@ -93503,25 +93659,6 @@ let translate ?loc name =
   else if i = 0 then name 
   else  String.sub name 0 i 
 
-(*
-let translate ?loc name =
-  let i = Ext_string.rfind ~sub:"_" name  in
-  if name.[0] = '_' then
-    if i <= 0 then
-      let len = (String.length name - 1) in
-      if len = 0 then
-        Location.raise_errorf ?loc "invalid label %s" name
-      else String.sub name 1 len
-    else
-      let len = (i - 1) in
-      if len = 0 then
-        Location.raise_errorf ?loc "invalid label %s" name 
-      else
-        String.sub name 1 len
-  else if i > 0 then
-    String.sub name 0 i
-  else name
-*)
 
 end
 module Lam_compile : sig 
@@ -99840,7 +99977,7 @@ let process_method_attributes_rev (attrs : t) =
                | Some e -> 
                  Ast_payload.assert_bool_lit e)
 
-            else Location.raise_errorf ~loc "unsupported predicates"
+            else Bs_syntaxerr.err loc Unsupported_predicates
           ) (false, false) (Ast_payload.as_config_record_and_process loc payload)  in 
 
         ({st with get = Some result}, acc  )
@@ -99857,7 +99994,7 @@ let process_method_attributes_rev (attrs : t) =
                 if Ast_payload.assert_bool_lit e then 
                   `No_get
                 else `Get
-            else Location.raise_errorf ~loc "unsupported predicates"
+            else Bs_syntaxerr.err loc Unsupported_predicates
           ) `Get (Ast_payload.as_config_record_and_process loc payload)  in 
         (* properties -- void 
               [@@bs.set{only}]
@@ -99880,9 +100017,7 @@ let process_attributes_rev (attrs : t) =
         -> `Method, acc
       | "bs", _
       | "bs.this", _
-        -> Location.raise_errorf 
-             ~loc
-             "[@bs.this], [@bs], [@bs.meth] can not be applied at the same time"
+        -> Bs_syntaxerr.err loc Conflict_bs_bs_this_bs_meth
       | _ , _ -> 
         st, attr::acc 
     ) ( `Nothing, []) attrs
@@ -99921,7 +100056,8 @@ let process_derive_type attrs =
              (Ast_payload.as_config_record_and_process loc payload)}, acc 
       | {bs_deriving = `Has_deriving _}, "bs.deriving"
         -> 
-        Location.raise_errorf ~loc "duplicated bs.deriving attribute"
+        Bs_syntaxerr.err loc Duplicated_bs_deriving
+
       | _ , _ ->
         let st = 
           if txt = "nonrec" then 
@@ -99954,7 +100090,7 @@ let process_bs_string_int_uncurry attrs =
       | "bs.string", _
       | "bs.ignore", _
         -> 
-        Location.raise_errorf ~loc "conflict attributes "
+        Bs_syntaxerr.err loc Conflict_attributes
       | _ , _ -> st, (attr :: attrs )
     ) (`Nothing, []) attrs
 
@@ -99967,12 +100103,12 @@ let process_bs_string_as  attrs =
         ->
         begin match Ast_payload.is_single_string payload with 
           | None -> 
-            Location.raise_errorf ~loc "expect string literal "
+            Bs_syntaxerr.err loc Expect_string_literal
           | Some  _ as v->  (v, attrs)  
         end
       | "bs.as",  _ 
         -> 
-          Location.raise_errorf ~loc "duplicated bs.as "
+          Bs_syntaxerr.err loc Duplicated_bs_as 
       | _ , _ -> (st, attr::attrs) 
     ) (None, []) attrs
 
@@ -99985,12 +100121,12 @@ let process_bs_int_as  attrs =
         ->
         begin match Ast_payload.is_single_int payload with 
           | None -> 
-            Location.raise_errorf ~loc "expect int literal "
+            Bs_syntaxerr.err loc Expect_int_literal
           | Some  _ as v->  (v, attrs)  
         end
       | "bs.as",  _ 
         -> 
-          Location.raise_errorf ~loc "duplicated bs.as "
+        Bs_syntaxerr.err loc Duplicated_bs_as
       | _ , _ -> (st, attr::attrs) 
     ) (None, []) attrs
 
@@ -100005,14 +100141,14 @@ let process_bs_string_or_int_as attrs =
           | None -> 
             begin match Ast_payload.is_single_string payload with 
             | None -> 
-              Location.raise_errorf ~loc "expect int or string literal "
+              Bs_syntaxerr.err loc Expect_int_or_string_literal
             | Some s -> (Some (`Str s), attrs)
             end
           | Some   v->  (Some (`Int v), attrs)  
         end
       | "bs.as",  _ 
         -> 
-          Location.raise_errorf ~loc "duplicated bs.as "
+        Bs_syntaxerr.err loc Duplicated_bs_as
       | _ , _ -> (st, attr::attrs) 
     ) (None, []) attrs
 
@@ -100030,6 +100166,7 @@ let warn_unused_attributes attrs =
     List.iter (fun (({txt; loc}, _) : Parsetree.attribute) -> 
         Bs_warnings.warn_unused_attribute loc txt 
       ) attrs
+
 end
 module Ast_signature : sig 
 #1 "ast_signature.mli"
@@ -100294,7 +100431,9 @@ let dispatch_extension ({Asttypes.txt ; loc}) typ =
   let txt = Ext_string.tail_from txt (String.length Literals.bs_deriving_dot) in 
     match (Ast_payload.table_dispatch !derive_table 
             ({txt ; loc}, None)).expression_gen with 
-    | None -> Location.raise_errorf ~loc "%s is not registered" txt 
+    | None ->
+      Bs_syntaxerr.err loc (Unregistered txt)
+
     | Some f -> f typ
 
 end
@@ -101046,10 +101185,11 @@ let get_arg_type ~nolabel optional
   let ptyp = if optional then Ast_core_type.extract_option_type_exn ptyp else ptyp in 
   if Ast_core_type.is_any ptyp then (* (_[@bs.as ])*)
     if optional then 
-      Location.raise_errorf ~loc:ptyp.ptyp_loc "_ is not allowed in combination with external optional type"
+      Bs_syntaxerr.err ptyp.ptyp_loc Invalid_underscore_type_in_external
     else begin match Ast_attributes.process_bs_string_or_int_as ptyp.Parsetree.ptyp_attributes with 
       |  None, _ -> 
-        Location.raise_errorf ~loc:ptyp.ptyp_loc "_ is not allowed in external type unless in (_[@bs.as])"
+        Bs_syntaxerr.err ptyp.ptyp_loc Invalid_underscore_type_in_external
+
       | Some (`Int i), others -> 
         Ast_attributes.warn_unused_attributes others;
         Arg_int_lit i, Ast_literal.type_int ~loc:ptyp.ptyp_loc ()  
@@ -101086,17 +101226,18 @@ let get_arg_type ~nolabel optional
                    `NonNull, ((Ext_pervasives.hash_variant label, label) :: acc),
                    (tag :: row_fields)
                end
-             | _ -> Location.raise_errorf ~loc:ptyp.ptyp_loc "Not a valid string type"
+             | _ -> Bs_syntaxerr.err ptyp.ptyp_loc Invalid_bs_string_type
+
            ) row_fields (`Nothing, [], [])) in 
       (match case with 
-       | `Nothing -> Location.raise_errorf ~loc:ptyp.ptyp_loc "Not a valid string type"
+       | `Nothing -> Bs_syntaxerr.err ptyp.ptyp_loc Invalid_bs_string_type
        | `Null -> NullString result 
        | `NonNull -> NonNullString result) , 
       {ptyp with ptyp_desc = Ptyp_variant(row_fields, Closed, None);
                  ptyp_attributes ;
       }
-    | (`String, _),  _ -> Location.raise_errorf ~loc:ptyp.ptyp_loc "Not a valid string type"
-
+    | (`String, _),  _ ->
+      Bs_syntaxerr.err ptyp.ptyp_loc Invalid_bs_string_type
     | (`Ignore, ptyp_attributes), _  -> 
       (Ignore, {ptyp with ptyp_attributes})
     | (`Int , ptyp_attributes),  Ptyp_variant ( row_fields, Closed, None) -> 
@@ -101114,7 +101255,9 @@ let get_arg_type ~nolabel optional
                     i + 1 , ((Ext_pervasives.hash_variant label , i):: acc ), rtag::row_fields
                 end
 
-              | _ -> Location.raise_errorf ~loc:ptyp.ptyp_loc "Not a valid string type"
+              | _ -> 
+                Bs_syntaxerr.err ptyp.ptyp_loc Invalid_bs_int_type
+
            ) (0, [],[]) row_fields) in 
       Int (List.rev acc),
       {ptyp with 
@@ -101122,7 +101265,7 @@ let get_arg_type ~nolabel optional
        ptyp_attributes
       }
 
-    | (`Int, _), _ -> Location.raise_errorf ~loc:ptyp.ptyp_loc "Not a valid string type"
+    | (`Int, _), _ -> Bs_syntaxerr.err ptyp.ptyp_loc Invalid_bs_int_type
     | (`Uncurry opt_arity, ptyp_attributes), ptyp_desc -> 
       let real_arity =  Ast_core_type.get_uncurry_arity ptyp in 
       (begin match opt_arity, real_arity with 
@@ -101629,7 +101772,8 @@ let handle_attributes
 
       | {set_index = true; _}
         ->
-        Location.raise_errorf ~loc "conflict attributes found"        
+        Bs_syntaxerr.err loc Conflict_ffi_attribute
+
 
       | {get_index = true;
 
@@ -101655,7 +101799,10 @@ let handle_attributes
         else Location.raise_errorf ~loc "Ill defined attribute [@@bs.get_index] (arity of 2)"
 
       | {get_index = true; _}
-        -> Location.raise_errorf ~loc "conflict attributes found"        
+
+        -> 
+        Bs_syntaxerr.err loc Conflict_ffi_attribute
+
 
 
 
@@ -101680,7 +101827,8 @@ let handle_attributes
           | [], `Nm_na,  _ -> Js_module_as_var external_module_name
           | _, `Nm_na, _ -> Js_module_as_fn {splice; external_module_name }
           | _, #bundle_source, #bundle_source ->
-            Location.raise_errorf ~loc "conflict attributes found"
+            Bs_syntaxerr.err loc Conflict_ffi_attribute
+
           | _, (`Nm_val _ | `Nm_external _) , `Nm_na
             -> Js_module_as_class external_module_name
           | _, `Nm_payload _ , `Nm_na
@@ -101690,7 +101838,9 @@ let handle_attributes
 
         end
       | {module_as_val = Some _; _}
-        -> Location.raise_errorf ~loc "conflict attributes found" 
+        -> 
+        Bs_syntaxerr.err loc Conflict_ffi_attribute
+
       | {call_name = (`Nm_val name | `Nm_external name | `Nm_payload name) ;
          splice; 
          external_module_name;
@@ -101710,7 +101860,9 @@ let handle_attributes
         } -> 
         Js_call {splice; name; external_module_name}
       | {call_name = #bundle_source ; _ } 
-        -> Location.raise_errorf ~loc "conflict attributes found"
+        ->
+        Bs_syntaxerr.err loc Conflict_ffi_attribute
+
 
       | {val_name = (`Nm_val name | `Nm_external name | `Nm_payload name);
          external_module_name;
@@ -101731,7 +101883,9 @@ let handle_attributes
         -> 
         Js_global { name; external_module_name}
       | {val_name = #bundle_source ; _ }
-        -> Location.raise_errorf ~loc "conflict attributes found"
+        ->
+        Bs_syntaxerr.err loc Conflict_ffi_attribute
+
       | {splice ;
          external_module_name = (Some _ as external_module_name);
 
@@ -101817,7 +101971,9 @@ let handle_attributes
         } 
         -> Js_new {name; external_module_name; splice}
       | {new_name = #bundle_source ; _ }
-        -> Location.raise_errorf ~loc "conflict attributes found"
+        -> 
+        Bs_syntaxerr.err loc Conflict_ffi_attribute
+
 
       | {set_name = (`Nm_val name | `Nm_external name | `Nm_payload name);
 

--- a/jscomp/common/lam_methname.ml
+++ b/jscomp/common/lam_methname.ml
@@ -149,22 +149,3 @@ let translate ?loc name =
   else if i = 0 then name 
   else  String.sub name 0 i 
 
-(*
-let translate ?loc name =
-  let i = Ext_string.rfind ~sub:"_" name  in
-  if name.[0] = '_' then
-    if i <= 0 then
-      let len = (String.length name - 1) in
-      if len = 0 then
-        Location.raise_errorf ?loc "invalid label %s" name
-      else String.sub name 1 len
-    else
-      let len = (i - 1) in
-      if len = 0 then
-        Location.raise_errorf ?loc "invalid label %s" name 
-      else
-        String.sub name 1 len
-  else if i > 0 then
-    String.sub name 0 i
-  else name
-*)

--- a/jscomp/core/lam.ml
+++ b/jscomp/core/lam.ml
@@ -1555,7 +1555,8 @@ let convert exports lam : _ * _  =
         | "#fn_mk" -> Pjs_fn_make (int_of_string p.prim_native_name)
         | "#fn_method" -> Pjs_fn_method (int_of_string p.prim_native_name)
         | "#unsafe_downgrade" -> Pjs_unsafe_downgrade (Ext_string.empty,loc)
-        | _ -> Location.raise_errorf ~loc "internal error, using unrecorgnized primitive %s" s 
+        | _ -> Location.raise_errorf ~loc
+                 "@{<error>Error:@} internal error, using unrecorgnized primitive %s" s 
       in
       prim ~primitive ~args loc 
   and aux_constant ( const : Lambda.structured_constant) : constant = 

--- a/jscomp/core/lam_compile_external_call.ml
+++ b/jscomp/core/lam_compile_external_call.ml
@@ -154,7 +154,7 @@ let assemble_args_splice call_loc ffi  js_splice arg_types args : E.t list * E.t
                 ls @ accs, eff 
               | _ -> 
                 Location.raise_errorf ~loc:call_loc
-                  {|function call with %s  is a primitive with [@@bs.splice], it expects its `bs.splice` argument to be a syntactic array in the call site and  all arguments to be supplied|}
+                  {|@{<error>Error:@} function call with %s  is a primitive with [@@bs.splice], it expects its `bs.splice` argument to be a syntactic array in the call site and  all arguments to be supplied|}
                   (Ast_ffi_types.name_of_ffi ffi)
             end
           | _ -> assert false 

--- a/jscomp/install-bsc.sh
+++ b/jscomp/install-bsc.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+# dev small utils
+# hot replace global bsb.exe for quick testing
+cp bin/bsc.exe /usr/local/lib/node_modules/bs-platform/bin/

--- a/jscomp/syntax/ast_attributes.ml
+++ b/jscomp/syntax/ast_attributes.ml
@@ -54,7 +54,7 @@ let process_method_attributes_rev (attrs : t) =
                | Some e -> 
                  Ast_payload.assert_bool_lit e)
 
-            else Location.raise_errorf ~loc "unsupported predicates"
+            else Bs_syntaxerr.err loc Unsupported_predicates
           ) (false, false) (Ast_payload.as_config_record_and_process loc payload)  in 
 
         ({st with get = Some result}, acc  )
@@ -71,7 +71,7 @@ let process_method_attributes_rev (attrs : t) =
                 if Ast_payload.assert_bool_lit e then 
                   `No_get
                 else `Get
-            else Location.raise_errorf ~loc "unsupported predicates"
+            else Bs_syntaxerr.err loc Unsupported_predicates
           ) `Get (Ast_payload.as_config_record_and_process loc payload)  in 
         (* properties -- void 
               [@@bs.set{only}]
@@ -94,9 +94,7 @@ let process_attributes_rev (attrs : t) =
         -> `Method, acc
       | "bs", _
       | "bs.this", _
-        -> Location.raise_errorf 
-             ~loc
-             "[@bs.this], [@bs], [@bs.meth] can not be applied at the same time"
+        -> Bs_syntaxerr.err loc Conflict_bs_bs_this_bs_meth
       | _ , _ -> 
         st, attr::acc 
     ) ( `Nothing, []) attrs
@@ -135,7 +133,8 @@ let process_derive_type attrs =
              (Ast_payload.as_config_record_and_process loc payload)}, acc 
       | {bs_deriving = `Has_deriving _}, "bs.deriving"
         -> 
-        Location.raise_errorf ~loc "duplicated bs.deriving attribute"
+        Bs_syntaxerr.err loc Duplicated_bs_deriving
+
       | _ , _ ->
         let st = 
           if txt = "nonrec" then 
@@ -168,7 +167,7 @@ let process_bs_string_int_uncurry attrs =
       | "bs.string", _
       | "bs.ignore", _
         -> 
-        Location.raise_errorf ~loc "conflict attributes "
+        Bs_syntaxerr.err loc Conflict_attributes
       | _ , _ -> st, (attr :: attrs )
     ) (`Nothing, []) attrs
 
@@ -181,12 +180,12 @@ let process_bs_string_as  attrs =
         ->
         begin match Ast_payload.is_single_string payload with 
           | None -> 
-            Location.raise_errorf ~loc "expect string literal "
+            Bs_syntaxerr.err loc Expect_string_literal
           | Some  _ as v->  (v, attrs)  
         end
       | "bs.as",  _ 
         -> 
-          Location.raise_errorf ~loc "duplicated bs.as "
+          Bs_syntaxerr.err loc Duplicated_bs_as 
       | _ , _ -> (st, attr::attrs) 
     ) (None, []) attrs
 
@@ -199,12 +198,12 @@ let process_bs_int_as  attrs =
         ->
         begin match Ast_payload.is_single_int payload with 
           | None -> 
-            Location.raise_errorf ~loc "expect int literal "
+            Bs_syntaxerr.err loc Expect_int_literal
           | Some  _ as v->  (v, attrs)  
         end
       | "bs.as",  _ 
         -> 
-          Location.raise_errorf ~loc "duplicated bs.as "
+        Bs_syntaxerr.err loc Duplicated_bs_as
       | _ , _ -> (st, attr::attrs) 
     ) (None, []) attrs
 
@@ -219,14 +218,14 @@ let process_bs_string_or_int_as attrs =
           | None -> 
             begin match Ast_payload.is_single_string payload with 
             | None -> 
-              Location.raise_errorf ~loc "expect int or string literal "
+              Bs_syntaxerr.err loc Expect_int_or_string_literal
             | Some s -> (Some (`Str s), attrs)
             end
           | Some   v->  (Some (`Int v), attrs)  
         end
       | "bs.as",  _ 
         -> 
-          Location.raise_errorf ~loc "duplicated bs.as "
+        Bs_syntaxerr.err loc Duplicated_bs_as
       | _ , _ -> (st, attr::attrs) 
     ) (None, []) attrs
 

--- a/jscomp/syntax/ast_core_type.ml
+++ b/jscomp/syntax/ast_core_type.ml
@@ -183,6 +183,6 @@ let list_of_arrow (ty : t) =
     | Ptyp_arrow(label,t1,t2) -> 
       aux t2 ((label,t1,ty.ptyp_attributes,ty.ptyp_loc) ::acc)
     | Ptyp_poly(_, ty) -> (* should not happen? *)
-      Location.raise_errorf ~loc:ty.ptyp_loc "Unhandled poly type"
+      Bs_syntaxerr.err ty.ptyp_loc Unhandled_poly_type
     | return_type -> ty, List.rev acc
   in aux ty []

--- a/jscomp/syntax/ast_derive.ml
+++ b/jscomp/syntax/ast_derive.ml
@@ -68,5 +68,7 @@ let dispatch_extension ({Asttypes.txt ; loc}) typ =
   let txt = Ext_string.tail_from txt (String.length Literals.bs_deriving_dot) in 
     match (Ast_payload.table_dispatch !derive_table 
             ({txt ; loc}, None)).expression_gen with 
-    | None -> Location.raise_errorf ~loc "%s is not registered" txt 
+    | None ->
+      Bs_syntaxerr.err loc (Unregistered txt)
+
     | Some f -> f typ

--- a/jscomp/syntax/bs_syntaxerr.ml
+++ b/jscomp/syntax/bs_syntaxerr.ml
@@ -1,0 +1,93 @@
+(* Copyright (C) 2015-2016 Bloomberg Finance L.P.
+ * 
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In addition to the permissions granted to you by the LGPL, you may combine
+ * or link a "work that uses the Library" with a publicly distributed version
+ * of this file to produce a combined library or application, then distribute
+ * that combined work under the terms of your choosing, with no requirement
+ * to comply with the obligations normally placed on you by section 4 of the
+ * LGPL version 3 (or the corresponding section of a later version of the LGPL
+ * should you choose to use a later version).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
+
+
+
+type error 
+  = Unsupported_predicates
+  | Conflict_bs_bs_this_bs_meth  
+  | Duplicated_bs_deriving
+  | Conflict_attributes
+
+  | Duplicated_bs_as 
+  | Expect_int_literal
+  | Expect_string_literal
+  | Expect_int_or_string_literal
+  | Unhandled_poly_type
+  | Unregistered of string 
+  | Invalid_underscore_type_in_external
+  | Invalid_bs_string_type 
+  | Invalid_bs_int_type 
+  | Conflict_ffi_attribute
+
+let pp_error fmt err =
+  Format.pp_print_string fmt @@ match err with 
+  | Unsupported_predicates 
+    ->
+     "unsupported predicates"
+  | Conflict_bs_bs_this_bs_meth -> 
+     "[@bs.this], [@bs], [@bs.meth] can not be applied at the same time"
+  | Duplicated_bs_deriving
+    -> "duplicated bs.deriving attribute"
+  | Conflict_attributes
+    -> "conflict attributes " 
+  | Expect_string_literal
+    -> "expect string literal "
+  | Duplicated_bs_as 
+    -> 
+    "duplicated bs.as "
+  | Expect_int_literal 
+    -> 
+    "expect int literal "
+  | Expect_int_or_string_literal
+    ->
+    "expect int or string literal "
+  | Unhandled_poly_type 
+    -> 
+    "Unhandled poly type"
+  | Unregistered str 
+    -> "Unregistered " ^ str 
+  | Invalid_underscore_type_in_external
+    ->
+    "_ is not allowed in combination with external optional type"
+  | Invalid_bs_string_type
+    -> 
+    "Not a valid  type for [@bs.string]"
+  | Invalid_bs_int_type 
+    -> 
+    "Not a valid  type for [@bs.int]"
+  | Conflict_ffi_attribute
+    ->
+    "conflict attributes found" 
+ 
+exception  Error of Location.t * error
+
+let () = 
+  Location.register_error_of_exn (function
+    | Error(loc,err) -> 
+      Some (Location.error_of_printer loc pp_error err)
+    | _ -> None
+    )
+
+let err loc error = raise (Error(loc, error))

--- a/jscomp/test/.depend
+++ b/jscomp/test/.depend
@@ -64,6 +64,7 @@ bal_set_mini.cmj :
 bang_primitive.cmj :
 basic_module_test.cmj : ../stdlib/set.cmj pr6726.cmj offset.cmj \
     mt_global.cmj mt.cmj basic_module_test.cmi
+bb.cmj :
 bdd.cmj : ../stdlib/array.cmj
 bench.cmj : ../stdlib/array.cmj
 bigarray_test.cmj : ../stdlib/int32.cmj ../stdlib/complex.cmj \

--- a/jscomp/test/Makefile
+++ b/jscomp/test/Makefile
@@ -118,8 +118,8 @@ OTHERS := literals a test_ari test_export2 test_internalOO test_obj_simple_ffi t
 	compare_test\
 	js_cast_test\
 	gpr_1423_nav\
-	gpr_1423_app_test
-
+	gpr_1423_app_test\
+	bb
 
 # bs_uncurry_test
 # needs Lam to get rid of Uncurry arity first

--- a/jscomp/test/bb.js
+++ b/jscomp/test/bb.js
@@ -1,0 +1,95 @@
+'use strict';
+
+var Caml_builtin_exceptions = require("../../lib/js/caml_builtin_exceptions");
+
+function f(x) {
+  if (x !== 98) {
+    if (x >= 99) {
+      return "c";
+    }
+    else {
+      return "a";
+    }
+  }
+  else {
+    return "b";
+  }
+}
+
+function ff(x) {
+  switch (x) {
+    case "a" : 
+        return /* a */97;
+    case "b" : 
+        return /* b */98;
+    case "c" : 
+        return /* c */99;
+    default:
+      throw [
+            Caml_builtin_exceptions.assert_failure,
+            [
+              "bb.ml",
+              17,
+              9
+            ]
+          ];
+  }
+}
+
+function test(x) {
+  var match;
+  switch (x) {
+    case "a" : 
+        match = /* a */97;
+        break;
+    case "b" : 
+        match = /* b */98;
+        break;
+    case "c" : 
+        match = /* c */99;
+        break;
+    default:
+      throw [
+            Caml_builtin_exceptions.assert_failure,
+            [
+              "bb.ml",
+              26,
+              13
+            ]
+          ];
+  }
+  if (match !== 98) {
+    if (match >= 99) {
+      return "c";
+    }
+    else {
+      return "a";
+    }
+  }
+  else {
+    return "b";
+  }
+}
+
+var test_poly = "a";
+
+var match_000 = f(/* a */97);
+
+var match_001 = f(/* b */98);
+
+var match_002 = f(/* c */99);
+
+var c = match_000;
+
+var d = match_001;
+
+var e = match_002;
+
+exports.f         = f;
+exports.ff        = ff;
+exports.test      = test;
+exports.test_poly = test_poly;
+exports.c         = c;
+exports.d         = d;
+exports.e         = e;
+/* match Not a pure module */

--- a/jscomp/test/bb.ml
+++ b/jscomp/test/bb.ml
@@ -1,0 +1,38 @@
+
+
+
+
+let f x =
+  match x with 
+  | `a -> "a"
+  | `b -> "b"
+  | `c -> "c"
+
+
+let ff x =
+  match x with 
+  | "a" -> `a
+  | "b" -> `b
+  | "c" -> `c 
+  | _ -> assert false 
+
+
+
+let test x = 
+  match (match x with 
+      | "a" -> `a
+      | "b" -> `b
+      | "c" -> `c 
+      | _ -> assert false ) with 
+  | `a -> "a"
+  | `b -> "b"
+  | `c -> "c"
+
+
+let test_poly = 
+  match `a with 
+  | `a -> "a"
+  | `b -> "b"
+  | `c -> "c"
+
+let c,d,e = f `a, f `b, f `c


### PR DESCRIPTION
Fix #1418 

Note this commit start to migrate from `Location.raise_errof` from the standard way of error reporting (see Bs_syntaxerr module) which supports syntax coloring etc

The change is incomplete since we have too many `Location.raise_errorf`