### PR TITLE
Fix typo of 'pakcage' to 'package'

### DIFF
--- a/jscomp/bin/bsb.ml
+++ b/jscomp/bin/bsb.ml
@@ -4231,14 +4231,14 @@ let  resolve_bs_package
           else
             begin 
               Format.fprintf Format.err_formatter 
-                "@{<error>Package not found: resolving pakcage %s in %s  @}@." name cwd ;             
+                "@{<error>Package not found: resolving package %s in %s  @}@." name cwd ;             
               Bsb_exception.error (Package_not_found (name, None))
             end
         with 
           Not_found -> 
           begin 
             Format.fprintf Format.err_formatter 
-              "@{<error>Package not found: resolving pakcage %s in %s  @}@." name cwd ;             
+              "@{<error>Package not found: resolving package %s in %s  @}@." name cwd ;             
             Bsb_exception.error (Package_not_found (name,None))
           end
   in

--- a/jscomp/bsb/bsb_pkg.ml
+++ b/jscomp/bsb/bsb_pkg.ml
@@ -30,14 +30,14 @@ let  resolve_bs_package
           else
             begin 
               Format.fprintf Format.err_formatter 
-                "@{<error>Package not found: resolving pakcage %s in %s  @}@." name cwd ;             
+                "@{<error>Package not found: resolving package %s in %s  @}@." name cwd ;             
               Bsb_exception.error (Package_not_found (name, None))
             end
         with 
           Not_found -> 
           begin 
             Format.fprintf Format.err_formatter 
-              "@{<error>Package not found: resolving pakcage %s in %s  @}@." name cwd ;             
+              "@{<error>Package not found: resolving package %s in %s  @}@." name cwd ;             
             Bsb_exception.error (Package_not_found (name,None))
           end
   in


### PR DESCRIPTION
Simple typo I found in output when a dependency was missing.