### PR TITLE
bug fix exit inlining and prepare js runtime

### DIFF
--- a/jscomp/all.depend
+++ b/jscomp/all.depend
@@ -334,7 +334,7 @@ core/lam_compile_primitive.cmi : core/lam_compile_defs.cmi core/lam.cmi \
     core/j.cmx
 core/lam_compile.cmi : core/lam_compile_defs.cmi core/lam.cmi \
     core/js_output.cmi core/j.cmx
-core/lam_pass_exits.cmi : core/lam.cmi ext/int_hashtbl.cmi
+core/lam_pass_exits.cmi : core/lam.cmi
 core/lam_pass_count.cmi : core/lam.cmi ext/ident_hashtbl.cmi
 core/lam_pass_eliminate_ref.cmi : core/lam.cmi
 core/lam_pass_lets_dce.cmi : core/lam.cmi
@@ -360,10 +360,10 @@ core/lam_module_ident.cmx : core/js_op.cmx common/js_config.cmx core/j.cmx \
 core/lam.cmx : ext/ordered_hash_map_local_ident.cmx \
     core/ocaml_stdlib_slots.cmx ext/literals.cmx core/lam_module_ident.cmx \
     common/js_config.cmx ext/int_vec_vec.cmx ext/int_vec_util.cmx \
-    ext/int_vec.cmx ext/ident_set.cmx ext/ident_hashtbl.cmx \
-    ext/ident_hash_set.cmx ext/hash_set_ident_mask.cmx ext/ext_string.cmx \
-    ext/ext_scc.cmx ext/ext_list.cmx syntax/ast_ffi_types.cmx \
-    syntax/ast_arg.cmx core/lam.cmi
+    ext/int_vec.cmx ext/int_hashtbl.cmx ext/ident_set.cmx \
+    ext/ident_hashtbl.cmx ext/ident_hash_set.cmx ext/hash_set_ident_mask.cmx \
+    ext/ext_string.cmx ext/ext_scc.cmx ext/ext_list.cmx \
+    syntax/ast_ffi_types.cmx syntax/ast_arg.cmx core/lam.cmi
 core/lam_print.cmx : core/lam.cmx core/lam_print.cmi
 core/lam_beta_reduce_util.cmx : core/lam.cmx ext/ident_hashtbl.cmx \
     core/lam_beta_reduce_util.cmi
@@ -552,7 +552,7 @@ core/lam_compile.cmx : ext/literals.cmx core/lam_util.cmx \
     core/lam_compile.cmi
 core/lam_pass_exits.cmx : core/lam_util.cmx core/lam_bounded_vars.cmx \
     core/lam_analysis.cmx core/lam.cmx ext/int_hashtbl.cmx ext/ident_map.cmx \
-    common/ext_log.cmx core/lam_pass_exits.cmi
+    core/lam_pass_exits.cmi
 core/lam_pass_count.cmx : core/lam_beta_reduce.cmx core/lam.cmx \
     ext/ident_map.cmx ext/ident_hashtbl.cmx ext/ext_list.cmx \
     core/lam_pass_count.cmi

--- a/jscomp/bin/bsdep.ml
+++ b/jscomp/bin/bsdep.ml
@@ -25788,6 +25788,7 @@ val weak : string
 val js_primitive : string
 val module_ : string
 val missing_polyfill : string
+val exn : string
 (** Debugging utilies *)
 val set_current_file : string -> unit 
 val get_current_file : unit -> string
@@ -26015,6 +26016,8 @@ let block = "Block"
 let js_primitive = "Js_primitive"
 let module_ = "Caml_module"
 let missing_polyfill = "Caml_missing_polyfill"
+let exn = "Js_exn"
+
 let current_file = ref ""
 let debug_file = ref ""
 

--- a/jscomp/bin/bsppx.ml
+++ b/jscomp/bin/bsppx.ml
@@ -7803,6 +7803,7 @@ val weak : string
 val js_primitive : string
 val module_ : string
 val missing_polyfill : string
+val exn : string
 (** Debugging utilies *)
 val set_current_file : string -> unit 
 val get_current_file : unit -> string
@@ -8030,6 +8031,8 @@ let block = "Block"
 let js_primitive = "Js_primitive"
 let module_ = "Caml_module"
 let missing_polyfill = "Caml_missing_polyfill"
+let exn = "Js_exn"
+
 let current_file = ref ""
 let debug_file = ref ""
 

--- a/jscomp/bin/whole_compiler.ml
+++ b/jscomp/bin/whole_compiler.ml
@@ -67823,7 +67823,7 @@ let convert exports lam : _ * _  =
       (** TODO:
           2. Check some optimizations
       *)
-      (* let newId = Ident.rename id in 
+      (*let newId = Ident.rename id in 
       let body = aux b in 
       let handler = aux handler in 
       Ltrywith (body, newId, 
@@ -67831,7 +67831,7 @@ let convert exports lam : _ * _  =
                   (prim ~primitive:Pwrap_exn ~args:[var newId] Location.none)
                   handler
                ) *)
-        Ltrywith (aux b, id, aux handler)       
+       Ltrywith (aux b, id, aux handler)       
     | Lifthenelse (b,then_,else_) -> 
       Lifthenelse (aux b, aux then_, aux else_)
     | Lsequence (a,b) 

--- a/jscomp/bin/whole_compiler.ml
+++ b/jscomp/bin/whole_compiler.ml
@@ -22323,6 +22323,7 @@ val weak : string
 val js_primitive : string
 val module_ : string
 val missing_polyfill : string
+val exn : string
 (** Debugging utilies *)
 val set_current_file : string -> unit 
 val get_current_file : unit -> string
@@ -22550,6 +22551,8 @@ let block = "Block"
 let js_primitive = "Js_primitive"
 let module_ = "Caml_module"
 let missing_polyfill = "Caml_missing_polyfill"
+let exn = "Js_exn"
+
 let current_file = ref ""
 let debug_file = ref ""
 
@@ -62533,6 +62536,244 @@ let invariant t =
 
 
 end
+module Ext_int : sig 
+#1 "ext_int.mli"
+(* Copyright (C) 2015-2016 Bloomberg Finance L.P.
+ * 
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In addition to the permissions granted to you by the LGPL, you may combine
+ * or link a "work that uses the Library" with a publicly distributed version
+ * of this file to produce a combined library or application, then distribute
+ * that combined work under the terms of your choosing, with no requirement
+ * to comply with the obligations normally placed on you by section 4 of the
+ * LGPL version 3 (or the corresponding section of a later version of the LGPL
+ * should you choose to use a later version).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
+
+
+type t = int
+val compare : t -> t -> int 
+val equal : t -> t -> bool 
+
+end = struct
+#1 "ext_int.ml"
+(* Copyright (C) 2015-2016 Bloomberg Finance L.P.
+ * 
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In addition to the permissions granted to you by the LGPL, you may combine
+ * or link a "work that uses the Library" with a publicly distributed version
+ * of this file to produce a combined library or application, then distribute
+ * that combined work under the terms of your choosing, with no requirement
+ * to comply with the obligations normally placed on you by section 4 of the
+ * LGPL version 3 (or the corresponding section of a later version of the LGPL
+ * should you choose to use a later version).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
+
+
+type t = int
+
+let compare (x : t) (y : t) = Pervasives.compare x y 
+
+let equal (x : t) (y : t) = x = y
+
+end
+module Int_hashtbl : sig 
+#1 "int_hashtbl.mli"
+(* Copyright (C) 2015-2016 Bloomberg Finance L.P.
+ * 
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In addition to the permissions granted to you by the LGPL, you may combine
+ * or link a "work that uses the Library" with a publicly distributed version
+ * of this file to produce a combined library or application, then distribute
+ * that combined work under the terms of your choosing, with no requirement
+ * to comply with the obligations normally placed on you by section 4 of the
+ * LGPL version 3 (or the corresponding section of a later version of the LGPL
+ * should you choose to use a later version).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
+
+
+
+include Hashtbl_gen.S with type key = int
+
+
+
+
+end = struct
+#1 "int_hashtbl.ml"
+# 15 "ext/hashtbl.cppo.ml"
+type key = int 
+type 'a t = (key, 'a)  Hashtbl_gen.t 
+let key_index (h : _ t ) (key : key) =
+  (Bs_hash_stubs.hash_int  key ) land (Array.length h.data - 1)
+let eq_key = Ext_int.equal   
+
+
+# 33
+type ('a, 'b) bucketlist = ('a,'b) Hashtbl_gen.bucketlist
+let create = Hashtbl_gen.create
+let clear = Hashtbl_gen.clear
+let reset = Hashtbl_gen.reset
+let copy = Hashtbl_gen.copy
+let iter = Hashtbl_gen.iter
+let fold = Hashtbl_gen.fold
+let length = Hashtbl_gen.length
+let stats = Hashtbl_gen.stats
+
+
+
+let add (h : _ t) key info =
+  let i = key_index h key in
+  let h_data = h.data in   
+  Array.unsafe_set h_data i (Cons(key, info, (Array.unsafe_get h_data i)));
+  h.size <- h.size + 1;
+  if h.size > Array.length h_data lsl 1 then Hashtbl_gen.resize key_index h
+
+(* after upgrade to 4.04 we should provide an efficient [replace_or_init] *)
+let modify_or_init (h : _ t) key modf default =
+  let rec find_bucket (bucketlist : _ bucketlist)  =
+    match bucketlist with
+    | Cons(k,i,next) ->
+      if eq_key k key then begin modf i; false end
+      else find_bucket next 
+    | Empty -> true in
+  let i = key_index h key in 
+  let h_data = h.data in 
+  if find_bucket (Array.unsafe_get h_data i) then
+    begin 
+      Array.unsafe_set h_data i  (Cons(key,default (), Array.unsafe_get h_data i));
+      h.size <- h.size + 1 ;
+      if h.size > Array.length h_data lsl 1 then Hashtbl_gen.resize key_index h 
+    end
+
+
+let rec remove_bucket key (h : _ t) (bucketlist : _ bucketlist) : _ bucketlist = 
+  match bucketlist with  
+  | Empty ->
+    Empty
+  | Cons(k, i, next) ->
+    if eq_key k key 
+    then begin h.size <- h.size - 1; next end
+    else Cons(k, i, remove_bucket key h next) 
+
+let remove (h : _ t ) key =
+  let i = key_index h key in
+  let h_data = h.data in 
+  let old_h_szie = h.size in 
+  let new_bucket = remove_bucket key h (Array.unsafe_get h_data i) in  
+  if old_h_szie <> h.size then 
+    Array.unsafe_set h_data i  new_bucket
+
+let rec find_rec key (bucketlist : _ bucketlist) = match bucketlist with  
+  | Empty ->
+    raise Not_found
+  | Cons(k, d, rest) ->
+    if eq_key key k then d else find_rec key rest
+
+let find_exn (h : _ t) key =
+  match Array.unsafe_get h.data (key_index h key) with
+  | Empty -> raise Not_found
+  | Cons(k1, d1, rest1) ->
+    if eq_key key k1 then d1 else
+      match rest1 with
+      | Empty -> raise Not_found
+      | Cons(k2, d2, rest2) ->
+        if eq_key key k2 then d2 else
+          match rest2 with
+          | Empty -> raise Not_found
+          | Cons(k3, d3, rest3) ->
+            if eq_key key k3  then d3 else find_rec key rest3
+
+let find_opt (h : _ t) key =
+  Hashtbl_gen.small_bucket_opt eq_key key (Array.unsafe_get h.data (key_index h key))
+
+let find_key_opt (h : _ t) key =
+  Hashtbl_gen.small_bucket_key_opt eq_key key (Array.unsafe_get h.data (key_index h key))
+  
+let find_default (h : _ t) key default = 
+  Hashtbl_gen.small_bucket_default eq_key key default (Array.unsafe_get h.data (key_index h key))
+let find_all (h : _ t) key =
+  let rec find_in_bucket (bucketlist : _ bucketlist) = match bucketlist with 
+    | Empty ->
+      []
+    | Cons(k, d, rest) ->
+      if eq_key k key 
+      then d :: find_in_bucket rest
+      else find_in_bucket rest in
+  find_in_bucket (Array.unsafe_get h.data (key_index h key))
+
+let replace h key info =
+  let rec replace_bucket (bucketlist : _ bucketlist) : _ bucketlist = match bucketlist with 
+    | Empty ->
+      raise_notrace Not_found
+    | Cons(k, i, next) ->
+      if eq_key k key
+      then Cons(key, info, next)
+      else Cons(k, i, replace_bucket next) in
+  let i = key_index h key in
+  let h_data = h.data in 
+  let l = Array.unsafe_get h_data i in
+  try
+    Array.unsafe_set h_data i  (replace_bucket l)
+  with Not_found ->
+    begin 
+      Array.unsafe_set h_data i (Cons(key, info, l));
+      h.size <- h.size + 1;
+      if h.size > Array.length h_data lsl 1 then Hashtbl_gen.resize key_index h;
+    end 
+
+let mem (h : _ t) key =
+  let rec mem_in_bucket (bucketlist : _ bucketlist) = match bucketlist with 
+    | Empty ->
+      false
+    | Cons(k, d, rest) ->
+      eq_key k key  || mem_in_bucket rest in
+  mem_in_bucket (Array.unsafe_get h.data (key_index h key))
+
+
+let of_list2 ks vs = 
+  let len = List.length ks in 
+  let map = create len in 
+  List.iter2 (fun k v -> add map k v) ks vs ; 
+  map
+
+
+end
 module Int_vec_util : sig 
 #1 "int_vec_util.mli"
 (* Copyright (C) 2015-2016 Bloomberg Finance L.P.
@@ -65530,7 +65771,7 @@ type primitive =
   | Pjs_is_instance_array
   | Pcaml_obj_length
   | Pcaml_obj_set_length
-  
+  | Pwrap_exn (* convert either JS exception or OCaml exception into OCaml format *)  
 
 type switch  =
   { sw_numconsts: int;
@@ -65880,7 +66121,7 @@ type primitive =
   | Pjs_is_instance_array
   | Pcaml_obj_length
   | Pcaml_obj_set_length
-
+  | Pwrap_exn (* convert either JS exception or OCaml exception into OCaml format *)
 
 type apply_status =
   | App_na
@@ -67237,7 +67478,8 @@ type required_modules = Lam_module_ident.Hash_set.t
 
 
 let convert exports lam : _ * _  = 
-  let alias = Ident_hashtbl.create 64 in 
+  let alias_tbl = Ident_hashtbl.create 64 in 
+  let exit_map = Int_hashtbl.create 0 in 
   let may_depends = Lam_module_ident.Hash_set.create 0 in 
 
   let rec
@@ -67331,7 +67573,7 @@ let convert exports lam : _ * _  =
   and aux (lam : Lambda.lambda) : t = 
     match lam with 
     | Lvar x -> 
-      let var = Ident_hashtbl.find_default alias x x in
+      let var = Ident_hashtbl.find_default alias_tbl x x in
       if Ident.persistent var then 
         Lglobal_module var 
       else       
@@ -67460,14 +67702,14 @@ let convert exports lam : _ * _  =
 
       begin match kind, e with 
         | Alias , (Lvar u ) ->
-          let new_u = (Ident_hashtbl.find_default alias u u) in
-          Ident_hashtbl.add alias id new_u ;
+          let new_u = (Ident_hashtbl.find_default alias_tbl u u) in
+          Ident_hashtbl.add alias_tbl id new_u ;
           if Ident_set.mem id exports then 
             Llet(kind, id, Lvar new_u, aux body)
           else aux body   
         | Alias ,  Lprim (Pgetglobal u,[], _) when not (Ident.is_predef_exn u)
           ->         
-          Ident_hashtbl.add alias id u;          
+          Ident_hashtbl.add alias_tbl id u;          
           may_depend may_depends (Lam_module_ident.of_ml u);
 
           if Ident_set.mem id exports then 
@@ -67562,13 +67804,34 @@ let convert exports lam : _ * _  =
                      | None -> None
                      | Some x -> Some (aux x)
                     )    
-
+    | Lstaticraise (id,[]) ->
+      begin match Int_hashtbl.find_opt exit_map id  with
+      | None -> Lstaticraise (id,[])
+      | Some new_id -> Lstaticraise (new_id,[])
+      end               
     | Lstaticraise (id, args) -> 
       Lstaticraise (id, List.map aux args)
+    | Lstaticcatch (b, (i,[]), Lstaticraise (j,[]) ) 
+      -> (* peep-hole [i] aliased to [j] *)
+
+        let new_i = Int_hashtbl.find_default exit_map j j in 
+        Int_hashtbl.add exit_map i new_i ; 
+        aux b
     | Lstaticcatch (b, (i, ids), handler) -> 
       Lstaticcatch (aux b, (i,ids), aux handler)
-    | Ltrywith (b, id, handler) -> 
-      Ltrywith (aux b, id, aux handler)
+    | Ltrywith (b, id, handler) ->
+      (** TODO:
+          2. Check some optimizations
+      *)
+      (* let newId = Ident.rename id in 
+      let body = aux b in 
+      let handler = aux handler in 
+      Ltrywith (body, newId, 
+                let_ StrictOpt id 
+                  (prim ~primitive:Pwrap_exn ~args:[var newId] Location.none)
+                  handler
+               ) *)
+        Ltrywith (aux b, id, aux handler)       
     | Lifthenelse (b,then_,else_) -> 
       Lifthenelse (aux b, aux then_, aux else_)
     | Lsequence (a,b) 
@@ -71070,6 +71333,7 @@ let rec no_side_effects (lam : Lam.t) : bool =
       | Pjs_function_length
       | Pcaml_obj_length
       | Pjs_is_instance_array
+      | Pwrap_exn
         -> true
       | Pjs_string_of_small_array
       | Pcaml_obj_set_length        
@@ -71394,6 +71658,7 @@ let rec
   
 and eq_primitive ( lhs : Lam.primitive) (rhs : Lam.primitive) = 
   match lhs with 
+  | Pwrap_exn -> rhs = Pwrap_exn
   | Pbytes_to_string ->  rhs = Pbytes_to_string 
   | Pbytes_of_string ->  rhs = Pbytes_of_string
   | Praise -> rhs = Praise
@@ -71666,6 +71931,7 @@ let string_of_loc_kind (loc : Lambda.loc_kind) =
   | Loc_LOC -> "loc_LOC"
 
 let primitive ppf (prim : Lam.primitive) = match prim with 
+  | Pwrap_exn -> fprintf ppf "#exn"
   | Pjs_string_of_small_array -> fprintf ppf "#string_of_small_array"
   | Pjs_is_instance_array -> fprintf ppf "#is_instance_array"
   | Pcaml_obj_length -> fprintf ppf "#obj_length"
@@ -72141,71 +72407,6 @@ let seriaize env (filename : string) (lam : Lam.t) : unit =
     close_out ou;
     Format.set_margin old
   end
-
-end
-module Ext_int : sig 
-#1 "ext_int.mli"
-(* Copyright (C) 2015-2016 Bloomberg Finance L.P.
- * 
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * In addition to the permissions granted to you by the LGPL, you may combine
- * or link a "work that uses the Library" with a publicly distributed version
- * of this file to produce a combined library or application, then distribute
- * that combined work under the terms of your choosing, with no requirement
- * to comply with the obligations normally placed on you by section 4 of the
- * LGPL version 3 (or the corresponding section of a later version of the LGPL
- * should you choose to use a later version).
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
- * 
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
-
-
-type t = int
-val compare : t -> t -> int 
-val equal : t -> t -> bool 
-
-end = struct
-#1 "ext_int.ml"
-(* Copyright (C) 2015-2016 Bloomberg Finance L.P.
- * 
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * In addition to the permissions granted to you by the LGPL, you may combine
- * or link a "work that uses the Library" with a publicly distributed version
- * of this file to produce a combined library or application, then distribute
- * that combined work under the terms of your choosing, with no requirement
- * to comply with the obligations normally placed on you by section 4 of the
- * LGPL version 3 (or the corresponding section of a later version of the LGPL
- * should you choose to use a later version).
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
- * 
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
-
-
-type t = int
-
-let compare (x : t) (y : t) = Pervasives.compare x y 
-
-let equal (x : t) (y : t) = x = y
 
 end
 module Int_hash_set : sig 
@@ -92653,6 +92854,8 @@ let translate  loc
     (prim : Lam.primitive)
     (args : J.expression list) : J.expression = 
   match prim with
+  | Pwrap_exn -> 
+    E.runtime_call Js_config.exn "internalToOCamlException" args 
   | Lam.Praw_js_code_exp s -> 
     E.raw_js_code Exp s  
   | Lam.Praw_js_code_stmt s -> 
@@ -96899,179 +97102,6 @@ let deep_flatten
   in aux lam
 
 end
-module Int_hashtbl : sig 
-#1 "int_hashtbl.mli"
-(* Copyright (C) 2015-2016 Bloomberg Finance L.P.
- * 
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * In addition to the permissions granted to you by the LGPL, you may combine
- * or link a "work that uses the Library" with a publicly distributed version
- * of this file to produce a combined library or application, then distribute
- * that combined work under the terms of your choosing, with no requirement
- * to comply with the obligations normally placed on you by section 4 of the
- * LGPL version 3 (or the corresponding section of a later version of the LGPL
- * should you choose to use a later version).
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
- * 
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
-
-
-
-include Hashtbl_gen.S with type key = int
-
-
-
-
-end = struct
-#1 "int_hashtbl.ml"
-# 15 "ext/hashtbl.cppo.ml"
-type key = int 
-type 'a t = (key, 'a)  Hashtbl_gen.t 
-let key_index (h : _ t ) (key : key) =
-  (Bs_hash_stubs.hash_int  key ) land (Array.length h.data - 1)
-let eq_key = Ext_int.equal   
-
-
-# 33
-type ('a, 'b) bucketlist = ('a,'b) Hashtbl_gen.bucketlist
-let create = Hashtbl_gen.create
-let clear = Hashtbl_gen.clear
-let reset = Hashtbl_gen.reset
-let copy = Hashtbl_gen.copy
-let iter = Hashtbl_gen.iter
-let fold = Hashtbl_gen.fold
-let length = Hashtbl_gen.length
-let stats = Hashtbl_gen.stats
-
-
-
-let add (h : _ t) key info =
-  let i = key_index h key in
-  let h_data = h.data in   
-  Array.unsafe_set h_data i (Cons(key, info, (Array.unsafe_get h_data i)));
-  h.size <- h.size + 1;
-  if h.size > Array.length h_data lsl 1 then Hashtbl_gen.resize key_index h
-
-(* after upgrade to 4.04 we should provide an efficient [replace_or_init] *)
-let modify_or_init (h : _ t) key modf default =
-  let rec find_bucket (bucketlist : _ bucketlist)  =
-    match bucketlist with
-    | Cons(k,i,next) ->
-      if eq_key k key then begin modf i; false end
-      else find_bucket next 
-    | Empty -> true in
-  let i = key_index h key in 
-  let h_data = h.data in 
-  if find_bucket (Array.unsafe_get h_data i) then
-    begin 
-      Array.unsafe_set h_data i  (Cons(key,default (), Array.unsafe_get h_data i));
-      h.size <- h.size + 1 ;
-      if h.size > Array.length h_data lsl 1 then Hashtbl_gen.resize key_index h 
-    end
-
-
-let rec remove_bucket key (h : _ t) (bucketlist : _ bucketlist) : _ bucketlist = 
-  match bucketlist with  
-  | Empty ->
-    Empty
-  | Cons(k, i, next) ->
-    if eq_key k key 
-    then begin h.size <- h.size - 1; next end
-    else Cons(k, i, remove_bucket key h next) 
-
-let remove (h : _ t ) key =
-  let i = key_index h key in
-  let h_data = h.data in 
-  let old_h_szie = h.size in 
-  let new_bucket = remove_bucket key h (Array.unsafe_get h_data i) in  
-  if old_h_szie <> h.size then 
-    Array.unsafe_set h_data i  new_bucket
-
-let rec find_rec key (bucketlist : _ bucketlist) = match bucketlist with  
-  | Empty ->
-    raise Not_found
-  | Cons(k, d, rest) ->
-    if eq_key key k then d else find_rec key rest
-
-let find_exn (h : _ t) key =
-  match Array.unsafe_get h.data (key_index h key) with
-  | Empty -> raise Not_found
-  | Cons(k1, d1, rest1) ->
-    if eq_key key k1 then d1 else
-      match rest1 with
-      | Empty -> raise Not_found
-      | Cons(k2, d2, rest2) ->
-        if eq_key key k2 then d2 else
-          match rest2 with
-          | Empty -> raise Not_found
-          | Cons(k3, d3, rest3) ->
-            if eq_key key k3  then d3 else find_rec key rest3
-
-let find_opt (h : _ t) key =
-  Hashtbl_gen.small_bucket_opt eq_key key (Array.unsafe_get h.data (key_index h key))
-
-let find_key_opt (h : _ t) key =
-  Hashtbl_gen.small_bucket_key_opt eq_key key (Array.unsafe_get h.data (key_index h key))
-  
-let find_default (h : _ t) key default = 
-  Hashtbl_gen.small_bucket_default eq_key key default (Array.unsafe_get h.data (key_index h key))
-let find_all (h : _ t) key =
-  let rec find_in_bucket (bucketlist : _ bucketlist) = match bucketlist with 
-    | Empty ->
-      []
-    | Cons(k, d, rest) ->
-      if eq_key k key 
-      then d :: find_in_bucket rest
-      else find_in_bucket rest in
-  find_in_bucket (Array.unsafe_get h.data (key_index h key))
-
-let replace h key info =
-  let rec replace_bucket (bucketlist : _ bucketlist) : _ bucketlist = match bucketlist with 
-    | Empty ->
-      raise_notrace Not_found
-    | Cons(k, i, next) ->
-      if eq_key k key
-      then Cons(key, info, next)
-      else Cons(k, i, replace_bucket next) in
-  let i = key_index h key in
-  let h_data = h.data in 
-  let l = Array.unsafe_get h_data i in
-  try
-    Array.unsafe_set h_data i  (replace_bucket l)
-  with Not_found ->
-    begin 
-      Array.unsafe_set h_data i (Cons(key, info, l));
-      h.size <- h.size + 1;
-      if h.size > Array.length h_data lsl 1 then Hashtbl_gen.resize key_index h;
-    end 
-
-let mem (h : _ t) key =
-  let rec mem_in_bucket (bucketlist : _ bucketlist) = match bucketlist with 
-    | Empty ->
-      false
-    | Cons(k, d, rest) ->
-      eq_key k key  || mem_in_bucket rest in
-  mem_in_bucket (Array.unsafe_get h.data (key_index h key))
-
-
-let of_list2 ks vs = 
-  let len = List.length ks in 
-  let map = create len in 
-  List.iter2 (fun k v -> add map k v) ks vs ; 
-  map
-
-
-end
 module Lam_pass_exits : sig 
 #1 "lam_pass_exits.mli"
 (***********************************************************************)
@@ -97092,11 +97122,7 @@ module Lam_pass_exits : sig
     [simplif] module
  *)
 
-val count_helper : Lam.t -> int ref Int_hashtbl.t
 
-type subst_tbl = (Ident.t list * Lam.t) Int_hashtbl.t
-
-val subst_helper : subst_tbl -> (int -> int) -> Lam.t -> Lam.t
 
 val simplify_exits : Lam.t -> Lam.t
 
@@ -97134,33 +97160,42 @@ end = struct
    ]}
 *)
 
+(** Don't modify it .. *)
+let default_zero = ref 0
+
 (* Count occurrences of (exit n ...) statements *)
 let count_exit exits i =
-  match 
-    (Int_hashtbl.find_opt exits i)
-  with
-  | None -> 0
-  | Some v -> !v 
+  !(Int_hashtbl.find_default exits i default_zero)
 
-and incr_exit exits i =
+let incr_exit exits i =
   Int_hashtbl.modify_or_init exits i incr (fun _ -> ref 1)
 
 
+(** 
+  This funcition counts how each [exit] is used, it will affect how the following optimizations performed.
+  
+  Some smart cases (this requires the following optimizations follow it): 
+  
+  {[
+    Lstaticcatch(l1, (i,_), l2) 
+  ]}
+  If [l1] does not contain [(exit i)],
+  [l2] will be removed, so don't count it.
+  
+  About Switch default branch handling, it maybe backend-specific
+  See https://github.com/ocaml/ocaml/commit/fcf3571123e2c914768e34f1bd17e4cbaaa7d212#diff-704f66c0fa0fc9339230b39ce7d90919 
+  For Lstringswitch ^
+  
+  For Lswitch, if it is not exhuastive pattern match, default will be counted twice.
+  Since for pattern match,  we will  test whether it is  an integer or block, both have default cases predicate: [sw_numconsts] vs nconsts
+*)
 let count_helper  (lam : Lam.t) : int ref Int_hashtbl.t  = 
   let exits  = Int_hashtbl.create 17 in
   let rec count (lam : Lam.t) = 
     match lam with 
     | Lstaticraise (i,ls) -> incr_exit exits i ; List.iter count ls
-    | Lstaticcatch (l1,(i,[]),Lstaticraise (j,[])) ->
-      (* i will be replaced by j in l1, so each occurence of i in l1
-         increases j's ref count *)
-      count l1 ;
-      let ic = count_exit exits i in
-      Int_hashtbl.modify_or_init exits j (fun x -> x := !x + ic) (fun _ -> ref ic)
     | Lstaticcatch(l1, (i,_), l2) ->
       count l1;
-      (* If l1 does not contain (exit i),
-         l2 will be removed, so don't count its exits *)
       if count_exit exits i > 0 
       then
         count l2
@@ -97170,15 +97205,7 @@ let count_helper  (lam : Lam.t) : int ref Int_hashtbl.t  =
       begin 
         match  d with
         | None -> ()
-        | Some d -> 
-          (* See https://github.com/ocaml/ocaml/commit/fcf3571123e2c914768e34f1bd17e4cbaaa7d212#diff-704f66c0fa0fc9339230b39ce7d90919 
-             might only necessary for native backend
-          *)
-          count d
-          (* begin match sw with *)
-          (* | []|[_] -> count d *)
-          (* | _ -> count d; count d (\** ASK: default will get replicated *\) *)
-          (* end *)
+        | Some d ->  count d
       end
     | Lvar _| Lconst _ -> ()
     | Lapply{fn = l1; args =  ll; _} -> count l1; List.iter count ll
@@ -97208,21 +97235,12 @@ let count_helper  (lam : Lam.t) : int ref Int_hashtbl.t  =
     match sw.sw_failaction with
     | None -> ()
     | Some al ->
-      let nconsts = List.length sw.sw_consts
-      and nblocks = List.length sw.sw_blocks in
-      if
-        nconsts < sw.sw_numconsts && nblocks < sw.sw_numblocks
-      then 
-        (*
-              Reason: for pattern match, 
-              we will  test whether it is 
-              an integer or block, both have default cases
-              predicate: [sw_numconsts] vs nconsts
-          *)
-
-        begin 
+      let nconsts = List.length sw.sw_consts in 
+      let nblocks = List.length sw.sw_blocks in
+      if nconsts < sw.sw_numconsts && nblocks < sw.sw_numblocks
+      then begin 
           count al ; count al
-        end 
+      end 
       else 
         begin (* default action will occur once *)
           assert (nconsts < sw.sw_numconsts || nblocks < sw.sw_numblocks) ;
@@ -97232,16 +97250,29 @@ let count_helper  (lam : Lam.t) : int ref Int_hashtbl.t  =
   exits
 ;;
 
-type subst_tbl = (Ident.t list * Lam.t) Int_hashtbl.t
+(** The third argument is its occurrence,
+  when do the substitution, if its occurence is > 1,
+  we should refresh
+ *)
+type lam_subst = 
+  | Id of Lam.t 
+  | Refresh of Lam.t
 
-(*
-   Second pass simplify  ``catch body with (i ...) handler''
+type subst_tbl = (Ident.t list * lam_subst ) Int_hashtbl.t
+
+let to_lam x = 
+  match x with 
+  | Id x -> x 
+  | Refresh x -> Lam_bounded_vars.refresh x 
+
+(**
+   Simplify  ``catch body with (i ...) handler''
       - if (exit i ...) does not occur in body, suppress catch
       - if (exit i ...) occurs exactly once in body,
         substitute it with handler
       - If handler is a single variable, replace (exit i ..) with it
-*)
-(*
+
+
   Note:
     In ``catch body with (i x1 .. xn) handler''
      Substituted expression is
@@ -97252,42 +97283,7 @@ type subst_tbl = (Ident.t list * Lam.t) Int_hashtbl.t
      (No alpha conversion of ``handler'' is presently needed, since
      substitution of several ``(exit i ...)''
      occurs only when ``handler'' is a variable.)
-*)
-
-
-let subst_helper (subst : subst_tbl) (query : int -> int) lam = 
-  let rec simplif (lam : Lam.t) = 
-    match lam with 
-    | Lstaticraise (i,[])  ->
-      begin match Int_hashtbl.find_opt subst i with
-        | Some (_, handler) -> handler
-        | None -> lam
-      end
-    | Lstaticraise (i,ls) ->
-      let ls = List.map simplif ls in
-      begin 
-        match Int_hashtbl.find_opt subst i with
-        | Some (xs,handler) -> 
-          let ys = List.map Ident.rename xs in
-          let env =
-            List.fold_right2
-              (fun x y t -> Ident_map.add x (Lam.var y) t)
-              xs ys Ident_map.empty in
-          List.fold_right2
-            (fun y l r -> Lam.let_ Alias y l r)
-            ys ls 
-            (Lam_util.subst_lambda  env  handler)
-        | None -> Lam.staticraise i ls
-      end
-    | Lstaticcatch (l1,(i,[]),(Lstaticraise (j,[]) as l2)) ->
-      Int_hashtbl.add subst i ([],simplif l2) ;
-      simplif l1 (** l1 will inline the exit handler *)
-    | Lstaticcatch (l1,(i,xs),l2) ->
-      begin 
-        match query i, l2 with
-        | 0,_ -> simplif l1
-
-        (* Note that 
+  Note that 
            for [query] result = 2, 
            the non-inline cost is 
            {[
@@ -97312,12 +97308,44 @@ let subst_helper (subst : subst_tbl) (query : int -> int) lam =
            since the outer is a traditional [try .. catch] body, 
            if it is guaranteed to be non throw, then we can inline
         *)
+
+let subst_helper (subst : subst_tbl) (query : int -> int) lam = 
+  let rec simplif (lam : Lam.t) = 
+    match lam with 
+    | Lstaticraise (i,[])  ->
+      begin match Int_hashtbl.find_opt subst i with
+        | Some (_,handler) -> to_lam handler
+        | None -> lam
+      end
+    | Lstaticraise (i,ls) ->
+      let ls = List.map simplif ls in
+      begin 
+        match Int_hashtbl.find_opt subst i with
+        | Some (xs, handler) -> 
+          let handler = to_lam handler in 
+          let ys = List.map Ident.rename xs in
+          let env =
+            List.fold_right2
+              (fun x y t -> Ident_map.add x (Lam.var y) t)
+              xs ys Ident_map.empty in
+          List.fold_right2
+            (fun y l r -> Lam.let_ Alias y l r)
+            ys ls 
+            (Lam_util.subst_lambda  env  handler)
+        | None -> Lam.staticraise i ls
+      end
+    | Lstaticcatch (l1,(i,xs),l2) ->
+      begin 
+        let i_occur = query i in 
+        match i_occur , l2 with
+        | 0,_ -> simplif l1
+
         | ( _ , Lvar _
           | _, Lconst _) ->  
-          Int_hashtbl.add subst i (xs,simplif l2) ;
+          Int_hashtbl.add subst i (xs, Id (simplif l2)) ;
           simplif l1 (** l1 will inline *)
         | 1,_ when i >= 0 -> (** Ask: Note that we have predicate i >=0 *)
-          Int_hashtbl.add subst i (xs,simplif l2) ;
+          Int_hashtbl.add subst i (xs, Id (simplif l2)) ;
           simplif l1 (** l1 will inline *)
         | j,_ ->
 
@@ -97339,15 +97367,14 @@ let subst_helper (subst : subst_tbl) (query : int -> int) lam =
               the j is not very indicative                
             *)             
           in 
-          if ok_to_inline 
+          if ok_to_inline (* && false *)
              (* #1438 when the action containes bounded variable 
                 to keep the invariant, everytime, we do an inlining,
                 we need refresh, just refreshing once is not enough
              *)
           then 
             begin 
-              Ext_log.dwarn __LOC__ "FUCK%d@." i;
-              Int_hashtbl.add subst i (xs, Lam_bounded_vars.refresh @@ simplif l2) ;
+              Int_hashtbl.add subst i (xs,  Refresh(simplif l2)) ;
               simplif l1 (** l1 will inline *)
             end
           else Lam.staticcatch (simplif l1) (i,xs) (simplif l2)

--- a/jscomp/common/js_config.ml
+++ b/jscomp/common/js_config.ml
@@ -201,6 +201,8 @@ let block = "Block"
 let js_primitive = "Js_primitive"
 let module_ = "Caml_module"
 let missing_polyfill = "Caml_missing_polyfill"
+let exn = "Js_exn"
+
 let current_file = ref ""
 let debug_file = ref ""
 

--- a/jscomp/common/js_config.mli
+++ b/jscomp/common/js_config.mli
@@ -149,6 +149,7 @@ val weak : string
 val js_primitive : string
 val module_ : string
 val missing_polyfill : string
+val exn : string
 (** Debugging utilies *)
 val set_current_file : string -> unit 
 val get_current_file : unit -> string

--- a/jscomp/core/lam.ml
+++ b/jscomp/core/lam.ml
@@ -1897,7 +1897,7 @@ let convert exports lam : _ * _  =
       (** TODO:
           2. Check some optimizations
       *)
-      (* let newId = Ident.rename id in 
+      (*let newId = Ident.rename id in 
       let body = aux b in 
       let handler = aux handler in 
       Ltrywith (body, newId, 
@@ -1905,7 +1905,7 @@ let convert exports lam : _ * _  =
                   (prim ~primitive:Pwrap_exn ~args:[var newId] Location.none)
                   handler
                ) *)
-        Ltrywith (aux b, id, aux handler)       
+       Ltrywith (aux b, id, aux handler)       
     | Lifthenelse (b,then_,else_) -> 
       Lifthenelse (aux b, aux then_, aux else_)
     | Lsequence (a,b) 

--- a/jscomp/core/lam.mli
+++ b/jscomp/core/lam.mli
@@ -194,7 +194,7 @@ type primitive =
   | Pjs_is_instance_array
   | Pcaml_obj_length
   | Pcaml_obj_set_length
-  
+  | Pwrap_exn (* convert either JS exception or OCaml exception into OCaml format *)  
 
 type switch  =
   { sw_numconsts: int;

--- a/jscomp/core/lam_analysis.ml
+++ b/jscomp/core/lam_analysis.ml
@@ -141,6 +141,7 @@ let rec no_side_effects (lam : Lam.t) : bool =
       | Pjs_function_length
       | Pcaml_obj_length
       | Pjs_is_instance_array
+      | Pwrap_exn
         -> true
       | Pjs_string_of_small_array
       | Pcaml_obj_set_length        
@@ -465,6 +466,7 @@ let rec
   
 and eq_primitive ( lhs : Lam.primitive) (rhs : Lam.primitive) = 
   match lhs with 
+  | Pwrap_exn -> rhs = Pwrap_exn
   | Pbytes_to_string ->  rhs = Pbytes_to_string 
   | Pbytes_of_string ->  rhs = Pbytes_of_string
   | Praise -> rhs = Praise

--- a/jscomp/core/lam_compile_group.ml
+++ b/jscomp/core/lam_compile_group.ml
@@ -383,7 +383,7 @@ let lambda_as_module
   begin 
     Js_config.set_current_file filename ;  
 #if BS_DEBUG then    
-    Js_config.set_debug_file "ocaml_typedtree_test.ml";
+    Js_config.set_debug_file "exception_rebound_err.ml";
 #end    
     let lambda_output = compile ~filename output_prefix env sigs lam in
     let (//) = Filename.concat in 

--- a/jscomp/core/lam_compile_primitive.ml
+++ b/jscomp/core/lam_compile_primitive.ml
@@ -46,6 +46,8 @@ let translate  loc
     (prim : Lam.primitive)
     (args : J.expression list) : J.expression = 
   match prim with
+  | Pwrap_exn -> 
+    E.runtime_call Js_config.exn "internalToOCamlException" args 
   | Lam.Praw_js_code_exp s -> 
     E.raw_js_code Exp s  
   | Lam.Praw_js_code_stmt s -> 

--- a/jscomp/core/lam_pass_exits.mli
+++ b/jscomp/core/lam_pass_exits.mli
@@ -16,10 +16,6 @@
     [simplif] module
  *)
 
-val count_helper : Lam.t -> int ref Int_hashtbl.t
 
-type subst_tbl = (Ident.t list * Lam.t) Int_hashtbl.t
-
-val subst_helper : subst_tbl -> (int -> int) -> Lam.t -> Lam.t
 
 val simplify_exits : Lam.t -> Lam.t

--- a/jscomp/core/lam_print.ml
+++ b/jscomp/core/lam_print.ml
@@ -101,6 +101,7 @@ let string_of_loc_kind (loc : Lambda.loc_kind) =
   | Loc_LOC -> "loc_LOC"
 
 let primitive ppf (prim : Lam.primitive) = match prim with 
+  | Pwrap_exn -> fprintf ppf "#exn"
   | Pjs_string_of_small_array -> fprintf ppf "#string_of_small_array"
   | Pjs_is_instance_array -> fprintf ppf "#is_instance_array"
   | Pcaml_obj_length -> fprintf ppf "#obj_length"

--- a/jscomp/others/.depend
+++ b/jscomp/others/.depend
@@ -1,6 +1,6 @@
 node_path.cmj :
 node_fs.cmj : node.cmj js_string.cmj
-node_process.cmj :
+node_process.cmj : js_dict.cmj
 node_module.cmj : node.cmj js_dict.cmj
 js_array.cmj :
 js_string.cmj : js_re.cmi js_array.cmj

--- a/jscomp/others/node_process.ml
+++ b/jscomp/others/node_process.ml
@@ -32,7 +32,7 @@ type t =
     cwd : unit -> string [@bs.meth];
     disconnect : unit -> unit [@bs.meth];
     platform : string;
-    env : string Js.Dict.t;
+    env : string Js_dict.t; (* ocamldep sucks which can not map [Js.Dic.t] to [Js_dict.t]*)
   >   Js.t
 
 external process : t = "" [@@bs.module]

--- a/jscomp/runtime/.depend
+++ b/jscomp/runtime/.depend
@@ -4,7 +4,7 @@ caml_bytes.cmj : caml_bytes.cmi
 caml_obj.cmj : js.cmj caml_array.cmj bs_obj.cmj caml_obj.cmi
 caml_int64.cmj : js_typed_array.cmj js_float.cmj caml_utils.cmj \
     caml_int32.cmj bs_string.cmj caml_int64.cmi
-caml_exceptions.cmj : caml_builtin_exceptions.cmj caml_exceptions.cmi
+caml_exceptions.cmj : js.cmj caml_builtin_exceptions.cmj caml_exceptions.cmi
 caml_utils.cmj : caml_utils.cmi
 caml_sys.cmj : caml_sys.cmi
 caml_io.cmj : js_undefined.cmj js.cmj bs_string.cmj
@@ -32,6 +32,7 @@ caml_module.cmj :
 caml_missing_polyfill.cmj : caml_missing_polyfill.cmi
 bs_string.cmj :
 js_float.cmj :
+js_exn.cmj : js.cmj caml_exceptions.cmj js_exn.cmi
 bs_obj.cmj : js.cmj
 js_nativeint.cmj :
 js_int.cmj :
@@ -61,5 +62,6 @@ js_primitive.cmi : js_undefined.cmi js.cmi
 caml_basic.cmi : js_undefined.cmi js.cmi
 caml_oo.cmi :
 caml_missing_polyfill.cmi :
+js_exn.cmi : js.cmi
 js_null.cmi : js.cmi
 js_undefined.cmi : js.cmi

--- a/jscomp/runtime/Makefile
+++ b/jscomp/runtime/Makefile
@@ -10,7 +10,7 @@ OTHERS= caml_array caml_string caml_bytes\
 	caml_backtrace caml_int32 caml_gc js_typed_array \
 	js_primitive caml_basic caml_oo curry caml_oo_curry caml_module \
 	caml_missing_polyfill\
-	bs_string  js_float bs_obj js_nativeint js_int js_null js_undefined
+	bs_string  js_float js_exn bs_obj js_nativeint js_int js_null js_undefined
 
 SOURCE_LIST= $(OTHERS) caml_builtin_exceptions  block  js js_unsafe
 
@@ -24,7 +24,7 @@ caml_builtin_exceptions.cmj: caml_builtin_exceptions.cmi js_unsafe.cmi
 block.cmj: block.cmi
 caml_int64.cmj : caml_obj.cmj
 # or we can do a post-processing to add missing cmj dependency manually
-
+js_exn.cmj : caml_exceptions.cmj
 $(addsuffix .cmj, $(OTHERS)): caml_builtin_exceptions.cmj  block.cmj js.cmj js_unsafe.cmj
 ## since we use ppx
 $(addsuffix .cmi, $(OTHERS)): js.cmi js_unsafe.cmj js_unsafe.cmi js.cmj

--- a/jscomp/runtime/caml_exceptions.ml
+++ b/jscomp/runtime/caml_exceptions.ml
@@ -60,9 +60,10 @@ let create (str : string) : Caml_builtin_exceptions.exception_block =
   Obj.set_tag (Obj.repr v) 248 (* Obj.object_tag*);
   v 
 
+external isUndefined : 'a -> bool = "#is_undef"
 (** It could be either customized exception or built in exception *)
 let isCamlException e = 
   let slot = Obj.field e 0 in 
-  not (Js.Undefined.testAny slot) &&
+  not (isUndefined slot) &&
   (Obj.tag slot = 248
    || (Js.typeof (Obj.field slot 0) == "string"))

--- a/jscomp/runtime/caml_exceptions.mli
+++ b/jscomp/runtime/caml_exceptions.mli
@@ -34,3 +34,5 @@ val caml_set_oo_id :
 val get_id : unit -> nativeint
 
 val create : string -> Caml_builtin_exceptions.exception_block
+
+val isCamlException : Obj.t -> bool

--- a/jscomp/runtime/caml_sys.ml
+++ b/jscomp/runtime/caml_sys.ml
@@ -43,9 +43,11 @@ function $$caml_sys_getenv(n) {
   }
 |}]
 
+(** TODO: rewrite in OCaml *)
 external caml_sys_getenv : string -> string = "$$caml_sys_getenv"
   [@@bs.val ] (* [@@bs.local] *)
 (* TODO: improve [js_pass_scope] to avoid remove unused n here *)
+
 
 [%%bs.raw{|
 function $$date(){

--- a/jscomp/runtime/js.ml
+++ b/jscomp/runtime/js.ml
@@ -104,11 +104,12 @@ external unsafe_ge : 'a -> 'a -> bool = "#unsafe_ge"
 (* end::utility_functions[]*)
 
 (* tag::nested_built_in_modules[] *)
-(** {3 nested modules}*)
+(** {4 nested modules}*)
 
 module Null = Js_null
 module Undefined = Js_undefined
 module Null_undefined = Js_null_undefined
+module Exn = Js_exn
 (* end::nested_built_in_modules[] *)
 
 (** {8 nested modules} *experimental* API, please refer to

--- a/jscomp/runtime/js.mli
+++ b/jscomp/runtime/js.mli
@@ -89,11 +89,12 @@ external unsafe_ge : 'a -> 'a -> bool = "#unsafe_ge"
 (* end::utility_functions[]*)
 
 (* tag::nested_built_in_modules[] *)
-(** {3 nested modules}*)
+(** {4 nested modules}*)
 
 module Null = Js_null
 module Undefined = Js_undefined
 module Null_undefined = Js_null_undefined
+module Exn = Js_exn
 (* end::nested_built_in_modules[] *)
 
 (** {8 nested modules} *experimental* API, please refer to

--- a/jscomp/runtime/js_exn.ml
+++ b/jscomp/runtime/js_exn.ml
@@ -1,0 +1,105 @@
+(* Copyright (C) 2015-2016 Bloomberg Finance L.P.
+ * 
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In addition to the permissions granted to you by the LGPL, you may combine
+ * or link a "work that uses the Library" with a publicly distributed version
+ * of this file to produce a combined library or application, then distribute
+ * that combined work under the terms of your choosing, with no requirement
+ * to comply with the obligations normally placed on you by section 4 of the
+ * LGPL version 3 (or the corresponding section of a later version of the LGPL
+ * should you choose to use a later version).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
+
+
+type t = 
+  < stack : string Js.undefined ;
+    message : string Js.undefined ; 
+    name : string Js.undefined;
+    fileName : string Js.undefined
+  > Js.t
+
+exception Error of t 
+
+external stack : t -> string option = ""
+  [@@bs.get] [@@bs.return undefined_to_opt]
+
+(**
+   {[
+     exception A of int;;
+     let v = A  3 ;;
+     Obj.tag (Obj.field (Obj.repr v) 0);;
+     - : int = 248
+   ]}
+*)
+let internalToOCamlException (e : Obj.t) =
+  if Caml_exceptions.isCamlException e  then
+    (Obj.magic e  : exn)
+  else Error (Obj.magic (e : Obj.t) : t) 
+
+type error
+external makeError : string -> error = "Error" [@@bs.new]
+
+let error str = 
+  raise (Obj.magic (makeError str : error) : exn)
+
+type eval_error
+external makeEvalError : string -> eval_error = "EvalError" [@@bs.new]
+
+let evalError str = 
+  raise (Obj.magic (makeEvalError str : eval_error) : exn)
+
+type range_error 
+external makeRangeError : string -> range_error = "RangeError" [@@bs.new]
+
+let rangeError str = 
+  raise (Obj.magic (makeRangeError str : range_error) : exn)
+
+type reference_error 
+
+external makeReferenceError : string  -> reference_error = "RerferenceError" [@@bs.new]
+
+let referenceError str = 
+  raise (Obj.magic (makeReferenceError str))
+
+type syntax_error 
+external makeSyntaxError : string -> syntax_error = "SyntaxError" [@@bs.new]
+
+let syntaxError str = 
+  raise (Obj.magic (makeSyntaxError str))
+
+type type_error
+external makeTypeError : string -> type_error = "TypeError" [@@bs.new]
+
+let typeError str = 
+  raise (Obj.magic (makeTypeError str))
+
+type uri_error
+external makeURIError : string -> uri_error = "URIError" [@@bs.new]
+
+let uriError str = 
+  raise (Obj.magic (makeURIError str))
+
+(** TODO add predicate to tell which error is which *)
+(*
+exception EvalError of error
+exception RangeError of error
+exception ReferenceError of error
+exception SyntaxError of error
+exception TypeError of error
+
+ The URIError object represents an error when a global URI handling function was used in a wrong way. 
+exception URIError of error    
+*)
+

--- a/jscomp/runtime/js_exn.mli
+++ b/jscomp/runtime/js_exn.mli
@@ -22,47 +22,28 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
 
-(** *)
+type t = 
+  < stack : string Js.undefined ;
+    message : string Js.undefined ; 
+    name : string Js.undefined;
+    fileName : string Js.undefined
+  > Js.t
 
 
+exception Error of t
 
 
-(** 
-   Could be exported for better inlining
-   It's common that we have 
-   {[ a = caml_set_oo_id([248,"string",0]) ]}
-   This can be inlined as 
-   {[ a = caml_set_oo_id([248,"tag", caml_oo_last_id++]) ]}
-*)
+external stack : t -> string option = ""
+  [@@bs.get] [@@bs.return undefined_to_opt]
 
-let id = ref 0n
+(** Used by the compiler internally *)
+val internalToOCamlException : Obj.t -> exn
 
-
-(* see  #251
-   {[
-     CAMLprim value caml_set_oo_id (value obj) {
-       Field(obj, 1) = oo_last_id;
-       oo_last_id += 2;
-       return obj;
-     }
-
-   ]}*)
-let caml_set_oo_id (b : Caml_builtin_exceptions.exception_block)  = 
-    Obj.set_field (Obj.repr b) 1 (Obj.repr !id);
-    id := Nativeint.add !id  1n; 
-    b
-
-let get_id () = 
-  id := Nativeint.add !id 1n; !id
-
-let create (str : string) : Caml_builtin_exceptions.exception_block = 
-  let v = ( str, get_id ()) in 
-  Obj.set_tag (Obj.repr v) 248 (* Obj.object_tag*);
-  v 
-
-(** It could be either customized exception or built in exception *)
-let isCamlException e = 
-  let slot = Obj.field e 0 in 
-  not (Js.Undefined.testAny slot) &&
-  (Obj.tag slot = 248
-   || (Js.typeof (Obj.field slot 0) == "string"))
+(** Raise Js exception Error object with stacktrace *)
+val error : string -> 'a
+val evalError : string -> 'a
+val rangeError : string -> 'a
+val referenceError :  string -> 'a
+val syntaxError : string -> 'a
+val typeError : string -> 'a
+val uriError :  string -> 'a

--- a/jscomp/runtime/js_undefined.ml
+++ b/jscomp/runtime/js_undefined.ml
@@ -28,6 +28,8 @@ type + 'a t = 'a Js.undefined
 external to_opt : 'a t -> 'a option = "#undefined_to_opt"
 external return : 'a -> 'a t = "%identity"
 external test : 'a t -> bool =  "#is_undef"
+external testAny : 'a -> bool = "#is_undef"
+  
 external empty : 'a t = "undefined"
 [@@bs.val]
 

--- a/jscomp/runtime/js_undefined.mli
+++ b/jscomp/runtime/js_undefined.mli
@@ -33,6 +33,14 @@ external return : 'a -> 'a t = "%identity"
 (** Returns [true] if the given value is [empty] ([undefined]), [false] otherwise *)
 external test : 'a t -> bool =  "#is_undef"
 
+
+(**
+   @since 1.6.1
+   Returns [true] if the given value is [empty] ([undefined])
+*)
+external testAny : 'a -> bool = "#is_undef"
+
+
 (** The empty value, [undefined] *)
 external empty : 'a t = "undefined" [@@bs.val]
 

--- a/jscomp/test/.depend
+++ b/jscomp/test/.depend
@@ -118,6 +118,7 @@ const_test.cmj :
 cont_int_fold_test.cmj :
 cps_test.cmj : mt.cmj ../stdlib/array.cmj
 cross_module_inline_test.cmj :
+custom_error_test.cmj : ../runtime/js.cmj
 debug_keep_test.cmj :
 debugger_test.cmj : ../runtime/js.cmj
 demo.cmj : ../runtime/js.cmj demo_binding.cmj
@@ -141,7 +142,8 @@ event_ffi.cmj : ../stdlib/list.cmj ../runtime/js_unsafe.cmj \
     ../runtime/js.cmj
 exception_alias.cmj : ../stdlib/list.cmj
 exception_raise_test.cmj : mt.cmj
-exception_value_test.cmj :
+exception_rebound_err.cmj : ../runtime/js.cmj
+exception_value_test.cmj : ../runtime/js.cmj
 export_keyword.cmj :
 ext_array.cmj : ../stdlib/list.cmj ../stdlib/array.cmj
 ext_bytes.cmj : ../stdlib/pervasives.cmj ../stdlib/bytes.cmj

--- a/jscomp/test/Makefile
+++ b/jscomp/test/Makefile
@@ -132,7 +132,9 @@ OTHERS := literals a test_ari test_export2 test_internalOO test_obj_simple_ffi t
 	ocaml_parsetree_test\
 	ocaml_typedtree_test\
 	gpr_1484\
-	gpr_1481
+	gpr_1481\
+	custom_error_test\
+	exception_rebound_err
 
 # bs_uncurry_test
 # needs Lam to get rid of Uncurry arity first

--- a/jscomp/test/custom_error_test.js
+++ b/jscomp/test/custom_error_test.js
@@ -1,0 +1,43 @@
+'use strict';
+
+var Js_exn       = require("../../lib/js/js_exn.js");
+var Js_primitive = require("../../lib/js/js_primitive.js");
+
+function test_js_error() {
+  var exit = 0;
+  var e;
+  try {
+    e = JSON.parse(" {\"x\" : }");
+    exit = 1;
+  }
+  catch (exn){
+    if (exn[0] === Js_exn.$$Error) {
+      console.log(Js_primitive.undefined_to_opt(exn[1].stack));
+      return /* None */0;
+    } else {
+      throw exn;
+    }
+  }
+  if (exit === 1) {
+    return /* Some */[e];
+  }
+  
+}
+
+function test_js_error2() {
+  try {
+    return JSON.parse(" {\"x\" : }");
+  }
+  catch (e){
+    if (e[0] === Js_exn.$$Error) {
+      console.log(Js_primitive.undefined_to_opt(e[1].stack));
+      throw e;
+    } else {
+      throw e;
+    }
+  }
+}
+
+exports.test_js_error  = test_js_error;
+exports.test_js_error2 = test_js_error2;
+/* No side effect */

--- a/jscomp/test/custom_error_test.ml
+++ b/jscomp/test/custom_error_test.ml
@@ -1,0 +1,22 @@
+
+
+
+
+let test_js_error () = 
+  match Js.Json.parse {| {"x" : }|} with
+  | (exception
+    Js.Exn.Error err ) ->
+    Js.log @@ Js.Exn.stack err;
+    None
+  | e -> Some e 
+
+
+let test_js_error2 () = 
+  try Js.Json.parse {| {"x" : }|} with
+  |(Js.Exn.Error err ) as e ->
+    Js.log @@ Js.Exn.stack err;
+    raise e
+
+(*let () = 
+  Js.log @@ test_js_error () 
+*)

--- a/jscomp/test/exception_rebound_err.js
+++ b/jscomp/test/exception_rebound_err.js
@@ -1,0 +1,59 @@
+'use strict';
+
+var Caml_exceptions         = require("../../lib/js/caml_exceptions.js");
+var Caml_builtin_exceptions = require("../../lib/js/caml_builtin_exceptions.js");
+
+var A = Caml_exceptions.create("Exception_rebound_err.A");
+
+var B = Caml_exceptions.create("Exception_rebound_err.B");
+
+var C = Caml_exceptions.create("Exception_rebound_err.C");
+
+function test_js_error4() {
+  try {
+    JSON.parse(" {\"x\"}");
+    return 1;
+  }
+  catch (e){
+    var exit = 0;
+    if (e === Caml_builtin_exceptions.not_found) {
+      return 2;
+    } else if (e[0] === Caml_builtin_exceptions.invalid_argument) {
+      if (e[1] === "x") {
+        return 3;
+      } else {
+        exit = 1;
+      }
+    } else {
+      exit = 1;
+    }
+    if (exit === 1) {
+      if (e[0] === A) {
+        if (e[1] !== 2) {
+          if (e === B) {
+            return 5;
+          } else if (e[0] === C && !(e[1] !== 1 || e[2] !== 2)) {
+            return 6;
+          } else {
+            return 7;
+          }
+        } else {
+          return 4;
+        }
+      } else if (e === B) {
+        return 5;
+      } else if (e[0] === C && !(e[1] !== 1 || e[2] !== 2)) {
+        return 6;
+      } else {
+        return 7;
+      }
+    }
+    
+  }
+}
+
+exports.A              = A;
+exports.B              = B;
+exports.C              = C;
+exports.test_js_error4 = test_js_error4;
+/* No side effect */

--- a/jscomp/test/exception_rebound_err.ml
+++ b/jscomp/test/exception_rebound_err.ml
@@ -1,0 +1,12 @@
+exception A of int 
+exception B 
+exception C of int * int 
+
+let test_js_error4 () = 
+  try ignore @@ Js.Json.parse {| {"x"}|}; 1 with
+  | Not_found -> 2
+  | Invalid_argument "x" -> 3 
+  | A 2 -> 4
+  | B -> 5  
+  | C (1,2) -> 6
+  | e -> 7

--- a/jscomp/test/exception_value_test.js
+++ b/jscomp/test/exception_value_test.js
@@ -1,5 +1,9 @@
 'use strict';
 
+var Curry                   = require("../../lib/js/curry.js");
+var Js_exn                  = require("../../lib/js/js_exn.js");
+var Js_primitive            = require("../../lib/js/js_primitive.js");
+var Caml_exceptions         = require("../../lib/js/caml_exceptions.js");
 var Caml_builtin_exceptions = require("../../lib/js/caml_builtin_exceptions.js");
 
 function f() {
@@ -24,7 +28,62 @@ function hh() {
   throw Caml_builtin_exceptions.not_found;
 }
 
-exports.f        = f;
-exports.assert_f = assert_f;
-exports.hh       = hh;
+var A = Caml_exceptions.create("Exception_value_test.A");
+
+var B = Caml_exceptions.create("Exception_value_test.B");
+
+var C = Caml_exceptions.create("Exception_value_test.C");
+
+var u = [
+  A,
+  3
+];
+
+function test_not_found(f, _) {
+  try {
+    return Curry._1(f, /* () */0);
+  }
+  catch (exn){
+    if (exn === Caml_builtin_exceptions.not_found) {
+      return 2;
+    } else {
+      throw exn;
+    }
+  }
+}
+
+function test_js_error2() {
+  try {
+    return JSON.parse(" {\"x\" : }");
+  }
+  catch (e){
+    if (e[0] === Js_exn.$$Error) {
+      console.log(Js_primitive.undefined_to_opt(e[1].stack));
+      throw e;
+    } else {
+      throw e;
+    }
+  }
+}
+
+function test_js_error3() {
+  try {
+    JSON.parse(" {\"x\"}");
+    return 1;
+  }
+  catch (e){
+    return 0;
+  }
+}
+
+exports.f              = f;
+exports.assert_f       = assert_f;
+exports.hh             = hh;
+exports.A              = A;
+exports.B              = B;
+exports.C              = C;
+exports.u              = u;
+exports.test_not_found = test_not_found;
+exports.test_js_error2 = test_js_error2;
+exports.test_js_error3 = test_js_error3;
 /* No side effect */

--- a/jscomp/test/exception_value_test.ml
+++ b/jscomp/test/exception_value_test.ml
@@ -13,4 +13,27 @@ let assert_f x =
 let hh () = 
   let v = raise Not_found in 
   v + 3 
- (* TODO: comment for line column number *)
+(* TODO: comment for line column number *)
+
+exception A of int 
+exception B 
+exception C of int * int 
+let u = A 3 
+let test_not_found f () = 
+  try f () with 
+  Not_found -> 2
+  (** note in ocaml, if such exception is not caught,
+  it will be re-raised *)
+
+
+
+let test_js_error2 () = 
+  try Js.Json.parse {| {"x" : }|} with
+  |(Js.Exn.Error err ) as e ->
+    Js.log @@ Js.Exn.stack err;
+    raise e
+
+let test_js_error3 () = 
+  try ignore @@ Js.Json.parse {| {"x"}|} ; 1 with 
+    e -> 0
+

--- a/lib/js/caml_exceptions.js
+++ b/lib/js/caml_exceptions.js
@@ -24,7 +24,21 @@ function create(str) {
   return v;
 }
 
-exports.caml_set_oo_id = caml_set_oo_id;
-exports.get_id         = get_id;
-exports.create         = create;
+function isCamlException(e) {
+  var slot = e[0];
+  if (slot !== undefined) {
+    if (slot.tag === 248) {
+      return /* true */1;
+    } else {
+      return +(typeof slot[0] === "string");
+    }
+  } else {
+    return /* false */0;
+  }
+}
+
+exports.caml_set_oo_id  = caml_set_oo_id;
+exports.get_id          = get_id;
+exports.create          = create;
+exports.isCamlException = isCamlException;
 /* No side effect */

--- a/lib/js/js.js
+++ b/lib/js/js.js
@@ -7,6 +7,8 @@ var Undefined = 0;
 
 var Null_undefined = 0;
 
+var Exn = 0;
+
 var $$Array = 0;
 
 var $$Boolean = 0;
@@ -38,6 +40,7 @@ var Int = 0;
 exports.Null           = Null;
 exports.Undefined      = Undefined;
 exports.Null_undefined = Null_undefined;
+exports.Exn            = Exn;
 exports.$$Array        = $$Array;
 exports.$$Boolean      = $$Boolean;
 exports.$$Date         = $$Date;

--- a/lib/js/js_exn.js
+++ b/lib/js/js_exn.js
@@ -1,0 +1,56 @@
+'use strict';
+
+var Caml_exceptions = require("./caml_exceptions.js");
+var Caml_exceptions = require("./caml_exceptions.js");
+
+var $$Error = Caml_exceptions.create("Js_exn.Error");
+
+function internalToOCamlException(e) {
+  if (Caml_exceptions.isCamlException(e)) {
+    return e;
+  } else {
+    return [
+            $$Error,
+            e
+          ];
+  }
+}
+
+function error(str) {
+  throw new Error(str);
+}
+
+function evalError(str) {
+  throw new EvalError(str);
+}
+
+function rangeError(str) {
+  throw new RangeError(str);
+}
+
+function referenceError(str) {
+  throw new RerferenceError(str);
+}
+
+function syntaxError(str) {
+  throw new SyntaxError(str);
+}
+
+function typeError(str) {
+  throw new TypeError(str);
+}
+
+function uriError(str) {
+  throw new URIError(str);
+}
+
+exports.$$Error                  = $$Error;
+exports.internalToOCamlException = internalToOCamlException;
+exports.error                    = error;
+exports.evalError                = evalError;
+exports.rangeError               = rangeError;
+exports.referenceError           = referenceError;
+exports.syntaxError              = syntaxError;
+exports.typeError                = typeError;
+exports.uriError                 = uriError;
+/* No side effect */


### PR DESCRIPTION
This commit prepare all runtime support for catching JS exceptions
It also fixed an exposed bug of exit inlining, the solution is we eliminate the jump table alias in the first pass, while  in {!Lam_pass_exists} we explicitly tell the substitution to do `Id` or `Refresh`.
This is a subtle bug, first substitution does not introduce local bound identifiers, however, the second (recursive substitution) will introduce ..