### PR TITLE
Fix typo of '=>' to '->' at Js.Re documentation

### DIFF
--- a/jscomp/others/js_re.mli
+++ b/jscomp/others/js_re.mli
@@ -73,7 +73,7 @@ let contentOf tag xmlString =
   Js.Re.fromString ("<" ^ tag ^ ">(.|\n)*?<\/" ^ tag ^">")
     |> Js.Re.exec xmlString
     |> function
-      | Some result => Some (Js.Re.matches result).(1)
+      | Some result -> Some (Js.Re.matches result).(1)
       | None -> None
 ]}
 *)


### PR DESCRIPTION
Simple typo I found in Js.Re documentation.