### PR TITLE
Fix handing spaces in buildocaml.sh

### DIFF
--- a/scripts/buildocaml.sh
+++ b/scripts/buildocaml.sh
@@ -28,4 +28,4 @@ else
     fi
 fi
 
-cd $OCAML &&  ./configure -prefix $(dirname $(pwd))  -no-ocamldoc -no-ocamlbuild -no-shared-libs -no-curses -no-graph -no-pthread -no-debugger  && make -j9 world.opt && make install  && cd ..
+cd $OCAML &&  ./configure -prefix "$(dirname "$PWD")"  -no-ocamldoc -no-ocamlbuild -no-shared-libs -no-curses -no-graph -no-pthread -no-debugger  && make -j9 world.opt && make install  && cd ..


### PR DESCRIPTION
This commit also gets rid of `$(pwd)` subshell invocation. Instead `$PWD` is used which buys some milliseconds.