### PR TITLE
wip: bsb generator/customize rule support

### DIFF
--- a/docs/docson/build-schema.json
+++ b/docs/docson/build-schema.json
@@ -21,7 +21,7 @@
         "ppx-specs": {
             "type": "array",
             "items": {
-              "type": "string"
+                "type": "string"
             }
         },
         "bs-dependency": {
@@ -38,9 +38,36 @@
             "type": "object",
             "properties": {
                 "cmd": {
-                  "type": "string"
+                    "type": "string"
                 }
             }
+        },
+        "rule-generator": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "command": {
+                    "type": "string"
+                }
+            },
+            "description": "The shell command is running in *dev* time, and you generated could should be checked in, the depedency is tracked properly during dev time,example: `{ \"name\" : \"ocamllex\", \"command\" : \"ocamllex.opt $in -o $out\"}`"
+        },
+        "build-generator": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "edge": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "description": "(WIP) Note that we will add the directory path accordingly"
         },
         "sourceItem": {
             "title": "sourceItem",
@@ -90,6 +117,13 @@
                                     ]
                                 }
                             ]
+                        },
+                        "generators": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/build-generator"
+                            },
+                            "description": "(WIP) Files generated in dev time"
                         },
                         "public": {
                             "oneOf": [
@@ -174,34 +208,34 @@
             "description": "Example: `\"src\"` or `[\"src\", \"test\"]` or `[{\"dir\": \"src\", \"subdirs\": [...]}]`"
         },
         "targetItems": {
-          "type": "object",
-          "properties": {
-            "kind": {
-              "enum": [
-                "native",
-                "bytecode",
-                "js"
-              ],
-              "description": "The compiler to use for the target"
-            },
-            "main": {
-              "type": "string",
-              "description": "Name of the main module used as entry point for this target. 'entry-point' isn't used when this project is built as a dependency."
+            "type": "object",
+            "properties": {
+                "kind": {
+                    "enum": [
+                        "native",
+                        "bytecode",
+                        "js"
+                    ],
+                    "description": "The compiler to use for the target"
+                },
+                "main": {
+                    "type": "string",
+                    "description": "Name of the main module used as entry point for this target. 'entry-point' isn't used when this project is built as a dependency."
+                }
             }
-          }
         },
         "entries": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/targetItems"
-          },
-          "description": "A list of buildable targets"
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/targetItems"
+            },
+            "description": "A list of buildable targets"
         },
         "reason-specs": {
             "type": "object",
             "properties": {
-                "react-jsx" : {
-                    "type" : "boolean",
+                "react-jsx": {
+                    "type": "boolean",
                     "description": "Whether to apply the [Reason-React](https://github.com/reasonml/reason-react)-specific JSX PPX transformation."
                 }
             }
@@ -221,15 +255,15 @@
                         "kind" :
                         {
                             "enum": [
-                            "reset",
-                            "prefix",
-                            "append"
-                        ]
+                                "reset",
+                                "prefix",
+                                "append"
+                            ]
                         },
-                        "flags" : {
+                        "flags": {
                             "type": "array",
                             "items": {
-                              "type": "string"
+                                "type": "string"
                             }
                         }
                     },
@@ -262,7 +296,13 @@
             "$ref": "#/definitions/dependencies",
             "description": "OCaml/Reason dev dependencies of the library, like in package.json. Currently searches in `node_modules`"
         },
-
+        "generators": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/rule-generator"
+            },
+            "description": "(WIP) Pre defined rules"
+        },
         "reason": {
             "$ref": "#/definitions/reason-specs",
             "description": "BuckleScript comes with [Reason](http://facebook.github.io/reason/) by default. Specific configurations here."
@@ -303,14 +343,14 @@
             "type": "boolean",
             "description": "Whether to generate the `.merlin` file for [Merlin](https://github.com/ocaml/merlin). Default: true"
         },
-        "use-stdlib" : {
-            "type" : "boolean",
+        "use-stdlib": {
+            "type": "boolean",
             "description": "(Experimental) whether to use the OCaml standard library. Default: true"
         },
         "bs-external-includes": {
             "type": "array",
             "items": {
-              "type": "string"
+                "type": "string"
             },
             "description": "(Not needed usually) external include directories, which will be applied `-I` to all compilation units"
         },
@@ -321,7 +361,7 @@
         "refmt-flags": {
             "type": "array",
             "items": {
-              "type": "string"
+                "type": "string"
             },
             "description": "(Not needed usually) arguments to pass to `refmt` above. Default: `[\"--print\", \"binary\"]`."
         }

--- a/jscomp/bin/bsb_helper.ml
+++ b/jscomp/bin/bsb_helper.ml
@@ -3998,8 +3998,9 @@ val bsbuild_cache : string
 
 
 
-(** if not added, it is guaranteed the reference equality will 
-    be held
+(** 
+  Currently it is okay to have duplicated module, 
+  In the future, we may emit a warning 
 *)
 val map_update : 
   ?dir:string -> file_group_rouces ->  string -> file_group_rouces

--- a/jscomp/bin/bsdep.ml
+++ b/jscomp/bin/bsdep.ml
@@ -17327,7 +17327,7 @@ val list_variables : Format.formatter -> unit
 
 end = struct
 #1 "lexer.ml"
-# 15 "../ocaml/parsing/lexer.mll"
+# 15 "parsing/lexer.mll"
  
 open Lexing
 open Misc
@@ -18048,7 +18048,7 @@ let () =
     )
 
 
-# 727 "../ocaml/parsing/lexer.ml"
+# 727 "parsing/lexer.ml"
 let __ocaml_lex_tables = {
   Lexing.lex_base = 
    "\000\000\164\255\165\255\224\000\003\001\038\001\073\001\108\001\
@@ -19291,123 +19291,123 @@ let rec token lexbuf =
 and __ocaml_lex_token_rec lexbuf __ocaml_lex_state =
   match Lexing.new_engine __ocaml_lex_tables __ocaml_lex_state lexbuf with
       | 0 ->
-# 767 "../ocaml/parsing/lexer.mll"
+# 767 "parsing/lexer.mll"
                  (
       if not !escaped_newlines then
         raise (Error(Illegal_character (Lexing.lexeme_char lexbuf 0),
                      Location.curr lexbuf));
       update_loc lexbuf None 1 false 0;
       token lexbuf )
-# 1977 "../ocaml/parsing/lexer.ml"
+# 1977 "parsing/lexer.ml"
 
   | 1 ->
-# 774 "../ocaml/parsing/lexer.mll"
+# 774 "parsing/lexer.mll"
       ( update_loc lexbuf None 1 false 0;
         EOL )
-# 1983 "../ocaml/parsing/lexer.ml"
+# 1983 "parsing/lexer.ml"
 
   | 2 ->
-# 777 "../ocaml/parsing/lexer.mll"
+# 777 "parsing/lexer.mll"
       ( token lexbuf )
-# 1988 "../ocaml/parsing/lexer.ml"
+# 1988 "parsing/lexer.ml"
 
   | 3 ->
-# 779 "../ocaml/parsing/lexer.mll"
+# 779 "parsing/lexer.mll"
       ( UNDERSCORE )
-# 1993 "../ocaml/parsing/lexer.ml"
+# 1993 "parsing/lexer.ml"
 
   | 4 ->
-# 781 "../ocaml/parsing/lexer.mll"
+# 781 "parsing/lexer.mll"
       ( TILDE )
-# 1998 "../ocaml/parsing/lexer.ml"
+# 1998 "parsing/lexer.ml"
 
   | 5 ->
-# 783 "../ocaml/parsing/lexer.mll"
+# 783 "parsing/lexer.mll"
       ( LABEL (get_label_name lexbuf) )
-# 2003 "../ocaml/parsing/lexer.ml"
+# 2003 "parsing/lexer.ml"
 
   | 6 ->
-# 785 "../ocaml/parsing/lexer.mll"
+# 785 "parsing/lexer.mll"
       ( warn_latin1 lexbuf; LABEL (get_label_name lexbuf) )
-# 2008 "../ocaml/parsing/lexer.ml"
+# 2008 "parsing/lexer.ml"
 
   | 7 ->
-# 787 "../ocaml/parsing/lexer.mll"
+# 787 "parsing/lexer.mll"
       ( QUESTION )
-# 2013 "../ocaml/parsing/lexer.ml"
+# 2013 "parsing/lexer.ml"
 
   | 8 ->
-# 789 "../ocaml/parsing/lexer.mll"
+# 789 "parsing/lexer.mll"
       ( OPTLABEL (get_label_name lexbuf) )
-# 2018 "../ocaml/parsing/lexer.ml"
+# 2018 "parsing/lexer.ml"
 
   | 9 ->
-# 791 "../ocaml/parsing/lexer.mll"
+# 791 "parsing/lexer.mll"
       ( warn_latin1 lexbuf; OPTLABEL (get_label_name lexbuf) )
-# 2023 "../ocaml/parsing/lexer.ml"
+# 2023 "parsing/lexer.ml"
 
   | 10 ->
-# 793 "../ocaml/parsing/lexer.mll"
+# 793 "parsing/lexer.mll"
       ( let s = Lexing.lexeme lexbuf in
         try Hashtbl.find keyword_table s
         with Not_found -> LIDENT s )
-# 2030 "../ocaml/parsing/lexer.ml"
+# 2030 "parsing/lexer.ml"
 
   | 11 ->
-# 797 "../ocaml/parsing/lexer.mll"
+# 797 "parsing/lexer.mll"
       ( warn_latin1 lexbuf; LIDENT (Lexing.lexeme lexbuf) )
-# 2035 "../ocaml/parsing/lexer.ml"
+# 2035 "parsing/lexer.ml"
 
   | 12 ->
-# 799 "../ocaml/parsing/lexer.mll"
+# 799 "parsing/lexer.mll"
       ( UIDENT(Lexing.lexeme lexbuf) )
-# 2040 "../ocaml/parsing/lexer.ml"
+# 2040 "parsing/lexer.ml"
 
   | 13 ->
-# 801 "../ocaml/parsing/lexer.mll"
+# 801 "parsing/lexer.mll"
       ( warn_latin1 lexbuf; UIDENT(Lexing.lexeme lexbuf) )
-# 2045 "../ocaml/parsing/lexer.ml"
+# 2045 "parsing/lexer.ml"
 
   | 14 ->
-# 803 "../ocaml/parsing/lexer.mll"
+# 803 "parsing/lexer.mll"
       ( try
           INT (cvt_int_literal (Lexing.lexeme lexbuf))
         with Failure _ ->
           raise (Error(Literal_overflow "int", Location.curr lexbuf))
       )
-# 2054 "../ocaml/parsing/lexer.ml"
+# 2054 "parsing/lexer.ml"
 
   | 15 ->
-# 809 "../ocaml/parsing/lexer.mll"
+# 809 "parsing/lexer.mll"
       ( FLOAT (remove_underscores(Lexing.lexeme lexbuf)) )
-# 2059 "../ocaml/parsing/lexer.ml"
+# 2059 "parsing/lexer.ml"
 
   | 16 ->
-# 811 "../ocaml/parsing/lexer.mll"
+# 811 "parsing/lexer.mll"
       ( try
           INT32 (cvt_int32_literal (Lexing.lexeme lexbuf))
         with Failure _ ->
           raise (Error(Literal_overflow "int32", Location.curr lexbuf)) )
-# 2067 "../ocaml/parsing/lexer.ml"
+# 2067 "parsing/lexer.ml"
 
   | 17 ->
-# 816 "../ocaml/parsing/lexer.mll"
+# 816 "parsing/lexer.mll"
       ( try
           INT64 (cvt_int64_literal (Lexing.lexeme lexbuf))
         with Failure _ ->
           raise (Error(Literal_overflow "int64", Location.curr lexbuf)) )
-# 2075 "../ocaml/parsing/lexer.ml"
+# 2075 "parsing/lexer.ml"
 
   | 18 ->
-# 821 "../ocaml/parsing/lexer.mll"
+# 821 "parsing/lexer.mll"
       ( try
           NATIVEINT (cvt_nativeint_literal (Lexing.lexeme lexbuf))
         with Failure _ ->
           raise (Error(Literal_overflow "nativeint", Location.curr lexbuf)) )
-# 2083 "../ocaml/parsing/lexer.ml"
+# 2083 "parsing/lexer.ml"
 
   | 19 ->
-# 826 "../ocaml/parsing/lexer.mll"
+# 826 "parsing/lexer.mll"
       ( reset_string_buffer();
         is_in_string := true;
         let string_start = lexbuf.lex_start_p in
@@ -19416,10 +19416,10 @@ and __ocaml_lex_token_rec lexbuf __ocaml_lex_state =
         is_in_string := false;
         lexbuf.lex_start_p <- string_start;
         STRING (get_stored_string(), None) )
-# 2095 "../ocaml/parsing/lexer.ml"
+# 2095 "parsing/lexer.ml"
 
   | 20 ->
-# 835 "../ocaml/parsing/lexer.mll"
+# 835 "parsing/lexer.mll"
       ( reset_string_buffer();
         let delim = Lexing.lexeme lexbuf in
         let delim = String.sub delim 1 (String.length delim - 2) in
@@ -19430,64 +19430,64 @@ and __ocaml_lex_token_rec lexbuf __ocaml_lex_state =
         is_in_string := false;
         lexbuf.lex_start_p <- string_start;
         STRING (get_stored_string(), Some delim) )
-# 2109 "../ocaml/parsing/lexer.ml"
+# 2109 "parsing/lexer.ml"
 
   | 21 ->
-# 846 "../ocaml/parsing/lexer.mll"
+# 846 "parsing/lexer.mll"
       ( update_loc lexbuf None 1 false 1;
         CHAR (Lexing.lexeme_char lexbuf 1) )
-# 2115 "../ocaml/parsing/lexer.ml"
+# 2115 "parsing/lexer.ml"
 
   | 22 ->
-# 849 "../ocaml/parsing/lexer.mll"
+# 849 "parsing/lexer.mll"
       ( CHAR(Lexing.lexeme_char lexbuf 1) )
-# 2120 "../ocaml/parsing/lexer.ml"
+# 2120 "parsing/lexer.ml"
 
   | 23 ->
-# 851 "../ocaml/parsing/lexer.mll"
+# 851 "parsing/lexer.mll"
       ( CHAR(char_for_backslash (Lexing.lexeme_char lexbuf 2)) )
-# 2125 "../ocaml/parsing/lexer.ml"
+# 2125 "parsing/lexer.ml"
 
   | 24 ->
-# 853 "../ocaml/parsing/lexer.mll"
+# 853 "parsing/lexer.mll"
       ( CHAR(char_for_decimal_code lexbuf 2) )
-# 2130 "../ocaml/parsing/lexer.ml"
+# 2130 "parsing/lexer.ml"
 
   | 25 ->
-# 855 "../ocaml/parsing/lexer.mll"
+# 855 "parsing/lexer.mll"
       ( CHAR(char_for_hexadecimal_code lexbuf 3) )
-# 2135 "../ocaml/parsing/lexer.ml"
+# 2135 "parsing/lexer.ml"
 
   | 26 ->
-# 857 "../ocaml/parsing/lexer.mll"
+# 857 "parsing/lexer.mll"
       ( let l = Lexing.lexeme lexbuf in
         let esc = String.sub l 1 (String.length l - 1) in
         raise (Error(Illegal_escape esc, Location.curr lexbuf))
       )
-# 2143 "../ocaml/parsing/lexer.ml"
+# 2143 "parsing/lexer.ml"
 
   | 27 ->
-# 862 "../ocaml/parsing/lexer.mll"
+# 862 "parsing/lexer.mll"
       ( let s, loc = with_comment_buffer comment lexbuf in
         COMMENT (s, loc) )
-# 2149 "../ocaml/parsing/lexer.ml"
+# 2149 "parsing/lexer.ml"
 
   | 28 ->
-# 865 "../ocaml/parsing/lexer.mll"
+# 865 "parsing/lexer.mll"
       ( let s, loc = with_comment_buffer comment lexbuf in
 
         DOCSTRING (Docstrings.docstring s loc) 
 
 )
-# 2160 "../ocaml/parsing/lexer.ml"
+# 2160 "parsing/lexer.ml"
 
   | 29 ->
 let
-# 872 "../ocaml/parsing/lexer.mll"
+# 872 "parsing/lexer.mll"
                     stars
-# 2166 "../ocaml/parsing/lexer.ml"
+# 2166 "parsing/lexer.ml"
 = Lexing.sub_lexeme lexbuf lexbuf.Lexing.lex_start_pos lexbuf.Lexing.lex_curr_pos in
-# 873 "../ocaml/parsing/lexer.mll"
+# 873 "parsing/lexer.mll"
       ( let s, loc =
           with_comment_buffer
             (fun lexbuf ->
@@ -19496,28 +19496,28 @@ let
             lexbuf
         in
         COMMENT (s, loc) )
-# 2177 "../ocaml/parsing/lexer.ml"
+# 2177 "parsing/lexer.ml"
 
   | 30 ->
-# 882 "../ocaml/parsing/lexer.mll"
+# 882 "parsing/lexer.mll"
       ( if !print_warnings then
           Location.prerr_warning (Location.curr lexbuf) Warnings.Comment_start;
         let s, loc = with_comment_buffer comment lexbuf in
         COMMENT (s, loc) )
-# 2185 "../ocaml/parsing/lexer.ml"
+# 2185 "parsing/lexer.ml"
 
   | 31 ->
 let
-# 886 "../ocaml/parsing/lexer.mll"
+# 886 "parsing/lexer.mll"
                    stars
-# 2191 "../ocaml/parsing/lexer.ml"
+# 2191 "parsing/lexer.ml"
 = Lexing.sub_lexeme lexbuf lexbuf.Lexing.lex_start_pos (lexbuf.Lexing.lex_curr_pos + -2) in
-# 887 "../ocaml/parsing/lexer.mll"
+# 887 "parsing/lexer.mll"
       ( COMMENT (stars, Location.curr lexbuf) )
-# 2195 "../ocaml/parsing/lexer.ml"
+# 2195 "parsing/lexer.ml"
 
   | 32 ->
-# 889 "../ocaml/parsing/lexer.mll"
+# 889 "parsing/lexer.mll"
       ( let loc = Location.curr lexbuf in
         Location.prerr_warning loc Warnings.Comment_not_end;
         lexbuf.Lexing.lex_curr_pos <- lexbuf.Lexing.lex_curr_pos - 1;
@@ -19525,307 +19525,307 @@ let
         lexbuf.lex_curr_p <- { curpos with pos_cnum = curpos.pos_cnum - 1 };
         STAR
       )
-# 2206 "../ocaml/parsing/lexer.ml"
+# 2206 "parsing/lexer.ml"
 
   | 33 ->
 let
-# 896 "../ocaml/parsing/lexer.mll"
+# 896 "parsing/lexer.mll"
                                    num
-# 2212 "../ocaml/parsing/lexer.ml"
+# 2212 "parsing/lexer.ml"
 = Lexing.sub_lexeme lexbuf lexbuf.Lexing.lex_mem.(0) lexbuf.Lexing.lex_mem.(1)
 and
-# 897 "../ocaml/parsing/lexer.mll"
+# 897 "parsing/lexer.mll"
                                            name
-# 2217 "../ocaml/parsing/lexer.ml"
+# 2217 "parsing/lexer.ml"
 = Lexing.sub_lexeme_opt lexbuf lexbuf.Lexing.lex_mem.(3) lexbuf.Lexing.lex_mem.(2) in
-# 899 "../ocaml/parsing/lexer.mll"
+# 899 "parsing/lexer.mll"
       ( update_loc lexbuf name (int_of_string num) true 0;
         token lexbuf
       )
-# 2223 "../ocaml/parsing/lexer.ml"
+# 2223 "parsing/lexer.ml"
 
   | 34 ->
-# 902 "../ocaml/parsing/lexer.mll"
+# 902 "parsing/lexer.mll"
          ( SHARP )
-# 2228 "../ocaml/parsing/lexer.ml"
+# 2228 "parsing/lexer.ml"
 
   | 35 ->
-# 903 "../ocaml/parsing/lexer.mll"
+# 903 "parsing/lexer.mll"
          ( AMPERSAND )
-# 2233 "../ocaml/parsing/lexer.ml"
+# 2233 "parsing/lexer.ml"
 
   | 36 ->
-# 904 "../ocaml/parsing/lexer.mll"
+# 904 "parsing/lexer.mll"
          ( AMPERAMPER )
-# 2238 "../ocaml/parsing/lexer.ml"
+# 2238 "parsing/lexer.ml"
 
   | 37 ->
-# 905 "../ocaml/parsing/lexer.mll"
+# 905 "parsing/lexer.mll"
          ( BACKQUOTE )
-# 2243 "../ocaml/parsing/lexer.ml"
+# 2243 "parsing/lexer.ml"
 
   | 38 ->
-# 906 "../ocaml/parsing/lexer.mll"
+# 906 "parsing/lexer.mll"
          ( QUOTE )
-# 2248 "../ocaml/parsing/lexer.ml"
+# 2248 "parsing/lexer.ml"
 
   | 39 ->
-# 907 "../ocaml/parsing/lexer.mll"
+# 907 "parsing/lexer.mll"
          ( LPAREN )
-# 2253 "../ocaml/parsing/lexer.ml"
+# 2253 "parsing/lexer.ml"
 
   | 40 ->
-# 908 "../ocaml/parsing/lexer.mll"
+# 908 "parsing/lexer.mll"
          ( RPAREN )
-# 2258 "../ocaml/parsing/lexer.ml"
+# 2258 "parsing/lexer.ml"
 
   | 41 ->
-# 909 "../ocaml/parsing/lexer.mll"
+# 909 "parsing/lexer.mll"
          ( STAR )
-# 2263 "../ocaml/parsing/lexer.ml"
+# 2263 "parsing/lexer.ml"
 
   | 42 ->
-# 910 "../ocaml/parsing/lexer.mll"
+# 910 "parsing/lexer.mll"
          ( COMMA )
-# 2268 "../ocaml/parsing/lexer.ml"
+# 2268 "parsing/lexer.ml"
 
   | 43 ->
-# 911 "../ocaml/parsing/lexer.mll"
+# 911 "parsing/lexer.mll"
          ( MINUSGREATER )
-# 2273 "../ocaml/parsing/lexer.ml"
+# 2273 "parsing/lexer.ml"
 
   | 44 ->
-# 912 "../ocaml/parsing/lexer.mll"
+# 912 "parsing/lexer.mll"
          ( DOT )
-# 2278 "../ocaml/parsing/lexer.ml"
+# 2278 "parsing/lexer.ml"
 
   | 45 ->
-# 913 "../ocaml/parsing/lexer.mll"
+# 913 "parsing/lexer.mll"
          ( DOTDOT )
-# 2283 "../ocaml/parsing/lexer.ml"
+# 2283 "parsing/lexer.ml"
 
   | 46 ->
-# 914 "../ocaml/parsing/lexer.mll"
+# 914 "parsing/lexer.mll"
          ( COLON )
-# 2288 "../ocaml/parsing/lexer.ml"
+# 2288 "parsing/lexer.ml"
 
   | 47 ->
-# 915 "../ocaml/parsing/lexer.mll"
+# 915 "parsing/lexer.mll"
          ( COLONCOLON )
-# 2293 "../ocaml/parsing/lexer.ml"
+# 2293 "parsing/lexer.ml"
 
   | 48 ->
-# 916 "../ocaml/parsing/lexer.mll"
+# 916 "parsing/lexer.mll"
          ( COLONEQUAL )
-# 2298 "../ocaml/parsing/lexer.ml"
+# 2298 "parsing/lexer.ml"
 
   | 49 ->
-# 917 "../ocaml/parsing/lexer.mll"
+# 917 "parsing/lexer.mll"
          ( COLONGREATER )
-# 2303 "../ocaml/parsing/lexer.ml"
+# 2303 "parsing/lexer.ml"
 
   | 50 ->
-# 918 "../ocaml/parsing/lexer.mll"
+# 918 "parsing/lexer.mll"
          ( SEMI )
-# 2308 "../ocaml/parsing/lexer.ml"
+# 2308 "parsing/lexer.ml"
 
   | 51 ->
-# 919 "../ocaml/parsing/lexer.mll"
+# 919 "parsing/lexer.mll"
          ( SEMISEMI )
-# 2313 "../ocaml/parsing/lexer.ml"
+# 2313 "parsing/lexer.ml"
 
   | 52 ->
-# 920 "../ocaml/parsing/lexer.mll"
+# 920 "parsing/lexer.mll"
          ( LESS )
-# 2318 "../ocaml/parsing/lexer.ml"
+# 2318 "parsing/lexer.ml"
 
   | 53 ->
-# 921 "../ocaml/parsing/lexer.mll"
+# 921 "parsing/lexer.mll"
          ( LESSMINUS )
-# 2323 "../ocaml/parsing/lexer.ml"
+# 2323 "parsing/lexer.ml"
 
   | 54 ->
-# 922 "../ocaml/parsing/lexer.mll"
+# 922 "parsing/lexer.mll"
          ( EQUAL )
-# 2328 "../ocaml/parsing/lexer.ml"
+# 2328 "parsing/lexer.ml"
 
   | 55 ->
-# 923 "../ocaml/parsing/lexer.mll"
+# 923 "parsing/lexer.mll"
          ( LBRACKET )
-# 2333 "../ocaml/parsing/lexer.ml"
+# 2333 "parsing/lexer.ml"
 
   | 56 ->
-# 924 "../ocaml/parsing/lexer.mll"
+# 924 "parsing/lexer.mll"
          ( LBRACKETBAR )
-# 2338 "../ocaml/parsing/lexer.ml"
+# 2338 "parsing/lexer.ml"
 
   | 57 ->
-# 925 "../ocaml/parsing/lexer.mll"
+# 925 "parsing/lexer.mll"
          ( LBRACKETLESS )
-# 2343 "../ocaml/parsing/lexer.ml"
+# 2343 "parsing/lexer.ml"
 
   | 58 ->
-# 926 "../ocaml/parsing/lexer.mll"
+# 926 "parsing/lexer.mll"
          ( LBRACKETGREATER )
-# 2348 "../ocaml/parsing/lexer.ml"
+# 2348 "parsing/lexer.ml"
 
   | 59 ->
-# 927 "../ocaml/parsing/lexer.mll"
+# 927 "parsing/lexer.mll"
          ( RBRACKET )
-# 2353 "../ocaml/parsing/lexer.ml"
+# 2353 "parsing/lexer.ml"
 
   | 60 ->
-# 928 "../ocaml/parsing/lexer.mll"
+# 928 "parsing/lexer.mll"
          ( LBRACE )
-# 2358 "../ocaml/parsing/lexer.ml"
+# 2358 "parsing/lexer.ml"
 
   | 61 ->
-# 929 "../ocaml/parsing/lexer.mll"
+# 929 "parsing/lexer.mll"
          ( LBRACELESS )
-# 2363 "../ocaml/parsing/lexer.ml"
+# 2363 "parsing/lexer.ml"
 
   | 62 ->
-# 930 "../ocaml/parsing/lexer.mll"
+# 930 "parsing/lexer.mll"
          ( BAR )
-# 2368 "../ocaml/parsing/lexer.ml"
+# 2368 "parsing/lexer.ml"
 
   | 63 ->
-# 931 "../ocaml/parsing/lexer.mll"
+# 931 "parsing/lexer.mll"
          ( BARBAR )
-# 2373 "../ocaml/parsing/lexer.ml"
+# 2373 "parsing/lexer.ml"
 
   | 64 ->
-# 932 "../ocaml/parsing/lexer.mll"
+# 932 "parsing/lexer.mll"
          ( BARRBRACKET )
-# 2378 "../ocaml/parsing/lexer.ml"
+# 2378 "parsing/lexer.ml"
 
   | 65 ->
-# 933 "../ocaml/parsing/lexer.mll"
+# 933 "parsing/lexer.mll"
          ( GREATER )
-# 2383 "../ocaml/parsing/lexer.ml"
+# 2383 "parsing/lexer.ml"
 
   | 66 ->
-# 934 "../ocaml/parsing/lexer.mll"
+# 934 "parsing/lexer.mll"
          ( GREATERRBRACKET )
-# 2388 "../ocaml/parsing/lexer.ml"
+# 2388 "parsing/lexer.ml"
 
   | 67 ->
-# 935 "../ocaml/parsing/lexer.mll"
+# 935 "parsing/lexer.mll"
          ( RBRACE )
-# 2393 "../ocaml/parsing/lexer.ml"
+# 2393 "parsing/lexer.ml"
 
   | 68 ->
-# 936 "../ocaml/parsing/lexer.mll"
+# 936 "parsing/lexer.mll"
          ( GREATERRBRACE )
-# 2398 "../ocaml/parsing/lexer.ml"
+# 2398 "parsing/lexer.ml"
 
   | 69 ->
-# 937 "../ocaml/parsing/lexer.mll"
+# 937 "parsing/lexer.mll"
          ( LBRACKETAT )
-# 2403 "../ocaml/parsing/lexer.ml"
+# 2403 "parsing/lexer.ml"
 
   | 70 ->
-# 938 "../ocaml/parsing/lexer.mll"
+# 938 "parsing/lexer.mll"
          ( LBRACKETPERCENT )
-# 2408 "../ocaml/parsing/lexer.ml"
+# 2408 "parsing/lexer.ml"
 
   | 71 ->
-# 939 "../ocaml/parsing/lexer.mll"
+# 939 "parsing/lexer.mll"
           ( LBRACKETPERCENTPERCENT )
-# 2413 "../ocaml/parsing/lexer.ml"
+# 2413 "parsing/lexer.ml"
 
   | 72 ->
-# 940 "../ocaml/parsing/lexer.mll"
+# 940 "parsing/lexer.mll"
           ( LBRACKETATAT )
-# 2418 "../ocaml/parsing/lexer.ml"
+# 2418 "parsing/lexer.ml"
 
   | 73 ->
-# 941 "../ocaml/parsing/lexer.mll"
+# 941 "parsing/lexer.mll"
            ( LBRACKETATATAT )
-# 2423 "../ocaml/parsing/lexer.ml"
+# 2423 "parsing/lexer.ml"
 
   | 74 ->
-# 942 "../ocaml/parsing/lexer.mll"
+# 942 "parsing/lexer.mll"
          ( BANG )
-# 2428 "../ocaml/parsing/lexer.ml"
+# 2428 "parsing/lexer.ml"
 
   | 75 ->
-# 943 "../ocaml/parsing/lexer.mll"
+# 943 "parsing/lexer.mll"
          ( INFIXOP0 "!=" )
-# 2433 "../ocaml/parsing/lexer.ml"
+# 2433 "parsing/lexer.ml"
 
   | 76 ->
-# 944 "../ocaml/parsing/lexer.mll"
+# 944 "parsing/lexer.mll"
          ( PLUS )
-# 2438 "../ocaml/parsing/lexer.ml"
+# 2438 "parsing/lexer.ml"
 
   | 77 ->
-# 945 "../ocaml/parsing/lexer.mll"
+# 945 "parsing/lexer.mll"
          ( PLUSDOT )
-# 2443 "../ocaml/parsing/lexer.ml"
+# 2443 "parsing/lexer.ml"
 
   | 78 ->
-# 946 "../ocaml/parsing/lexer.mll"
+# 946 "parsing/lexer.mll"
          ( PLUSEQ )
-# 2448 "../ocaml/parsing/lexer.ml"
+# 2448 "parsing/lexer.ml"
 
   | 79 ->
-# 947 "../ocaml/parsing/lexer.mll"
+# 947 "parsing/lexer.mll"
          ( MINUS )
-# 2453 "../ocaml/parsing/lexer.ml"
+# 2453 "parsing/lexer.ml"
 
   | 80 ->
-# 948 "../ocaml/parsing/lexer.mll"
+# 948 "parsing/lexer.mll"
          ( MINUSDOT )
-# 2458 "../ocaml/parsing/lexer.ml"
+# 2458 "parsing/lexer.ml"
 
   | 81 ->
-# 951 "../ocaml/parsing/lexer.mll"
+# 951 "parsing/lexer.mll"
             ( PREFIXOP(Lexing.lexeme lexbuf) )
-# 2463 "../ocaml/parsing/lexer.ml"
+# 2463 "parsing/lexer.ml"
 
   | 82 ->
-# 953 "../ocaml/parsing/lexer.mll"
+# 953 "parsing/lexer.mll"
             ( PREFIXOP(Lexing.lexeme lexbuf) )
-# 2468 "../ocaml/parsing/lexer.ml"
+# 2468 "parsing/lexer.ml"
 
   | 83 ->
-# 955 "../ocaml/parsing/lexer.mll"
+# 955 "parsing/lexer.mll"
             ( INFIXOP0(Lexing.lexeme lexbuf) )
-# 2473 "../ocaml/parsing/lexer.ml"
+# 2473 "parsing/lexer.ml"
 
   | 84 ->
-# 957 "../ocaml/parsing/lexer.mll"
+# 957 "parsing/lexer.mll"
             ( INFIXOP1(Lexing.lexeme lexbuf) )
-# 2478 "../ocaml/parsing/lexer.ml"
+# 2478 "parsing/lexer.ml"
 
   | 85 ->
-# 959 "../ocaml/parsing/lexer.mll"
+# 959 "parsing/lexer.mll"
             ( INFIXOP2(Lexing.lexeme lexbuf) )
-# 2483 "../ocaml/parsing/lexer.ml"
+# 2483 "parsing/lexer.ml"
 
   | 86 ->
-# 961 "../ocaml/parsing/lexer.mll"
+# 961 "parsing/lexer.mll"
             ( INFIXOP4(Lexing.lexeme lexbuf) )
-# 2488 "../ocaml/parsing/lexer.ml"
+# 2488 "parsing/lexer.ml"
 
   | 87 ->
-# 962 "../ocaml/parsing/lexer.mll"
+# 962 "parsing/lexer.mll"
             ( PERCENT )
-# 2493 "../ocaml/parsing/lexer.ml"
+# 2493 "parsing/lexer.ml"
 
   | 88 ->
-# 964 "../ocaml/parsing/lexer.mll"
+# 964 "parsing/lexer.mll"
             ( INFIXOP3(Lexing.lexeme lexbuf) )
-# 2498 "../ocaml/parsing/lexer.ml"
+# 2498 "parsing/lexer.ml"
 
   | 89 ->
-# 966 "../ocaml/parsing/lexer.mll"
+# 966 "parsing/lexer.mll"
             ( SHARPOP(Lexing.lexeme lexbuf) )
-# 2503 "../ocaml/parsing/lexer.ml"
+# 2503 "parsing/lexer.ml"
 
   | 90 ->
-# 967 "../ocaml/parsing/lexer.mll"
+# 967 "parsing/lexer.mll"
         (
       if !if_then_else <> Dir_out then
         if !if_then_else = Dir_if_true then
@@ -19835,14 +19835,14 @@ and
         EOF
         
     )
-# 2516 "../ocaml/parsing/lexer.ml"
+# 2516 "parsing/lexer.ml"
 
   | 91 ->
-# 977 "../ocaml/parsing/lexer.mll"
+# 977 "parsing/lexer.mll"
       ( raise (Error(Illegal_character (Lexing.lexeme_char lexbuf 0),
                      Location.curr lexbuf))
       )
-# 2523 "../ocaml/parsing/lexer.ml"
+# 2523 "parsing/lexer.ml"
 
   | __ocaml_lex_state -> lexbuf.Lexing.refill_buff lexbuf; 
       __ocaml_lex_token_rec lexbuf __ocaml_lex_state
@@ -19852,15 +19852,15 @@ and comment lexbuf =
 and __ocaml_lex_comment_rec lexbuf __ocaml_lex_state =
   match Lexing.engine __ocaml_lex_tables __ocaml_lex_state lexbuf with
       | 0 ->
-# 983 "../ocaml/parsing/lexer.mll"
+# 983 "parsing/lexer.mll"
       ( comment_start_loc := (Location.curr lexbuf) :: !comment_start_loc;
         store_lexeme lexbuf;
         comment lexbuf;
       )
-# 2538 "../ocaml/parsing/lexer.ml"
+# 2538 "parsing/lexer.ml"
 
   | 1 ->
-# 988 "../ocaml/parsing/lexer.mll"
+# 988 "parsing/lexer.mll"
       ( match !comment_start_loc with
         | [] -> assert false
         | [_] -> comment_start_loc := []; Location.curr lexbuf
@@ -19868,10 +19868,10 @@ and __ocaml_lex_comment_rec lexbuf __ocaml_lex_state =
                   store_lexeme lexbuf;
                   comment lexbuf;
        )
-# 2549 "../ocaml/parsing/lexer.ml"
+# 2549 "parsing/lexer.ml"
 
   | 2 ->
-# 996 "../ocaml/parsing/lexer.mll"
+# 996 "parsing/lexer.mll"
       (
         string_start_loc := Location.curr lexbuf;
         store_string_char '"';
@@ -19889,10 +19889,10 @@ and __ocaml_lex_comment_rec lexbuf __ocaml_lex_state =
         is_in_string := false;
         store_string_char '"';
         comment lexbuf )
-# 2570 "../ocaml/parsing/lexer.ml"
+# 2570 "parsing/lexer.ml"
 
   | 3 ->
-# 1014 "../ocaml/parsing/lexer.mll"
+# 1014 "parsing/lexer.mll"
       (
         let delim = Lexing.lexeme lexbuf in
         let delim = String.sub delim 1 (String.length delim - 2) in
@@ -19914,43 +19914,43 @@ and __ocaml_lex_comment_rec lexbuf __ocaml_lex_state =
         store_string delim;
         store_string_char '}';
         comment lexbuf )
-# 2595 "../ocaml/parsing/lexer.ml"
+# 2595 "parsing/lexer.ml"
 
   | 4 ->
-# 1037 "../ocaml/parsing/lexer.mll"
+# 1037 "parsing/lexer.mll"
       ( store_lexeme lexbuf; comment lexbuf )
-# 2600 "../ocaml/parsing/lexer.ml"
+# 2600 "parsing/lexer.ml"
 
   | 5 ->
-# 1039 "../ocaml/parsing/lexer.mll"
+# 1039 "parsing/lexer.mll"
       ( update_loc lexbuf None 1 false 1;
         store_lexeme lexbuf;
         comment lexbuf
       )
-# 2608 "../ocaml/parsing/lexer.ml"
+# 2608 "parsing/lexer.ml"
 
   | 6 ->
-# 1044 "../ocaml/parsing/lexer.mll"
+# 1044 "parsing/lexer.mll"
       ( store_lexeme lexbuf; comment lexbuf )
-# 2613 "../ocaml/parsing/lexer.ml"
+# 2613 "parsing/lexer.ml"
 
   | 7 ->
-# 1046 "../ocaml/parsing/lexer.mll"
+# 1046 "parsing/lexer.mll"
       ( store_lexeme lexbuf; comment lexbuf )
-# 2618 "../ocaml/parsing/lexer.ml"
+# 2618 "parsing/lexer.ml"
 
   | 8 ->
-# 1048 "../ocaml/parsing/lexer.mll"
+# 1048 "parsing/lexer.mll"
       ( store_lexeme lexbuf; comment lexbuf )
-# 2623 "../ocaml/parsing/lexer.ml"
+# 2623 "parsing/lexer.ml"
 
   | 9 ->
-# 1050 "../ocaml/parsing/lexer.mll"
+# 1050 "parsing/lexer.mll"
       ( store_lexeme lexbuf; comment lexbuf )
-# 2628 "../ocaml/parsing/lexer.ml"
+# 2628 "parsing/lexer.ml"
 
   | 10 ->
-# 1052 "../ocaml/parsing/lexer.mll"
+# 1052 "parsing/lexer.mll"
       ( match !comment_start_loc with
         | [] -> assert false
         | loc :: _ ->
@@ -19958,20 +19958,20 @@ and __ocaml_lex_comment_rec lexbuf __ocaml_lex_state =
           comment_start_loc := [];
           raise (Error (Unterminated_comment start, loc))
       )
-# 2639 "../ocaml/parsing/lexer.ml"
+# 2639 "parsing/lexer.ml"
 
   | 11 ->
-# 1060 "../ocaml/parsing/lexer.mll"
+# 1060 "parsing/lexer.mll"
       ( update_loc lexbuf None 1 false 0;
         store_lexeme lexbuf;
         comment lexbuf
       )
-# 2647 "../ocaml/parsing/lexer.ml"
+# 2647 "parsing/lexer.ml"
 
   | 12 ->
-# 1065 "../ocaml/parsing/lexer.mll"
+# 1065 "parsing/lexer.mll"
       ( store_lexeme lexbuf; comment lexbuf )
-# 2652 "../ocaml/parsing/lexer.ml"
+# 2652 "parsing/lexer.ml"
 
   | __ocaml_lex_state -> lexbuf.Lexing.refill_buff lexbuf; 
       __ocaml_lex_comment_rec lexbuf __ocaml_lex_state
@@ -19981,42 +19981,42 @@ and string lexbuf =
 and __ocaml_lex_string_rec lexbuf __ocaml_lex_state =
   match Lexing.new_engine __ocaml_lex_tables __ocaml_lex_state lexbuf with
       | 0 ->
-# 1069 "../ocaml/parsing/lexer.mll"
+# 1069 "parsing/lexer.mll"
       ( () )
-# 2664 "../ocaml/parsing/lexer.ml"
+# 2664 "parsing/lexer.ml"
 
   | 1 ->
 let
-# 1070 "../ocaml/parsing/lexer.mll"
+# 1070 "parsing/lexer.mll"
                                   space
-# 2670 "../ocaml/parsing/lexer.ml"
+# 2670 "parsing/lexer.ml"
 = Lexing.sub_lexeme lexbuf lexbuf.Lexing.lex_mem.(0) lexbuf.Lexing.lex_curr_pos in
-# 1071 "../ocaml/parsing/lexer.mll"
+# 1071 "parsing/lexer.mll"
       ( update_loc lexbuf None 1 false (String.length space);
         string lexbuf
       )
-# 2676 "../ocaml/parsing/lexer.ml"
+# 2676 "parsing/lexer.ml"
 
   | 2 ->
-# 1075 "../ocaml/parsing/lexer.mll"
+# 1075 "parsing/lexer.mll"
       ( store_string_char(char_for_backslash(Lexing.lexeme_char lexbuf 1));
         string lexbuf )
-# 2682 "../ocaml/parsing/lexer.ml"
+# 2682 "parsing/lexer.ml"
 
   | 3 ->
-# 1078 "../ocaml/parsing/lexer.mll"
+# 1078 "parsing/lexer.mll"
       ( store_string_char(char_for_decimal_code lexbuf 1);
          string lexbuf )
-# 2688 "../ocaml/parsing/lexer.ml"
+# 2688 "parsing/lexer.ml"
 
   | 4 ->
-# 1081 "../ocaml/parsing/lexer.mll"
+# 1081 "parsing/lexer.mll"
       ( store_string_char(char_for_hexadecimal_code lexbuf 2);
          string lexbuf )
-# 2694 "../ocaml/parsing/lexer.ml"
+# 2694 "parsing/lexer.ml"
 
   | 5 ->
-# 1084 "../ocaml/parsing/lexer.mll"
+# 1084 "parsing/lexer.mll"
       ( if in_comment ()
         then string lexbuf
         else begin
@@ -20031,29 +20031,29 @@ let
           string lexbuf
         end
       )
-# 2712 "../ocaml/parsing/lexer.ml"
+# 2712 "parsing/lexer.ml"
 
   | 6 ->
-# 1099 "../ocaml/parsing/lexer.mll"
+# 1099 "parsing/lexer.mll"
       ( if not (in_comment ()) then
           Location.prerr_warning (Location.curr lexbuf) Warnings.Eol_in_string;
         update_loc lexbuf None 1 false 0;
         store_lexeme lexbuf;
         string lexbuf
       )
-# 2722 "../ocaml/parsing/lexer.ml"
+# 2722 "parsing/lexer.ml"
 
   | 7 ->
-# 1106 "../ocaml/parsing/lexer.mll"
+# 1106 "parsing/lexer.mll"
       ( is_in_string := false;
         raise (Error (Unterminated_string, !string_start_loc)) )
-# 2728 "../ocaml/parsing/lexer.ml"
+# 2728 "parsing/lexer.ml"
 
   | 8 ->
-# 1109 "../ocaml/parsing/lexer.mll"
+# 1109 "parsing/lexer.mll"
       ( store_string_char(Lexing.lexeme_char lexbuf 0);
         string lexbuf )
-# 2734 "../ocaml/parsing/lexer.ml"
+# 2734 "parsing/lexer.ml"
 
   | __ocaml_lex_state -> lexbuf.Lexing.refill_buff lexbuf; 
       __ocaml_lex_string_rec lexbuf __ocaml_lex_state
@@ -20063,34 +20063,34 @@ and quoted_string delim lexbuf =
 and __ocaml_lex_quoted_string_rec delim lexbuf __ocaml_lex_state =
   match Lexing.engine __ocaml_lex_tables __ocaml_lex_state lexbuf with
       | 0 ->
-# 1114 "../ocaml/parsing/lexer.mll"
+# 1114 "parsing/lexer.mll"
       ( update_loc lexbuf None 1 false 0;
         store_lexeme lexbuf;
         quoted_string delim lexbuf
       )
-# 2749 "../ocaml/parsing/lexer.ml"
+# 2749 "parsing/lexer.ml"
 
   | 1 ->
-# 1119 "../ocaml/parsing/lexer.mll"
+# 1119 "parsing/lexer.mll"
       ( is_in_string := false;
         raise (Error (Unterminated_string, !string_start_loc)) )
-# 2755 "../ocaml/parsing/lexer.ml"
+# 2755 "parsing/lexer.ml"
 
   | 2 ->
-# 1122 "../ocaml/parsing/lexer.mll"
+# 1122 "parsing/lexer.mll"
       (
         let edelim = Lexing.lexeme lexbuf in
         let edelim = String.sub edelim 1 (String.length edelim - 2) in
         if delim = edelim then ()
         else (store_lexeme lexbuf; quoted_string delim lexbuf)
       )
-# 2765 "../ocaml/parsing/lexer.ml"
+# 2765 "parsing/lexer.ml"
 
   | 3 ->
-# 1129 "../ocaml/parsing/lexer.mll"
+# 1129 "parsing/lexer.mll"
       ( store_string_char(Lexing.lexeme_char lexbuf 0);
         quoted_string delim lexbuf )
-# 2771 "../ocaml/parsing/lexer.ml"
+# 2771 "parsing/lexer.ml"
 
   | __ocaml_lex_state -> lexbuf.Lexing.refill_buff lexbuf; 
       __ocaml_lex_quoted_string_rec delim lexbuf __ocaml_lex_state
@@ -20100,26 +20100,26 @@ and skip_sharp_bang lexbuf =
 and __ocaml_lex_skip_sharp_bang_rec lexbuf __ocaml_lex_state =
   match Lexing.engine __ocaml_lex_tables __ocaml_lex_state lexbuf with
       | 0 ->
-# 1134 "../ocaml/parsing/lexer.mll"
+# 1134 "parsing/lexer.mll"
        ( update_loc lexbuf None 3 false 0 )
-# 2783 "../ocaml/parsing/lexer.ml"
+# 2783 "parsing/lexer.ml"
 
   | 1 ->
-# 1136 "../ocaml/parsing/lexer.mll"
+# 1136 "parsing/lexer.mll"
        ( update_loc lexbuf None 1 false 0 )
-# 2788 "../ocaml/parsing/lexer.ml"
+# 2788 "parsing/lexer.ml"
 
   | 2 ->
-# 1137 "../ocaml/parsing/lexer.mll"
+# 1137 "parsing/lexer.mll"
        ( () )
-# 2793 "../ocaml/parsing/lexer.ml"
+# 2793 "parsing/lexer.ml"
 
   | __ocaml_lex_state -> lexbuf.Lexing.refill_buff lexbuf; 
       __ocaml_lex_skip_sharp_bang_rec lexbuf __ocaml_lex_state
 
 ;;
 
-# 1139 "../ocaml/parsing/lexer.mll"
+# 1139 "parsing/lexer.mll"
  
 
   let at_bol lexbuf = 
@@ -20354,7 +20354,7 @@ and __ocaml_lex_skip_sharp_bang_rec lexbuf __ocaml_lex_state =
     preprocessor := Some (init, preprocess)
 
 
-# 3035 "../ocaml/parsing/lexer.ml"
+# 3035 "parsing/lexer.ml"
 
 end
 module Bs_conditional_initial : sig 

--- a/jscomp/bin/bspp.ml
+++ b/jscomp/bin/bspp.ml
@@ -2653,7 +2653,7 @@ val list_variables : Format.formatter -> unit
 
 end = struct
 #1 "lexer.ml"
-# 15 "../ocaml/parsing/lexer.mll"
+# 15 "parsing/lexer.mll"
  
 open Lexing
 open Misc
@@ -3371,7 +3371,7 @@ let () =
     )
 
 
-# 727 "../ocaml/parsing/lexer.ml"
+# 727 "parsing/lexer.ml"
 let __ocaml_lex_tables = {
   Lexing.lex_base = 
    "\000\000\164\255\165\255\224\000\003\001\038\001\073\001\108\001\
@@ -4614,123 +4614,123 @@ let rec token lexbuf =
 and __ocaml_lex_token_rec lexbuf __ocaml_lex_state =
   match Lexing.new_engine __ocaml_lex_tables __ocaml_lex_state lexbuf with
       | 0 ->
-# 767 "../ocaml/parsing/lexer.mll"
+# 767 "parsing/lexer.mll"
                  (
       if not !escaped_newlines then
         raise (Error(Illegal_character (Lexing.lexeme_char lexbuf 0),
                      Location.curr lexbuf));
       update_loc lexbuf None 1 false 0;
       token lexbuf )
-# 1977 "../ocaml/parsing/lexer.ml"
+# 1977 "parsing/lexer.ml"
 
   | 1 ->
-# 774 "../ocaml/parsing/lexer.mll"
+# 774 "parsing/lexer.mll"
       ( update_loc lexbuf None 1 false 0;
         EOL )
-# 1983 "../ocaml/parsing/lexer.ml"
+# 1983 "parsing/lexer.ml"
 
   | 2 ->
-# 777 "../ocaml/parsing/lexer.mll"
+# 777 "parsing/lexer.mll"
       ( token lexbuf )
-# 1988 "../ocaml/parsing/lexer.ml"
+# 1988 "parsing/lexer.ml"
 
   | 3 ->
-# 779 "../ocaml/parsing/lexer.mll"
+# 779 "parsing/lexer.mll"
       ( UNDERSCORE )
-# 1993 "../ocaml/parsing/lexer.ml"
+# 1993 "parsing/lexer.ml"
 
   | 4 ->
-# 781 "../ocaml/parsing/lexer.mll"
+# 781 "parsing/lexer.mll"
       ( TILDE )
-# 1998 "../ocaml/parsing/lexer.ml"
+# 1998 "parsing/lexer.ml"
 
   | 5 ->
-# 783 "../ocaml/parsing/lexer.mll"
+# 783 "parsing/lexer.mll"
       ( LABEL (get_label_name lexbuf) )
-# 2003 "../ocaml/parsing/lexer.ml"
+# 2003 "parsing/lexer.ml"
 
   | 6 ->
-# 785 "../ocaml/parsing/lexer.mll"
+# 785 "parsing/lexer.mll"
       ( warn_latin1 lexbuf; LABEL (get_label_name lexbuf) )
-# 2008 "../ocaml/parsing/lexer.ml"
+# 2008 "parsing/lexer.ml"
 
   | 7 ->
-# 787 "../ocaml/parsing/lexer.mll"
+# 787 "parsing/lexer.mll"
       ( QUESTION )
-# 2013 "../ocaml/parsing/lexer.ml"
+# 2013 "parsing/lexer.ml"
 
   | 8 ->
-# 789 "../ocaml/parsing/lexer.mll"
+# 789 "parsing/lexer.mll"
       ( OPTLABEL (get_label_name lexbuf) )
-# 2018 "../ocaml/parsing/lexer.ml"
+# 2018 "parsing/lexer.ml"
 
   | 9 ->
-# 791 "../ocaml/parsing/lexer.mll"
+# 791 "parsing/lexer.mll"
       ( warn_latin1 lexbuf; OPTLABEL (get_label_name lexbuf) )
-# 2023 "../ocaml/parsing/lexer.ml"
+# 2023 "parsing/lexer.ml"
 
   | 10 ->
-# 793 "../ocaml/parsing/lexer.mll"
+# 793 "parsing/lexer.mll"
       ( let s = Lexing.lexeme lexbuf in
         try Hashtbl.find keyword_table s
         with Not_found -> LIDENT s )
-# 2030 "../ocaml/parsing/lexer.ml"
+# 2030 "parsing/lexer.ml"
 
   | 11 ->
-# 797 "../ocaml/parsing/lexer.mll"
+# 797 "parsing/lexer.mll"
       ( warn_latin1 lexbuf; LIDENT (Lexing.lexeme lexbuf) )
-# 2035 "../ocaml/parsing/lexer.ml"
+# 2035 "parsing/lexer.ml"
 
   | 12 ->
-# 799 "../ocaml/parsing/lexer.mll"
+# 799 "parsing/lexer.mll"
       ( UIDENT(Lexing.lexeme lexbuf) )
-# 2040 "../ocaml/parsing/lexer.ml"
+# 2040 "parsing/lexer.ml"
 
   | 13 ->
-# 801 "../ocaml/parsing/lexer.mll"
+# 801 "parsing/lexer.mll"
       ( warn_latin1 lexbuf; UIDENT(Lexing.lexeme lexbuf) )
-# 2045 "../ocaml/parsing/lexer.ml"
+# 2045 "parsing/lexer.ml"
 
   | 14 ->
-# 803 "../ocaml/parsing/lexer.mll"
+# 803 "parsing/lexer.mll"
       ( try
           INT (cvt_int_literal (Lexing.lexeme lexbuf))
         with Failure _ ->
           raise (Error(Literal_overflow "int", Location.curr lexbuf))
       )
-# 2054 "../ocaml/parsing/lexer.ml"
+# 2054 "parsing/lexer.ml"
 
   | 15 ->
-# 809 "../ocaml/parsing/lexer.mll"
+# 809 "parsing/lexer.mll"
       ( FLOAT (remove_underscores(Lexing.lexeme lexbuf)) )
-# 2059 "../ocaml/parsing/lexer.ml"
+# 2059 "parsing/lexer.ml"
 
   | 16 ->
-# 811 "../ocaml/parsing/lexer.mll"
+# 811 "parsing/lexer.mll"
       ( try
           INT32 (cvt_int32_literal (Lexing.lexeme lexbuf))
         with Failure _ ->
           raise (Error(Literal_overflow "int32", Location.curr lexbuf)) )
-# 2067 "../ocaml/parsing/lexer.ml"
+# 2067 "parsing/lexer.ml"
 
   | 17 ->
-# 816 "../ocaml/parsing/lexer.mll"
+# 816 "parsing/lexer.mll"
       ( try
           INT64 (cvt_int64_literal (Lexing.lexeme lexbuf))
         with Failure _ ->
           raise (Error(Literal_overflow "int64", Location.curr lexbuf)) )
-# 2075 "../ocaml/parsing/lexer.ml"
+# 2075 "parsing/lexer.ml"
 
   | 18 ->
-# 821 "../ocaml/parsing/lexer.mll"
+# 821 "parsing/lexer.mll"
       ( try
           NATIVEINT (cvt_nativeint_literal (Lexing.lexeme lexbuf))
         with Failure _ ->
           raise (Error(Literal_overflow "nativeint", Location.curr lexbuf)) )
-# 2083 "../ocaml/parsing/lexer.ml"
+# 2083 "parsing/lexer.ml"
 
   | 19 ->
-# 826 "../ocaml/parsing/lexer.mll"
+# 826 "parsing/lexer.mll"
       ( reset_string_buffer();
         is_in_string := true;
         let string_start = lexbuf.lex_start_p in
@@ -4739,10 +4739,10 @@ and __ocaml_lex_token_rec lexbuf __ocaml_lex_state =
         is_in_string := false;
         lexbuf.lex_start_p <- string_start;
         STRING (get_stored_string(), None) )
-# 2095 "../ocaml/parsing/lexer.ml"
+# 2095 "parsing/lexer.ml"
 
   | 20 ->
-# 835 "../ocaml/parsing/lexer.mll"
+# 835 "parsing/lexer.mll"
       ( reset_string_buffer();
         let delim = Lexing.lexeme lexbuf in
         let delim = String.sub delim 1 (String.length delim - 2) in
@@ -4753,64 +4753,64 @@ and __ocaml_lex_token_rec lexbuf __ocaml_lex_state =
         is_in_string := false;
         lexbuf.lex_start_p <- string_start;
         STRING (get_stored_string(), Some delim) )
-# 2109 "../ocaml/parsing/lexer.ml"
+# 2109 "parsing/lexer.ml"
 
   | 21 ->
-# 846 "../ocaml/parsing/lexer.mll"
+# 846 "parsing/lexer.mll"
       ( update_loc lexbuf None 1 false 1;
         CHAR (Lexing.lexeme_char lexbuf 1) )
-# 2115 "../ocaml/parsing/lexer.ml"
+# 2115 "parsing/lexer.ml"
 
   | 22 ->
-# 849 "../ocaml/parsing/lexer.mll"
+# 849 "parsing/lexer.mll"
       ( CHAR(Lexing.lexeme_char lexbuf 1) )
-# 2120 "../ocaml/parsing/lexer.ml"
+# 2120 "parsing/lexer.ml"
 
   | 23 ->
-# 851 "../ocaml/parsing/lexer.mll"
+# 851 "parsing/lexer.mll"
       ( CHAR(char_for_backslash (Lexing.lexeme_char lexbuf 2)) )
-# 2125 "../ocaml/parsing/lexer.ml"
+# 2125 "parsing/lexer.ml"
 
   | 24 ->
-# 853 "../ocaml/parsing/lexer.mll"
+# 853 "parsing/lexer.mll"
       ( CHAR(char_for_decimal_code lexbuf 2) )
-# 2130 "../ocaml/parsing/lexer.ml"
+# 2130 "parsing/lexer.ml"
 
   | 25 ->
-# 855 "../ocaml/parsing/lexer.mll"
+# 855 "parsing/lexer.mll"
       ( CHAR(char_for_hexadecimal_code lexbuf 3) )
-# 2135 "../ocaml/parsing/lexer.ml"
+# 2135 "parsing/lexer.ml"
 
   | 26 ->
-# 857 "../ocaml/parsing/lexer.mll"
+# 857 "parsing/lexer.mll"
       ( let l = Lexing.lexeme lexbuf in
         let esc = String.sub l 1 (String.length l - 1) in
         raise (Error(Illegal_escape esc, Location.curr lexbuf))
       )
-# 2143 "../ocaml/parsing/lexer.ml"
+# 2143 "parsing/lexer.ml"
 
   | 27 ->
-# 862 "../ocaml/parsing/lexer.mll"
+# 862 "parsing/lexer.mll"
       ( let s, loc = with_comment_buffer comment lexbuf in
         COMMENT (s, loc) )
-# 2149 "../ocaml/parsing/lexer.ml"
+# 2149 "parsing/lexer.ml"
 
   | 28 ->
-# 865 "../ocaml/parsing/lexer.mll"
+# 865 "parsing/lexer.mll"
       ( let s, loc = with_comment_buffer comment lexbuf in
 
         COMMENT (s,loc)    
 
 )
-# 2160 "../ocaml/parsing/lexer.ml"
+# 2160 "parsing/lexer.ml"
 
   | 29 ->
 let
-# 872 "../ocaml/parsing/lexer.mll"
+# 872 "parsing/lexer.mll"
                     stars
-# 2166 "../ocaml/parsing/lexer.ml"
+# 2166 "parsing/lexer.ml"
 = Lexing.sub_lexeme lexbuf lexbuf.Lexing.lex_start_pos lexbuf.Lexing.lex_curr_pos in
-# 873 "../ocaml/parsing/lexer.mll"
+# 873 "parsing/lexer.mll"
       ( let s, loc =
           with_comment_buffer
             (fun lexbuf ->
@@ -4819,28 +4819,28 @@ let
             lexbuf
         in
         COMMENT (s, loc) )
-# 2177 "../ocaml/parsing/lexer.ml"
+# 2177 "parsing/lexer.ml"
 
   | 30 ->
-# 882 "../ocaml/parsing/lexer.mll"
+# 882 "parsing/lexer.mll"
       ( if !print_warnings then
           Location.prerr_warning (Location.curr lexbuf) Warnings.Comment_start;
         let s, loc = with_comment_buffer comment lexbuf in
         COMMENT (s, loc) )
-# 2185 "../ocaml/parsing/lexer.ml"
+# 2185 "parsing/lexer.ml"
 
   | 31 ->
 let
-# 886 "../ocaml/parsing/lexer.mll"
+# 886 "parsing/lexer.mll"
                    stars
-# 2191 "../ocaml/parsing/lexer.ml"
+# 2191 "parsing/lexer.ml"
 = Lexing.sub_lexeme lexbuf lexbuf.Lexing.lex_start_pos (lexbuf.Lexing.lex_curr_pos + -2) in
-# 887 "../ocaml/parsing/lexer.mll"
+# 887 "parsing/lexer.mll"
       ( COMMENT (stars, Location.curr lexbuf) )
-# 2195 "../ocaml/parsing/lexer.ml"
+# 2195 "parsing/lexer.ml"
 
   | 32 ->
-# 889 "../ocaml/parsing/lexer.mll"
+# 889 "parsing/lexer.mll"
       ( let loc = Location.curr lexbuf in
         Location.prerr_warning loc Warnings.Comment_not_end;
         lexbuf.Lexing.lex_curr_pos <- lexbuf.Lexing.lex_curr_pos - 1;
@@ -4848,307 +4848,307 @@ let
         lexbuf.lex_curr_p <- { curpos with pos_cnum = curpos.pos_cnum - 1 };
         STAR
       )
-# 2206 "../ocaml/parsing/lexer.ml"
+# 2206 "parsing/lexer.ml"
 
   | 33 ->
 let
-# 896 "../ocaml/parsing/lexer.mll"
+# 896 "parsing/lexer.mll"
                                    num
-# 2212 "../ocaml/parsing/lexer.ml"
+# 2212 "parsing/lexer.ml"
 = Lexing.sub_lexeme lexbuf lexbuf.Lexing.lex_mem.(0) lexbuf.Lexing.lex_mem.(1)
 and
-# 897 "../ocaml/parsing/lexer.mll"
+# 897 "parsing/lexer.mll"
                                            name
-# 2217 "../ocaml/parsing/lexer.ml"
+# 2217 "parsing/lexer.ml"
 = Lexing.sub_lexeme_opt lexbuf lexbuf.Lexing.lex_mem.(3) lexbuf.Lexing.lex_mem.(2) in
-# 899 "../ocaml/parsing/lexer.mll"
+# 899 "parsing/lexer.mll"
       ( update_loc lexbuf name (int_of_string num) true 0;
         token lexbuf
       )
-# 2223 "../ocaml/parsing/lexer.ml"
+# 2223 "parsing/lexer.ml"
 
   | 34 ->
-# 902 "../ocaml/parsing/lexer.mll"
+# 902 "parsing/lexer.mll"
          ( SHARP )
-# 2228 "../ocaml/parsing/lexer.ml"
+# 2228 "parsing/lexer.ml"
 
   | 35 ->
-# 903 "../ocaml/parsing/lexer.mll"
+# 903 "parsing/lexer.mll"
          ( AMPERSAND )
-# 2233 "../ocaml/parsing/lexer.ml"
+# 2233 "parsing/lexer.ml"
 
   | 36 ->
-# 904 "../ocaml/parsing/lexer.mll"
+# 904 "parsing/lexer.mll"
          ( AMPERAMPER )
-# 2238 "../ocaml/parsing/lexer.ml"
+# 2238 "parsing/lexer.ml"
 
   | 37 ->
-# 905 "../ocaml/parsing/lexer.mll"
+# 905 "parsing/lexer.mll"
          ( BACKQUOTE )
-# 2243 "../ocaml/parsing/lexer.ml"
+# 2243 "parsing/lexer.ml"
 
   | 38 ->
-# 906 "../ocaml/parsing/lexer.mll"
+# 906 "parsing/lexer.mll"
          ( QUOTE )
-# 2248 "../ocaml/parsing/lexer.ml"
+# 2248 "parsing/lexer.ml"
 
   | 39 ->
-# 907 "../ocaml/parsing/lexer.mll"
+# 907 "parsing/lexer.mll"
          ( LPAREN )
-# 2253 "../ocaml/parsing/lexer.ml"
+# 2253 "parsing/lexer.ml"
 
   | 40 ->
-# 908 "../ocaml/parsing/lexer.mll"
+# 908 "parsing/lexer.mll"
          ( RPAREN )
-# 2258 "../ocaml/parsing/lexer.ml"
+# 2258 "parsing/lexer.ml"
 
   | 41 ->
-# 909 "../ocaml/parsing/lexer.mll"
+# 909 "parsing/lexer.mll"
          ( STAR )
-# 2263 "../ocaml/parsing/lexer.ml"
+# 2263 "parsing/lexer.ml"
 
   | 42 ->
-# 910 "../ocaml/parsing/lexer.mll"
+# 910 "parsing/lexer.mll"
          ( COMMA )
-# 2268 "../ocaml/parsing/lexer.ml"
+# 2268 "parsing/lexer.ml"
 
   | 43 ->
-# 911 "../ocaml/parsing/lexer.mll"
+# 911 "parsing/lexer.mll"
          ( MINUSGREATER )
-# 2273 "../ocaml/parsing/lexer.ml"
+# 2273 "parsing/lexer.ml"
 
   | 44 ->
-# 912 "../ocaml/parsing/lexer.mll"
+# 912 "parsing/lexer.mll"
          ( DOT )
-# 2278 "../ocaml/parsing/lexer.ml"
+# 2278 "parsing/lexer.ml"
 
   | 45 ->
-# 913 "../ocaml/parsing/lexer.mll"
+# 913 "parsing/lexer.mll"
          ( DOTDOT )
-# 2283 "../ocaml/parsing/lexer.ml"
+# 2283 "parsing/lexer.ml"
 
   | 46 ->
-# 914 "../ocaml/parsing/lexer.mll"
+# 914 "parsing/lexer.mll"
          ( COLON )
-# 2288 "../ocaml/parsing/lexer.ml"
+# 2288 "parsing/lexer.ml"
 
   | 47 ->
-# 915 "../ocaml/parsing/lexer.mll"
+# 915 "parsing/lexer.mll"
          ( COLONCOLON )
-# 2293 "../ocaml/parsing/lexer.ml"
+# 2293 "parsing/lexer.ml"
 
   | 48 ->
-# 916 "../ocaml/parsing/lexer.mll"
+# 916 "parsing/lexer.mll"
          ( COLONEQUAL )
-# 2298 "../ocaml/parsing/lexer.ml"
+# 2298 "parsing/lexer.ml"
 
   | 49 ->
-# 917 "../ocaml/parsing/lexer.mll"
+# 917 "parsing/lexer.mll"
          ( COLONGREATER )
-# 2303 "../ocaml/parsing/lexer.ml"
+# 2303 "parsing/lexer.ml"
 
   | 50 ->
-# 918 "../ocaml/parsing/lexer.mll"
+# 918 "parsing/lexer.mll"
          ( SEMI )
-# 2308 "../ocaml/parsing/lexer.ml"
+# 2308 "parsing/lexer.ml"
 
   | 51 ->
-# 919 "../ocaml/parsing/lexer.mll"
+# 919 "parsing/lexer.mll"
          ( SEMISEMI )
-# 2313 "../ocaml/parsing/lexer.ml"
+# 2313 "parsing/lexer.ml"
 
   | 52 ->
-# 920 "../ocaml/parsing/lexer.mll"
+# 920 "parsing/lexer.mll"
          ( LESS )
-# 2318 "../ocaml/parsing/lexer.ml"
+# 2318 "parsing/lexer.ml"
 
   | 53 ->
-# 921 "../ocaml/parsing/lexer.mll"
+# 921 "parsing/lexer.mll"
          ( LESSMINUS )
-# 2323 "../ocaml/parsing/lexer.ml"
+# 2323 "parsing/lexer.ml"
 
   | 54 ->
-# 922 "../ocaml/parsing/lexer.mll"
+# 922 "parsing/lexer.mll"
          ( EQUAL )
-# 2328 "../ocaml/parsing/lexer.ml"
+# 2328 "parsing/lexer.ml"
 
   | 55 ->
-# 923 "../ocaml/parsing/lexer.mll"
+# 923 "parsing/lexer.mll"
          ( LBRACKET )
-# 2333 "../ocaml/parsing/lexer.ml"
+# 2333 "parsing/lexer.ml"
 
   | 56 ->
-# 924 "../ocaml/parsing/lexer.mll"
+# 924 "parsing/lexer.mll"
          ( LBRACKETBAR )
-# 2338 "../ocaml/parsing/lexer.ml"
+# 2338 "parsing/lexer.ml"
 
   | 57 ->
-# 925 "../ocaml/parsing/lexer.mll"
+# 925 "parsing/lexer.mll"
          ( LBRACKETLESS )
-# 2343 "../ocaml/parsing/lexer.ml"
+# 2343 "parsing/lexer.ml"
 
   | 58 ->
-# 926 "../ocaml/parsing/lexer.mll"
+# 926 "parsing/lexer.mll"
          ( LBRACKETGREATER )
-# 2348 "../ocaml/parsing/lexer.ml"
+# 2348 "parsing/lexer.ml"
 
   | 59 ->
-# 927 "../ocaml/parsing/lexer.mll"
+# 927 "parsing/lexer.mll"
          ( RBRACKET )
-# 2353 "../ocaml/parsing/lexer.ml"
+# 2353 "parsing/lexer.ml"
 
   | 60 ->
-# 928 "../ocaml/parsing/lexer.mll"
+# 928 "parsing/lexer.mll"
          ( LBRACE )
-# 2358 "../ocaml/parsing/lexer.ml"
+# 2358 "parsing/lexer.ml"
 
   | 61 ->
-# 929 "../ocaml/parsing/lexer.mll"
+# 929 "parsing/lexer.mll"
          ( LBRACELESS )
-# 2363 "../ocaml/parsing/lexer.ml"
+# 2363 "parsing/lexer.ml"
 
   | 62 ->
-# 930 "../ocaml/parsing/lexer.mll"
+# 930 "parsing/lexer.mll"
          ( BAR )
-# 2368 "../ocaml/parsing/lexer.ml"
+# 2368 "parsing/lexer.ml"
 
   | 63 ->
-# 931 "../ocaml/parsing/lexer.mll"
+# 931 "parsing/lexer.mll"
          ( BARBAR )
-# 2373 "../ocaml/parsing/lexer.ml"
+# 2373 "parsing/lexer.ml"
 
   | 64 ->
-# 932 "../ocaml/parsing/lexer.mll"
+# 932 "parsing/lexer.mll"
          ( BARRBRACKET )
-# 2378 "../ocaml/parsing/lexer.ml"
+# 2378 "parsing/lexer.ml"
 
   | 65 ->
-# 933 "../ocaml/parsing/lexer.mll"
+# 933 "parsing/lexer.mll"
          ( GREATER )
-# 2383 "../ocaml/parsing/lexer.ml"
+# 2383 "parsing/lexer.ml"
 
   | 66 ->
-# 934 "../ocaml/parsing/lexer.mll"
+# 934 "parsing/lexer.mll"
          ( GREATERRBRACKET )
-# 2388 "../ocaml/parsing/lexer.ml"
+# 2388 "parsing/lexer.ml"
 
   | 67 ->
-# 935 "../ocaml/parsing/lexer.mll"
+# 935 "parsing/lexer.mll"
          ( RBRACE )
-# 2393 "../ocaml/parsing/lexer.ml"
+# 2393 "parsing/lexer.ml"
 
   | 68 ->
-# 936 "../ocaml/parsing/lexer.mll"
+# 936 "parsing/lexer.mll"
          ( GREATERRBRACE )
-# 2398 "../ocaml/parsing/lexer.ml"
+# 2398 "parsing/lexer.ml"
 
   | 69 ->
-# 937 "../ocaml/parsing/lexer.mll"
+# 937 "parsing/lexer.mll"
          ( LBRACKETAT )
-# 2403 "../ocaml/parsing/lexer.ml"
+# 2403 "parsing/lexer.ml"
 
   | 70 ->
-# 938 "../ocaml/parsing/lexer.mll"
+# 938 "parsing/lexer.mll"
          ( LBRACKETPERCENT )
-# 2408 "../ocaml/parsing/lexer.ml"
+# 2408 "parsing/lexer.ml"
 
   | 71 ->
-# 939 "../ocaml/parsing/lexer.mll"
+# 939 "parsing/lexer.mll"
           ( LBRACKETPERCENTPERCENT )
-# 2413 "../ocaml/parsing/lexer.ml"
+# 2413 "parsing/lexer.ml"
 
   | 72 ->
-# 940 "../ocaml/parsing/lexer.mll"
+# 940 "parsing/lexer.mll"
           ( LBRACKETATAT )
-# 2418 "../ocaml/parsing/lexer.ml"
+# 2418 "parsing/lexer.ml"
 
   | 73 ->
-# 941 "../ocaml/parsing/lexer.mll"
+# 941 "parsing/lexer.mll"
            ( LBRACKETATATAT )
-# 2423 "../ocaml/parsing/lexer.ml"
+# 2423 "parsing/lexer.ml"
 
   | 74 ->
-# 942 "../ocaml/parsing/lexer.mll"
+# 942 "parsing/lexer.mll"
          ( BANG )
-# 2428 "../ocaml/parsing/lexer.ml"
+# 2428 "parsing/lexer.ml"
 
   | 75 ->
-# 943 "../ocaml/parsing/lexer.mll"
+# 943 "parsing/lexer.mll"
          ( INFIXOP0 "!=" )
-# 2433 "../ocaml/parsing/lexer.ml"
+# 2433 "parsing/lexer.ml"
 
   | 76 ->
-# 944 "../ocaml/parsing/lexer.mll"
+# 944 "parsing/lexer.mll"
          ( PLUS )
-# 2438 "../ocaml/parsing/lexer.ml"
+# 2438 "parsing/lexer.ml"
 
   | 77 ->
-# 945 "../ocaml/parsing/lexer.mll"
+# 945 "parsing/lexer.mll"
          ( PLUSDOT )
-# 2443 "../ocaml/parsing/lexer.ml"
+# 2443 "parsing/lexer.ml"
 
   | 78 ->
-# 946 "../ocaml/parsing/lexer.mll"
+# 946 "parsing/lexer.mll"
          ( PLUSEQ )
-# 2448 "../ocaml/parsing/lexer.ml"
+# 2448 "parsing/lexer.ml"
 
   | 79 ->
-# 947 "../ocaml/parsing/lexer.mll"
+# 947 "parsing/lexer.mll"
          ( MINUS )
-# 2453 "../ocaml/parsing/lexer.ml"
+# 2453 "parsing/lexer.ml"
 
   | 80 ->
-# 948 "../ocaml/parsing/lexer.mll"
+# 948 "parsing/lexer.mll"
          ( MINUSDOT )
-# 2458 "../ocaml/parsing/lexer.ml"
+# 2458 "parsing/lexer.ml"
 
   | 81 ->
-# 951 "../ocaml/parsing/lexer.mll"
+# 951 "parsing/lexer.mll"
             ( PREFIXOP(Lexing.lexeme lexbuf) )
-# 2463 "../ocaml/parsing/lexer.ml"
+# 2463 "parsing/lexer.ml"
 
   | 82 ->
-# 953 "../ocaml/parsing/lexer.mll"
+# 953 "parsing/lexer.mll"
             ( PREFIXOP(Lexing.lexeme lexbuf) )
-# 2468 "../ocaml/parsing/lexer.ml"
+# 2468 "parsing/lexer.ml"
 
   | 83 ->
-# 955 "../ocaml/parsing/lexer.mll"
+# 955 "parsing/lexer.mll"
             ( INFIXOP0(Lexing.lexeme lexbuf) )
-# 2473 "../ocaml/parsing/lexer.ml"
+# 2473 "parsing/lexer.ml"
 
   | 84 ->
-# 957 "../ocaml/parsing/lexer.mll"
+# 957 "parsing/lexer.mll"
             ( INFIXOP1(Lexing.lexeme lexbuf) )
-# 2478 "../ocaml/parsing/lexer.ml"
+# 2478 "parsing/lexer.ml"
 
   | 85 ->
-# 959 "../ocaml/parsing/lexer.mll"
+# 959 "parsing/lexer.mll"
             ( INFIXOP2(Lexing.lexeme lexbuf) )
-# 2483 "../ocaml/parsing/lexer.ml"
+# 2483 "parsing/lexer.ml"
 
   | 86 ->
-# 961 "../ocaml/parsing/lexer.mll"
+# 961 "parsing/lexer.mll"
             ( INFIXOP4(Lexing.lexeme lexbuf) )
-# 2488 "../ocaml/parsing/lexer.ml"
+# 2488 "parsing/lexer.ml"
 
   | 87 ->
-# 962 "../ocaml/parsing/lexer.mll"
+# 962 "parsing/lexer.mll"
             ( PERCENT )
-# 2493 "../ocaml/parsing/lexer.ml"
+# 2493 "parsing/lexer.ml"
 
   | 88 ->
-# 964 "../ocaml/parsing/lexer.mll"
+# 964 "parsing/lexer.mll"
             ( INFIXOP3(Lexing.lexeme lexbuf) )
-# 2498 "../ocaml/parsing/lexer.ml"
+# 2498 "parsing/lexer.ml"
 
   | 89 ->
-# 966 "../ocaml/parsing/lexer.mll"
+# 966 "parsing/lexer.mll"
             ( SHARPOP(Lexing.lexeme lexbuf) )
-# 2503 "../ocaml/parsing/lexer.ml"
+# 2503 "parsing/lexer.ml"
 
   | 90 ->
-# 967 "../ocaml/parsing/lexer.mll"
+# 967 "parsing/lexer.mll"
         (
       if !if_then_else <> Dir_out then
         if !if_then_else = Dir_if_true then
@@ -5158,14 +5158,14 @@ and
         EOF
         
     )
-# 2516 "../ocaml/parsing/lexer.ml"
+# 2516 "parsing/lexer.ml"
 
   | 91 ->
-# 977 "../ocaml/parsing/lexer.mll"
+# 977 "parsing/lexer.mll"
       ( raise (Error(Illegal_character (Lexing.lexeme_char lexbuf 0),
                      Location.curr lexbuf))
       )
-# 2523 "../ocaml/parsing/lexer.ml"
+# 2523 "parsing/lexer.ml"
 
   | __ocaml_lex_state -> lexbuf.Lexing.refill_buff lexbuf; 
       __ocaml_lex_token_rec lexbuf __ocaml_lex_state
@@ -5175,15 +5175,15 @@ and comment lexbuf =
 and __ocaml_lex_comment_rec lexbuf __ocaml_lex_state =
   match Lexing.engine __ocaml_lex_tables __ocaml_lex_state lexbuf with
       | 0 ->
-# 983 "../ocaml/parsing/lexer.mll"
+# 983 "parsing/lexer.mll"
       ( comment_start_loc := (Location.curr lexbuf) :: !comment_start_loc;
         store_lexeme lexbuf;
         comment lexbuf;
       )
-# 2538 "../ocaml/parsing/lexer.ml"
+# 2538 "parsing/lexer.ml"
 
   | 1 ->
-# 988 "../ocaml/parsing/lexer.mll"
+# 988 "parsing/lexer.mll"
       ( match !comment_start_loc with
         | [] -> assert false
         | [_] -> comment_start_loc := []; Location.curr lexbuf
@@ -5191,10 +5191,10 @@ and __ocaml_lex_comment_rec lexbuf __ocaml_lex_state =
                   store_lexeme lexbuf;
                   comment lexbuf;
        )
-# 2549 "../ocaml/parsing/lexer.ml"
+# 2549 "parsing/lexer.ml"
 
   | 2 ->
-# 996 "../ocaml/parsing/lexer.mll"
+# 996 "parsing/lexer.mll"
       (
         string_start_loc := Location.curr lexbuf;
         store_string_char '"';
@@ -5212,10 +5212,10 @@ and __ocaml_lex_comment_rec lexbuf __ocaml_lex_state =
         is_in_string := false;
         store_string_char '"';
         comment lexbuf )
-# 2570 "../ocaml/parsing/lexer.ml"
+# 2570 "parsing/lexer.ml"
 
   | 3 ->
-# 1014 "../ocaml/parsing/lexer.mll"
+# 1014 "parsing/lexer.mll"
       (
         let delim = Lexing.lexeme lexbuf in
         let delim = String.sub delim 1 (String.length delim - 2) in
@@ -5237,43 +5237,43 @@ and __ocaml_lex_comment_rec lexbuf __ocaml_lex_state =
         store_string delim;
         store_string_char '}';
         comment lexbuf )
-# 2595 "../ocaml/parsing/lexer.ml"
+# 2595 "parsing/lexer.ml"
 
   | 4 ->
-# 1037 "../ocaml/parsing/lexer.mll"
+# 1037 "parsing/lexer.mll"
       ( store_lexeme lexbuf; comment lexbuf )
-# 2600 "../ocaml/parsing/lexer.ml"
+# 2600 "parsing/lexer.ml"
 
   | 5 ->
-# 1039 "../ocaml/parsing/lexer.mll"
+# 1039 "parsing/lexer.mll"
       ( update_loc lexbuf None 1 false 1;
         store_lexeme lexbuf;
         comment lexbuf
       )
-# 2608 "../ocaml/parsing/lexer.ml"
+# 2608 "parsing/lexer.ml"
 
   | 6 ->
-# 1044 "../ocaml/parsing/lexer.mll"
+# 1044 "parsing/lexer.mll"
       ( store_lexeme lexbuf; comment lexbuf )
-# 2613 "../ocaml/parsing/lexer.ml"
+# 2613 "parsing/lexer.ml"
 
   | 7 ->
-# 1046 "../ocaml/parsing/lexer.mll"
+# 1046 "parsing/lexer.mll"
       ( store_lexeme lexbuf; comment lexbuf )
-# 2618 "../ocaml/parsing/lexer.ml"
+# 2618 "parsing/lexer.ml"
 
   | 8 ->
-# 1048 "../ocaml/parsing/lexer.mll"
+# 1048 "parsing/lexer.mll"
       ( store_lexeme lexbuf; comment lexbuf )
-# 2623 "../ocaml/parsing/lexer.ml"
+# 2623 "parsing/lexer.ml"
 
   | 9 ->
-# 1050 "../ocaml/parsing/lexer.mll"
+# 1050 "parsing/lexer.mll"
       ( store_lexeme lexbuf; comment lexbuf )
-# 2628 "../ocaml/parsing/lexer.ml"
+# 2628 "parsing/lexer.ml"
 
   | 10 ->
-# 1052 "../ocaml/parsing/lexer.mll"
+# 1052 "parsing/lexer.mll"
       ( match !comment_start_loc with
         | [] -> assert false
         | loc :: _ ->
@@ -5281,20 +5281,20 @@ and __ocaml_lex_comment_rec lexbuf __ocaml_lex_state =
           comment_start_loc := [];
           raise (Error (Unterminated_comment start, loc))
       )
-# 2639 "../ocaml/parsing/lexer.ml"
+# 2639 "parsing/lexer.ml"
 
   | 11 ->
-# 1060 "../ocaml/parsing/lexer.mll"
+# 1060 "parsing/lexer.mll"
       ( update_loc lexbuf None 1 false 0;
         store_lexeme lexbuf;
         comment lexbuf
       )
-# 2647 "../ocaml/parsing/lexer.ml"
+# 2647 "parsing/lexer.ml"
 
   | 12 ->
-# 1065 "../ocaml/parsing/lexer.mll"
+# 1065 "parsing/lexer.mll"
       ( store_lexeme lexbuf; comment lexbuf )
-# 2652 "../ocaml/parsing/lexer.ml"
+# 2652 "parsing/lexer.ml"
 
   | __ocaml_lex_state -> lexbuf.Lexing.refill_buff lexbuf; 
       __ocaml_lex_comment_rec lexbuf __ocaml_lex_state
@@ -5304,42 +5304,42 @@ and string lexbuf =
 and __ocaml_lex_string_rec lexbuf __ocaml_lex_state =
   match Lexing.new_engine __ocaml_lex_tables __ocaml_lex_state lexbuf with
       | 0 ->
-# 1069 "../ocaml/parsing/lexer.mll"
+# 1069 "parsing/lexer.mll"
       ( () )
-# 2664 "../ocaml/parsing/lexer.ml"
+# 2664 "parsing/lexer.ml"
 
   | 1 ->
 let
-# 1070 "../ocaml/parsing/lexer.mll"
+# 1070 "parsing/lexer.mll"
                                   space
-# 2670 "../ocaml/parsing/lexer.ml"
+# 2670 "parsing/lexer.ml"
 = Lexing.sub_lexeme lexbuf lexbuf.Lexing.lex_mem.(0) lexbuf.Lexing.lex_curr_pos in
-# 1071 "../ocaml/parsing/lexer.mll"
+# 1071 "parsing/lexer.mll"
       ( update_loc lexbuf None 1 false (String.length space);
         string lexbuf
       )
-# 2676 "../ocaml/parsing/lexer.ml"
+# 2676 "parsing/lexer.ml"
 
   | 2 ->
-# 1075 "../ocaml/parsing/lexer.mll"
+# 1075 "parsing/lexer.mll"
       ( store_string_char(char_for_backslash(Lexing.lexeme_char lexbuf 1));
         string lexbuf )
-# 2682 "../ocaml/parsing/lexer.ml"
+# 2682 "parsing/lexer.ml"
 
   | 3 ->
-# 1078 "../ocaml/parsing/lexer.mll"
+# 1078 "parsing/lexer.mll"
       ( store_string_char(char_for_decimal_code lexbuf 1);
          string lexbuf )
-# 2688 "../ocaml/parsing/lexer.ml"
+# 2688 "parsing/lexer.ml"
 
   | 4 ->
-# 1081 "../ocaml/parsing/lexer.mll"
+# 1081 "parsing/lexer.mll"
       ( store_string_char(char_for_hexadecimal_code lexbuf 2);
          string lexbuf )
-# 2694 "../ocaml/parsing/lexer.ml"
+# 2694 "parsing/lexer.ml"
 
   | 5 ->
-# 1084 "../ocaml/parsing/lexer.mll"
+# 1084 "parsing/lexer.mll"
       ( if in_comment ()
         then string lexbuf
         else begin
@@ -5354,29 +5354,29 @@ let
           string lexbuf
         end
       )
-# 2712 "../ocaml/parsing/lexer.ml"
+# 2712 "parsing/lexer.ml"
 
   | 6 ->
-# 1099 "../ocaml/parsing/lexer.mll"
+# 1099 "parsing/lexer.mll"
       ( if not (in_comment ()) then
           Location.prerr_warning (Location.curr lexbuf) Warnings.Eol_in_string;
         update_loc lexbuf None 1 false 0;
         store_lexeme lexbuf;
         string lexbuf
       )
-# 2722 "../ocaml/parsing/lexer.ml"
+# 2722 "parsing/lexer.ml"
 
   | 7 ->
-# 1106 "../ocaml/parsing/lexer.mll"
+# 1106 "parsing/lexer.mll"
       ( is_in_string := false;
         raise (Error (Unterminated_string, !string_start_loc)) )
-# 2728 "../ocaml/parsing/lexer.ml"
+# 2728 "parsing/lexer.ml"
 
   | 8 ->
-# 1109 "../ocaml/parsing/lexer.mll"
+# 1109 "parsing/lexer.mll"
       ( store_string_char(Lexing.lexeme_char lexbuf 0);
         string lexbuf )
-# 2734 "../ocaml/parsing/lexer.ml"
+# 2734 "parsing/lexer.ml"
 
   | __ocaml_lex_state -> lexbuf.Lexing.refill_buff lexbuf; 
       __ocaml_lex_string_rec lexbuf __ocaml_lex_state
@@ -5386,34 +5386,34 @@ and quoted_string delim lexbuf =
 and __ocaml_lex_quoted_string_rec delim lexbuf __ocaml_lex_state =
   match Lexing.engine __ocaml_lex_tables __ocaml_lex_state lexbuf with
       | 0 ->
-# 1114 "../ocaml/parsing/lexer.mll"
+# 1114 "parsing/lexer.mll"
       ( update_loc lexbuf None 1 false 0;
         store_lexeme lexbuf;
         quoted_string delim lexbuf
       )
-# 2749 "../ocaml/parsing/lexer.ml"
+# 2749 "parsing/lexer.ml"
 
   | 1 ->
-# 1119 "../ocaml/parsing/lexer.mll"
+# 1119 "parsing/lexer.mll"
       ( is_in_string := false;
         raise (Error (Unterminated_string, !string_start_loc)) )
-# 2755 "../ocaml/parsing/lexer.ml"
+# 2755 "parsing/lexer.ml"
 
   | 2 ->
-# 1122 "../ocaml/parsing/lexer.mll"
+# 1122 "parsing/lexer.mll"
       (
         let edelim = Lexing.lexeme lexbuf in
         let edelim = String.sub edelim 1 (String.length edelim - 2) in
         if delim = edelim then ()
         else (store_lexeme lexbuf; quoted_string delim lexbuf)
       )
-# 2765 "../ocaml/parsing/lexer.ml"
+# 2765 "parsing/lexer.ml"
 
   | 3 ->
-# 1129 "../ocaml/parsing/lexer.mll"
+# 1129 "parsing/lexer.mll"
       ( store_string_char(Lexing.lexeme_char lexbuf 0);
         quoted_string delim lexbuf )
-# 2771 "../ocaml/parsing/lexer.ml"
+# 2771 "parsing/lexer.ml"
 
   | __ocaml_lex_state -> lexbuf.Lexing.refill_buff lexbuf; 
       __ocaml_lex_quoted_string_rec delim lexbuf __ocaml_lex_state
@@ -5423,26 +5423,26 @@ and skip_sharp_bang lexbuf =
 and __ocaml_lex_skip_sharp_bang_rec lexbuf __ocaml_lex_state =
   match Lexing.engine __ocaml_lex_tables __ocaml_lex_state lexbuf with
       | 0 ->
-# 1134 "../ocaml/parsing/lexer.mll"
+# 1134 "parsing/lexer.mll"
        ( update_loc lexbuf None 3 false 0 )
-# 2783 "../ocaml/parsing/lexer.ml"
+# 2783 "parsing/lexer.ml"
 
   | 1 ->
-# 1136 "../ocaml/parsing/lexer.mll"
+# 1136 "parsing/lexer.mll"
        ( update_loc lexbuf None 1 false 0 )
-# 2788 "../ocaml/parsing/lexer.ml"
+# 2788 "parsing/lexer.ml"
 
   | 2 ->
-# 1137 "../ocaml/parsing/lexer.mll"
+# 1137 "parsing/lexer.mll"
        ( () )
-# 2793 "../ocaml/parsing/lexer.ml"
+# 2793 "parsing/lexer.ml"
 
   | __ocaml_lex_state -> lexbuf.Lexing.refill_buff lexbuf; 
       __ocaml_lex_skip_sharp_bang_rec lexbuf __ocaml_lex_state
 
 ;;
 
-# 1139 "../ocaml/parsing/lexer.mll"
+# 1139 "parsing/lexer.mll"
  
 
   let at_bol lexbuf = 
@@ -5627,7 +5627,7 @@ and __ocaml_lex_skip_sharp_bang_rec lexbuf __ocaml_lex_state =
     preprocessor := Some (init, preprocess)
 
 
-# 3035 "../ocaml/parsing/lexer.ml"
+# 3035 "parsing/lexer.ml"
 
 end
 module Bspp_main : sig 

--- a/jscomp/bin/whole_compiler.ml
+++ b/jscomp/bin/whole_compiler.ml
@@ -17096,7 +17096,7 @@ val list_variables : Format.formatter -> unit
 
 end = struct
 #1 "lexer.ml"
-# 15 "../ocaml/parsing/lexer.mll"
+# 15 "parsing/lexer.mll"
  
 open Lexing
 open Misc
@@ -17817,7 +17817,7 @@ let () =
     )
 
 
-# 727 "../ocaml/parsing/lexer.ml"
+# 727 "parsing/lexer.ml"
 let __ocaml_lex_tables = {
   Lexing.lex_base = 
    "\000\000\164\255\165\255\224\000\003\001\038\001\073\001\108\001\
@@ -19060,123 +19060,123 @@ let rec token lexbuf =
 and __ocaml_lex_token_rec lexbuf __ocaml_lex_state =
   match Lexing.new_engine __ocaml_lex_tables __ocaml_lex_state lexbuf with
       | 0 ->
-# 767 "../ocaml/parsing/lexer.mll"
+# 767 "parsing/lexer.mll"
                  (
       if not !escaped_newlines then
         raise (Error(Illegal_character (Lexing.lexeme_char lexbuf 0),
                      Location.curr lexbuf));
       update_loc lexbuf None 1 false 0;
       token lexbuf )
-# 1977 "../ocaml/parsing/lexer.ml"
+# 1977 "parsing/lexer.ml"
 
   | 1 ->
-# 774 "../ocaml/parsing/lexer.mll"
+# 774 "parsing/lexer.mll"
       ( update_loc lexbuf None 1 false 0;
         EOL )
-# 1983 "../ocaml/parsing/lexer.ml"
+# 1983 "parsing/lexer.ml"
 
   | 2 ->
-# 777 "../ocaml/parsing/lexer.mll"
+# 777 "parsing/lexer.mll"
       ( token lexbuf )
-# 1988 "../ocaml/parsing/lexer.ml"
+# 1988 "parsing/lexer.ml"
 
   | 3 ->
-# 779 "../ocaml/parsing/lexer.mll"
+# 779 "parsing/lexer.mll"
       ( UNDERSCORE )
-# 1993 "../ocaml/parsing/lexer.ml"
+# 1993 "parsing/lexer.ml"
 
   | 4 ->
-# 781 "../ocaml/parsing/lexer.mll"
+# 781 "parsing/lexer.mll"
       ( TILDE )
-# 1998 "../ocaml/parsing/lexer.ml"
+# 1998 "parsing/lexer.ml"
 
   | 5 ->
-# 783 "../ocaml/parsing/lexer.mll"
+# 783 "parsing/lexer.mll"
       ( LABEL (get_label_name lexbuf) )
-# 2003 "../ocaml/parsing/lexer.ml"
+# 2003 "parsing/lexer.ml"
 
   | 6 ->
-# 785 "../ocaml/parsing/lexer.mll"
+# 785 "parsing/lexer.mll"
       ( warn_latin1 lexbuf; LABEL (get_label_name lexbuf) )
-# 2008 "../ocaml/parsing/lexer.ml"
+# 2008 "parsing/lexer.ml"
 
   | 7 ->
-# 787 "../ocaml/parsing/lexer.mll"
+# 787 "parsing/lexer.mll"
       ( QUESTION )
-# 2013 "../ocaml/parsing/lexer.ml"
+# 2013 "parsing/lexer.ml"
 
   | 8 ->
-# 789 "../ocaml/parsing/lexer.mll"
+# 789 "parsing/lexer.mll"
       ( OPTLABEL (get_label_name lexbuf) )
-# 2018 "../ocaml/parsing/lexer.ml"
+# 2018 "parsing/lexer.ml"
 
   | 9 ->
-# 791 "../ocaml/parsing/lexer.mll"
+# 791 "parsing/lexer.mll"
       ( warn_latin1 lexbuf; OPTLABEL (get_label_name lexbuf) )
-# 2023 "../ocaml/parsing/lexer.ml"
+# 2023 "parsing/lexer.ml"
 
   | 10 ->
-# 793 "../ocaml/parsing/lexer.mll"
+# 793 "parsing/lexer.mll"
       ( let s = Lexing.lexeme lexbuf in
         try Hashtbl.find keyword_table s
         with Not_found -> LIDENT s )
-# 2030 "../ocaml/parsing/lexer.ml"
+# 2030 "parsing/lexer.ml"
 
   | 11 ->
-# 797 "../ocaml/parsing/lexer.mll"
+# 797 "parsing/lexer.mll"
       ( warn_latin1 lexbuf; LIDENT (Lexing.lexeme lexbuf) )
-# 2035 "../ocaml/parsing/lexer.ml"
+# 2035 "parsing/lexer.ml"
 
   | 12 ->
-# 799 "../ocaml/parsing/lexer.mll"
+# 799 "parsing/lexer.mll"
       ( UIDENT(Lexing.lexeme lexbuf) )
-# 2040 "../ocaml/parsing/lexer.ml"
+# 2040 "parsing/lexer.ml"
 
   | 13 ->
-# 801 "../ocaml/parsing/lexer.mll"
+# 801 "parsing/lexer.mll"
       ( warn_latin1 lexbuf; UIDENT(Lexing.lexeme lexbuf) )
-# 2045 "../ocaml/parsing/lexer.ml"
+# 2045 "parsing/lexer.ml"
 
   | 14 ->
-# 803 "../ocaml/parsing/lexer.mll"
+# 803 "parsing/lexer.mll"
       ( try
           INT (cvt_int_literal (Lexing.lexeme lexbuf))
         with Failure _ ->
           raise (Error(Literal_overflow "int", Location.curr lexbuf))
       )
-# 2054 "../ocaml/parsing/lexer.ml"
+# 2054 "parsing/lexer.ml"
 
   | 15 ->
-# 809 "../ocaml/parsing/lexer.mll"
+# 809 "parsing/lexer.mll"
       ( FLOAT (remove_underscores(Lexing.lexeme lexbuf)) )
-# 2059 "../ocaml/parsing/lexer.ml"
+# 2059 "parsing/lexer.ml"
 
   | 16 ->
-# 811 "../ocaml/parsing/lexer.mll"
+# 811 "parsing/lexer.mll"
       ( try
           INT32 (cvt_int32_literal (Lexing.lexeme lexbuf))
         with Failure _ ->
           raise (Error(Literal_overflow "int32", Location.curr lexbuf)) )
-# 2067 "../ocaml/parsing/lexer.ml"
+# 2067 "parsing/lexer.ml"
 
   | 17 ->
-# 816 "../ocaml/parsing/lexer.mll"
+# 816 "parsing/lexer.mll"
       ( try
           INT64 (cvt_int64_literal (Lexing.lexeme lexbuf))
         with Failure _ ->
           raise (Error(Literal_overflow "int64", Location.curr lexbuf)) )
-# 2075 "../ocaml/parsing/lexer.ml"
+# 2075 "parsing/lexer.ml"
 
   | 18 ->
-# 821 "../ocaml/parsing/lexer.mll"
+# 821 "parsing/lexer.mll"
       ( try
           NATIVEINT (cvt_nativeint_literal (Lexing.lexeme lexbuf))
         with Failure _ ->
           raise (Error(Literal_overflow "nativeint", Location.curr lexbuf)) )
-# 2083 "../ocaml/parsing/lexer.ml"
+# 2083 "parsing/lexer.ml"
 
   | 19 ->
-# 826 "../ocaml/parsing/lexer.mll"
+# 826 "parsing/lexer.mll"
       ( reset_string_buffer();
         is_in_string := true;
         let string_start = lexbuf.lex_start_p in
@@ -19185,10 +19185,10 @@ and __ocaml_lex_token_rec lexbuf __ocaml_lex_state =
         is_in_string := false;
         lexbuf.lex_start_p <- string_start;
         STRING (get_stored_string(), None) )
-# 2095 "../ocaml/parsing/lexer.ml"
+# 2095 "parsing/lexer.ml"
 
   | 20 ->
-# 835 "../ocaml/parsing/lexer.mll"
+# 835 "parsing/lexer.mll"
       ( reset_string_buffer();
         let delim = Lexing.lexeme lexbuf in
         let delim = String.sub delim 1 (String.length delim - 2) in
@@ -19199,64 +19199,64 @@ and __ocaml_lex_token_rec lexbuf __ocaml_lex_state =
         is_in_string := false;
         lexbuf.lex_start_p <- string_start;
         STRING (get_stored_string(), Some delim) )
-# 2109 "../ocaml/parsing/lexer.ml"
+# 2109 "parsing/lexer.ml"
 
   | 21 ->
-# 846 "../ocaml/parsing/lexer.mll"
+# 846 "parsing/lexer.mll"
       ( update_loc lexbuf None 1 false 1;
         CHAR (Lexing.lexeme_char lexbuf 1) )
-# 2115 "../ocaml/parsing/lexer.ml"
+# 2115 "parsing/lexer.ml"
 
   | 22 ->
-# 849 "../ocaml/parsing/lexer.mll"
+# 849 "parsing/lexer.mll"
       ( CHAR(Lexing.lexeme_char lexbuf 1) )
-# 2120 "../ocaml/parsing/lexer.ml"
+# 2120 "parsing/lexer.ml"
 
   | 23 ->
-# 851 "../ocaml/parsing/lexer.mll"
+# 851 "parsing/lexer.mll"
       ( CHAR(char_for_backslash (Lexing.lexeme_char lexbuf 2)) )
-# 2125 "../ocaml/parsing/lexer.ml"
+# 2125 "parsing/lexer.ml"
 
   | 24 ->
-# 853 "../ocaml/parsing/lexer.mll"
+# 853 "parsing/lexer.mll"
       ( CHAR(char_for_decimal_code lexbuf 2) )
-# 2130 "../ocaml/parsing/lexer.ml"
+# 2130 "parsing/lexer.ml"
 
   | 25 ->
-# 855 "../ocaml/parsing/lexer.mll"
+# 855 "parsing/lexer.mll"
       ( CHAR(char_for_hexadecimal_code lexbuf 3) )
-# 2135 "../ocaml/parsing/lexer.ml"
+# 2135 "parsing/lexer.ml"
 
   | 26 ->
-# 857 "../ocaml/parsing/lexer.mll"
+# 857 "parsing/lexer.mll"
       ( let l = Lexing.lexeme lexbuf in
         let esc = String.sub l 1 (String.length l - 1) in
         raise (Error(Illegal_escape esc, Location.curr lexbuf))
       )
-# 2143 "../ocaml/parsing/lexer.ml"
+# 2143 "parsing/lexer.ml"
 
   | 27 ->
-# 862 "../ocaml/parsing/lexer.mll"
+# 862 "parsing/lexer.mll"
       ( let s, loc = with_comment_buffer comment lexbuf in
         COMMENT (s, loc) )
-# 2149 "../ocaml/parsing/lexer.ml"
+# 2149 "parsing/lexer.ml"
 
   | 28 ->
-# 865 "../ocaml/parsing/lexer.mll"
+# 865 "parsing/lexer.mll"
       ( let s, loc = with_comment_buffer comment lexbuf in
 
         DOCSTRING (Docstrings.docstring s loc) 
 
 )
-# 2160 "../ocaml/parsing/lexer.ml"
+# 2160 "parsing/lexer.ml"
 
   | 29 ->
 let
-# 872 "../ocaml/parsing/lexer.mll"
+# 872 "parsing/lexer.mll"
                     stars
-# 2166 "../ocaml/parsing/lexer.ml"
+# 2166 "parsing/lexer.ml"
 = Lexing.sub_lexeme lexbuf lexbuf.Lexing.lex_start_pos lexbuf.Lexing.lex_curr_pos in
-# 873 "../ocaml/parsing/lexer.mll"
+# 873 "parsing/lexer.mll"
       ( let s, loc =
           with_comment_buffer
             (fun lexbuf ->
@@ -19265,28 +19265,28 @@ let
             lexbuf
         in
         COMMENT (s, loc) )
-# 2177 "../ocaml/parsing/lexer.ml"
+# 2177 "parsing/lexer.ml"
 
   | 30 ->
-# 882 "../ocaml/parsing/lexer.mll"
+# 882 "parsing/lexer.mll"
       ( if !print_warnings then
           Location.prerr_warning (Location.curr lexbuf) Warnings.Comment_start;
         let s, loc = with_comment_buffer comment lexbuf in
         COMMENT (s, loc) )
-# 2185 "../ocaml/parsing/lexer.ml"
+# 2185 "parsing/lexer.ml"
 
   | 31 ->
 let
-# 886 "../ocaml/parsing/lexer.mll"
+# 886 "parsing/lexer.mll"
                    stars
-# 2191 "../ocaml/parsing/lexer.ml"
+# 2191 "parsing/lexer.ml"
 = Lexing.sub_lexeme lexbuf lexbuf.Lexing.lex_start_pos (lexbuf.Lexing.lex_curr_pos + -2) in
-# 887 "../ocaml/parsing/lexer.mll"
+# 887 "parsing/lexer.mll"
       ( COMMENT (stars, Location.curr lexbuf) )
-# 2195 "../ocaml/parsing/lexer.ml"
+# 2195 "parsing/lexer.ml"
 
   | 32 ->
-# 889 "../ocaml/parsing/lexer.mll"
+# 889 "parsing/lexer.mll"
       ( let loc = Location.curr lexbuf in
         Location.prerr_warning loc Warnings.Comment_not_end;
         lexbuf.Lexing.lex_curr_pos <- lexbuf.Lexing.lex_curr_pos - 1;
@@ -19294,307 +19294,307 @@ let
         lexbuf.lex_curr_p <- { curpos with pos_cnum = curpos.pos_cnum - 1 };
         STAR
       )
-# 2206 "../ocaml/parsing/lexer.ml"
+# 2206 "parsing/lexer.ml"
 
   | 33 ->
 let
-# 896 "../ocaml/parsing/lexer.mll"
+# 896 "parsing/lexer.mll"
                                    num
-# 2212 "../ocaml/parsing/lexer.ml"
+# 2212 "parsing/lexer.ml"
 = Lexing.sub_lexeme lexbuf lexbuf.Lexing.lex_mem.(0) lexbuf.Lexing.lex_mem.(1)
 and
-# 897 "../ocaml/parsing/lexer.mll"
+# 897 "parsing/lexer.mll"
                                            name
-# 2217 "../ocaml/parsing/lexer.ml"
+# 2217 "parsing/lexer.ml"
 = Lexing.sub_lexeme_opt lexbuf lexbuf.Lexing.lex_mem.(3) lexbuf.Lexing.lex_mem.(2) in
-# 899 "../ocaml/parsing/lexer.mll"
+# 899 "parsing/lexer.mll"
       ( update_loc lexbuf name (int_of_string num) true 0;
         token lexbuf
       )
-# 2223 "../ocaml/parsing/lexer.ml"
+# 2223 "parsing/lexer.ml"
 
   | 34 ->
-# 902 "../ocaml/parsing/lexer.mll"
+# 902 "parsing/lexer.mll"
          ( SHARP )
-# 2228 "../ocaml/parsing/lexer.ml"
+# 2228 "parsing/lexer.ml"
 
   | 35 ->
-# 903 "../ocaml/parsing/lexer.mll"
+# 903 "parsing/lexer.mll"
          ( AMPERSAND )
-# 2233 "../ocaml/parsing/lexer.ml"
+# 2233 "parsing/lexer.ml"
 
   | 36 ->
-# 904 "../ocaml/parsing/lexer.mll"
+# 904 "parsing/lexer.mll"
          ( AMPERAMPER )
-# 2238 "../ocaml/parsing/lexer.ml"
+# 2238 "parsing/lexer.ml"
 
   | 37 ->
-# 905 "../ocaml/parsing/lexer.mll"
+# 905 "parsing/lexer.mll"
          ( BACKQUOTE )
-# 2243 "../ocaml/parsing/lexer.ml"
+# 2243 "parsing/lexer.ml"
 
   | 38 ->
-# 906 "../ocaml/parsing/lexer.mll"
+# 906 "parsing/lexer.mll"
          ( QUOTE )
-# 2248 "../ocaml/parsing/lexer.ml"
+# 2248 "parsing/lexer.ml"
 
   | 39 ->
-# 907 "../ocaml/parsing/lexer.mll"
+# 907 "parsing/lexer.mll"
          ( LPAREN )
-# 2253 "../ocaml/parsing/lexer.ml"
+# 2253 "parsing/lexer.ml"
 
   | 40 ->
-# 908 "../ocaml/parsing/lexer.mll"
+# 908 "parsing/lexer.mll"
          ( RPAREN )
-# 2258 "../ocaml/parsing/lexer.ml"
+# 2258 "parsing/lexer.ml"
 
   | 41 ->
-# 909 "../ocaml/parsing/lexer.mll"
+# 909 "parsing/lexer.mll"
          ( STAR )
-# 2263 "../ocaml/parsing/lexer.ml"
+# 2263 "parsing/lexer.ml"
 
   | 42 ->
-# 910 "../ocaml/parsing/lexer.mll"
+# 910 "parsing/lexer.mll"
          ( COMMA )
-# 2268 "../ocaml/parsing/lexer.ml"
+# 2268 "parsing/lexer.ml"
 
   | 43 ->
-# 911 "../ocaml/parsing/lexer.mll"
+# 911 "parsing/lexer.mll"
          ( MINUSGREATER )
-# 2273 "../ocaml/parsing/lexer.ml"
+# 2273 "parsing/lexer.ml"
 
   | 44 ->
-# 912 "../ocaml/parsing/lexer.mll"
+# 912 "parsing/lexer.mll"
          ( DOT )
-# 2278 "../ocaml/parsing/lexer.ml"
+# 2278 "parsing/lexer.ml"
 
   | 45 ->
-# 913 "../ocaml/parsing/lexer.mll"
+# 913 "parsing/lexer.mll"
          ( DOTDOT )
-# 2283 "../ocaml/parsing/lexer.ml"
+# 2283 "parsing/lexer.ml"
 
   | 46 ->
-# 914 "../ocaml/parsing/lexer.mll"
+# 914 "parsing/lexer.mll"
          ( COLON )
-# 2288 "../ocaml/parsing/lexer.ml"
+# 2288 "parsing/lexer.ml"
 
   | 47 ->
-# 915 "../ocaml/parsing/lexer.mll"
+# 915 "parsing/lexer.mll"
          ( COLONCOLON )
-# 2293 "../ocaml/parsing/lexer.ml"
+# 2293 "parsing/lexer.ml"
 
   | 48 ->
-# 916 "../ocaml/parsing/lexer.mll"
+# 916 "parsing/lexer.mll"
          ( COLONEQUAL )
-# 2298 "../ocaml/parsing/lexer.ml"
+# 2298 "parsing/lexer.ml"
 
   | 49 ->
-# 917 "../ocaml/parsing/lexer.mll"
+# 917 "parsing/lexer.mll"
          ( COLONGREATER )
-# 2303 "../ocaml/parsing/lexer.ml"
+# 2303 "parsing/lexer.ml"
 
   | 50 ->
-# 918 "../ocaml/parsing/lexer.mll"
+# 918 "parsing/lexer.mll"
          ( SEMI )
-# 2308 "../ocaml/parsing/lexer.ml"
+# 2308 "parsing/lexer.ml"
 
   | 51 ->
-# 919 "../ocaml/parsing/lexer.mll"
+# 919 "parsing/lexer.mll"
          ( SEMISEMI )
-# 2313 "../ocaml/parsing/lexer.ml"
+# 2313 "parsing/lexer.ml"
 
   | 52 ->
-# 920 "../ocaml/parsing/lexer.mll"
+# 920 "parsing/lexer.mll"
          ( LESS )
-# 2318 "../ocaml/parsing/lexer.ml"
+# 2318 "parsing/lexer.ml"
 
   | 53 ->
-# 921 "../ocaml/parsing/lexer.mll"
+# 921 "parsing/lexer.mll"
          ( LESSMINUS )
-# 2323 "../ocaml/parsing/lexer.ml"
+# 2323 "parsing/lexer.ml"
 
   | 54 ->
-# 922 "../ocaml/parsing/lexer.mll"
+# 922 "parsing/lexer.mll"
          ( EQUAL )
-# 2328 "../ocaml/parsing/lexer.ml"
+# 2328 "parsing/lexer.ml"
 
   | 55 ->
-# 923 "../ocaml/parsing/lexer.mll"
+# 923 "parsing/lexer.mll"
          ( LBRACKET )
-# 2333 "../ocaml/parsing/lexer.ml"
+# 2333 "parsing/lexer.ml"
 
   | 56 ->
-# 924 "../ocaml/parsing/lexer.mll"
+# 924 "parsing/lexer.mll"
          ( LBRACKETBAR )
-# 2338 "../ocaml/parsing/lexer.ml"
+# 2338 "parsing/lexer.ml"
 
   | 57 ->
-# 925 "../ocaml/parsing/lexer.mll"
+# 925 "parsing/lexer.mll"
          ( LBRACKETLESS )
-# 2343 "../ocaml/parsing/lexer.ml"
+# 2343 "parsing/lexer.ml"
 
   | 58 ->
-# 926 "../ocaml/parsing/lexer.mll"
+# 926 "parsing/lexer.mll"
          ( LBRACKETGREATER )
-# 2348 "../ocaml/parsing/lexer.ml"
+# 2348 "parsing/lexer.ml"
 
   | 59 ->
-# 927 "../ocaml/parsing/lexer.mll"
+# 927 "parsing/lexer.mll"
          ( RBRACKET )
-# 2353 "../ocaml/parsing/lexer.ml"
+# 2353 "parsing/lexer.ml"
 
   | 60 ->
-# 928 "../ocaml/parsing/lexer.mll"
+# 928 "parsing/lexer.mll"
          ( LBRACE )
-# 2358 "../ocaml/parsing/lexer.ml"
+# 2358 "parsing/lexer.ml"
 
   | 61 ->
-# 929 "../ocaml/parsing/lexer.mll"
+# 929 "parsing/lexer.mll"
          ( LBRACELESS )
-# 2363 "../ocaml/parsing/lexer.ml"
+# 2363 "parsing/lexer.ml"
 
   | 62 ->
-# 930 "../ocaml/parsing/lexer.mll"
+# 930 "parsing/lexer.mll"
          ( BAR )
-# 2368 "../ocaml/parsing/lexer.ml"
+# 2368 "parsing/lexer.ml"
 
   | 63 ->
-# 931 "../ocaml/parsing/lexer.mll"
+# 931 "parsing/lexer.mll"
          ( BARBAR )
-# 2373 "../ocaml/parsing/lexer.ml"
+# 2373 "parsing/lexer.ml"
 
   | 64 ->
-# 932 "../ocaml/parsing/lexer.mll"
+# 932 "parsing/lexer.mll"
          ( BARRBRACKET )
-# 2378 "../ocaml/parsing/lexer.ml"
+# 2378 "parsing/lexer.ml"
 
   | 65 ->
-# 933 "../ocaml/parsing/lexer.mll"
+# 933 "parsing/lexer.mll"
          ( GREATER )
-# 2383 "../ocaml/parsing/lexer.ml"
+# 2383 "parsing/lexer.ml"
 
   | 66 ->
-# 934 "../ocaml/parsing/lexer.mll"
+# 934 "parsing/lexer.mll"
          ( GREATERRBRACKET )
-# 2388 "../ocaml/parsing/lexer.ml"
+# 2388 "parsing/lexer.ml"
 
   | 67 ->
-# 935 "../ocaml/parsing/lexer.mll"
+# 935 "parsing/lexer.mll"
          ( RBRACE )
-# 2393 "../ocaml/parsing/lexer.ml"
+# 2393 "parsing/lexer.ml"
 
   | 68 ->
-# 936 "../ocaml/parsing/lexer.mll"
+# 936 "parsing/lexer.mll"
          ( GREATERRBRACE )
-# 2398 "../ocaml/parsing/lexer.ml"
+# 2398 "parsing/lexer.ml"
 
   | 69 ->
-# 937 "../ocaml/parsing/lexer.mll"
+# 937 "parsing/lexer.mll"
          ( LBRACKETAT )
-# 2403 "../ocaml/parsing/lexer.ml"
+# 2403 "parsing/lexer.ml"
 
   | 70 ->
-# 938 "../ocaml/parsing/lexer.mll"
+# 938 "parsing/lexer.mll"
          ( LBRACKETPERCENT )
-# 2408 "../ocaml/parsing/lexer.ml"
+# 2408 "parsing/lexer.ml"
 
   | 71 ->
-# 939 "../ocaml/parsing/lexer.mll"
+# 939 "parsing/lexer.mll"
           ( LBRACKETPERCENTPERCENT )
-# 2413 "../ocaml/parsing/lexer.ml"
+# 2413 "parsing/lexer.ml"
 
   | 72 ->
-# 940 "../ocaml/parsing/lexer.mll"
+# 940 "parsing/lexer.mll"
           ( LBRACKETATAT )
-# 2418 "../ocaml/parsing/lexer.ml"
+# 2418 "parsing/lexer.ml"
 
   | 73 ->
-# 941 "../ocaml/parsing/lexer.mll"
+# 941 "parsing/lexer.mll"
            ( LBRACKETATATAT )
-# 2423 "../ocaml/parsing/lexer.ml"
+# 2423 "parsing/lexer.ml"
 
   | 74 ->
-# 942 "../ocaml/parsing/lexer.mll"
+# 942 "parsing/lexer.mll"
          ( BANG )
-# 2428 "../ocaml/parsing/lexer.ml"
+# 2428 "parsing/lexer.ml"
 
   | 75 ->
-# 943 "../ocaml/parsing/lexer.mll"
+# 943 "parsing/lexer.mll"
          ( INFIXOP0 "!=" )
-# 2433 "../ocaml/parsing/lexer.ml"
+# 2433 "parsing/lexer.ml"
 
   | 76 ->
-# 944 "../ocaml/parsing/lexer.mll"
+# 944 "parsing/lexer.mll"
          ( PLUS )
-# 2438 "../ocaml/parsing/lexer.ml"
+# 2438 "parsing/lexer.ml"
 
   | 77 ->
-# 945 "../ocaml/parsing/lexer.mll"
+# 945 "parsing/lexer.mll"
          ( PLUSDOT )
-# 2443 "../ocaml/parsing/lexer.ml"
+# 2443 "parsing/lexer.ml"
 
   | 78 ->
-# 946 "../ocaml/parsing/lexer.mll"
+# 946 "parsing/lexer.mll"
          ( PLUSEQ )
-# 2448 "../ocaml/parsing/lexer.ml"
+# 2448 "parsing/lexer.ml"
 
   | 79 ->
-# 947 "../ocaml/parsing/lexer.mll"
+# 947 "parsing/lexer.mll"
          ( MINUS )
-# 2453 "../ocaml/parsing/lexer.ml"
+# 2453 "parsing/lexer.ml"
 
   | 80 ->
-# 948 "../ocaml/parsing/lexer.mll"
+# 948 "parsing/lexer.mll"
          ( MINUSDOT )
-# 2458 "../ocaml/parsing/lexer.ml"
+# 2458 "parsing/lexer.ml"
 
   | 81 ->
-# 951 "../ocaml/parsing/lexer.mll"
+# 951 "parsing/lexer.mll"
             ( PREFIXOP(Lexing.lexeme lexbuf) )
-# 2463 "../ocaml/parsing/lexer.ml"
+# 2463 "parsing/lexer.ml"
 
   | 82 ->
-# 953 "../ocaml/parsing/lexer.mll"
+# 953 "parsing/lexer.mll"
             ( PREFIXOP(Lexing.lexeme lexbuf) )
-# 2468 "../ocaml/parsing/lexer.ml"
+# 2468 "parsing/lexer.ml"
 
   | 83 ->
-# 955 "../ocaml/parsing/lexer.mll"
+# 955 "parsing/lexer.mll"
             ( INFIXOP0(Lexing.lexeme lexbuf) )
-# 2473 "../ocaml/parsing/lexer.ml"
+# 2473 "parsing/lexer.ml"
 
   | 84 ->
-# 957 "../ocaml/parsing/lexer.mll"
+# 957 "parsing/lexer.mll"
             ( INFIXOP1(Lexing.lexeme lexbuf) )
-# 2478 "../ocaml/parsing/lexer.ml"
+# 2478 "parsing/lexer.ml"
 
   | 85 ->
-# 959 "../ocaml/parsing/lexer.mll"
+# 959 "parsing/lexer.mll"
             ( INFIXOP2(Lexing.lexeme lexbuf) )
-# 2483 "../ocaml/parsing/lexer.ml"
+# 2483 "parsing/lexer.ml"
 
   | 86 ->
-# 961 "../ocaml/parsing/lexer.mll"
+# 961 "parsing/lexer.mll"
             ( INFIXOP4(Lexing.lexeme lexbuf) )
-# 2488 "../ocaml/parsing/lexer.ml"
+# 2488 "parsing/lexer.ml"
 
   | 87 ->
-# 962 "../ocaml/parsing/lexer.mll"
+# 962 "parsing/lexer.mll"
             ( PERCENT )
-# 2493 "../ocaml/parsing/lexer.ml"
+# 2493 "parsing/lexer.ml"
 
   | 88 ->
-# 964 "../ocaml/parsing/lexer.mll"
+# 964 "parsing/lexer.mll"
             ( INFIXOP3(Lexing.lexeme lexbuf) )
-# 2498 "../ocaml/parsing/lexer.ml"
+# 2498 "parsing/lexer.ml"
 
   | 89 ->
-# 966 "../ocaml/parsing/lexer.mll"
+# 966 "parsing/lexer.mll"
             ( SHARPOP(Lexing.lexeme lexbuf) )
-# 2503 "../ocaml/parsing/lexer.ml"
+# 2503 "parsing/lexer.ml"
 
   | 90 ->
-# 967 "../ocaml/parsing/lexer.mll"
+# 967 "parsing/lexer.mll"
         (
       if !if_then_else <> Dir_out then
         if !if_then_else = Dir_if_true then
@@ -19604,14 +19604,14 @@ and
         EOF
         
     )
-# 2516 "../ocaml/parsing/lexer.ml"
+# 2516 "parsing/lexer.ml"
 
   | 91 ->
-# 977 "../ocaml/parsing/lexer.mll"
+# 977 "parsing/lexer.mll"
       ( raise (Error(Illegal_character (Lexing.lexeme_char lexbuf 0),
                      Location.curr lexbuf))
       )
-# 2523 "../ocaml/parsing/lexer.ml"
+# 2523 "parsing/lexer.ml"
 
   | __ocaml_lex_state -> lexbuf.Lexing.refill_buff lexbuf; 
       __ocaml_lex_token_rec lexbuf __ocaml_lex_state
@@ -19621,15 +19621,15 @@ and comment lexbuf =
 and __ocaml_lex_comment_rec lexbuf __ocaml_lex_state =
   match Lexing.engine __ocaml_lex_tables __ocaml_lex_state lexbuf with
       | 0 ->
-# 983 "../ocaml/parsing/lexer.mll"
+# 983 "parsing/lexer.mll"
       ( comment_start_loc := (Location.curr lexbuf) :: !comment_start_loc;
         store_lexeme lexbuf;
         comment lexbuf;
       )
-# 2538 "../ocaml/parsing/lexer.ml"
+# 2538 "parsing/lexer.ml"
 
   | 1 ->
-# 988 "../ocaml/parsing/lexer.mll"
+# 988 "parsing/lexer.mll"
       ( match !comment_start_loc with
         | [] -> assert false
         | [_] -> comment_start_loc := []; Location.curr lexbuf
@@ -19637,10 +19637,10 @@ and __ocaml_lex_comment_rec lexbuf __ocaml_lex_state =
                   store_lexeme lexbuf;
                   comment lexbuf;
        )
-# 2549 "../ocaml/parsing/lexer.ml"
+# 2549 "parsing/lexer.ml"
 
   | 2 ->
-# 996 "../ocaml/parsing/lexer.mll"
+# 996 "parsing/lexer.mll"
       (
         string_start_loc := Location.curr lexbuf;
         store_string_char '"';
@@ -19658,10 +19658,10 @@ and __ocaml_lex_comment_rec lexbuf __ocaml_lex_state =
         is_in_string := false;
         store_string_char '"';
         comment lexbuf )
-# 2570 "../ocaml/parsing/lexer.ml"
+# 2570 "parsing/lexer.ml"
 
   | 3 ->
-# 1014 "../ocaml/parsing/lexer.mll"
+# 1014 "parsing/lexer.mll"
       (
         let delim = Lexing.lexeme lexbuf in
         let delim = String.sub delim 1 (String.length delim - 2) in
@@ -19683,43 +19683,43 @@ and __ocaml_lex_comment_rec lexbuf __ocaml_lex_state =
         store_string delim;
         store_string_char '}';
         comment lexbuf )
-# 2595 "../ocaml/parsing/lexer.ml"
+# 2595 "parsing/lexer.ml"
 
   | 4 ->
-# 1037 "../ocaml/parsing/lexer.mll"
+# 1037 "parsing/lexer.mll"
       ( store_lexeme lexbuf; comment lexbuf )
-# 2600 "../ocaml/parsing/lexer.ml"
+# 2600 "parsing/lexer.ml"
 
   | 5 ->
-# 1039 "../ocaml/parsing/lexer.mll"
+# 1039 "parsing/lexer.mll"
       ( update_loc lexbuf None 1 false 1;
         store_lexeme lexbuf;
         comment lexbuf
       )
-# 2608 "../ocaml/parsing/lexer.ml"
+# 2608 "parsing/lexer.ml"
 
   | 6 ->
-# 1044 "../ocaml/parsing/lexer.mll"
+# 1044 "parsing/lexer.mll"
       ( store_lexeme lexbuf; comment lexbuf )
-# 2613 "../ocaml/parsing/lexer.ml"
+# 2613 "parsing/lexer.ml"
 
   | 7 ->
-# 1046 "../ocaml/parsing/lexer.mll"
+# 1046 "parsing/lexer.mll"
       ( store_lexeme lexbuf; comment lexbuf )
-# 2618 "../ocaml/parsing/lexer.ml"
+# 2618 "parsing/lexer.ml"
 
   | 8 ->
-# 1048 "../ocaml/parsing/lexer.mll"
+# 1048 "parsing/lexer.mll"
       ( store_lexeme lexbuf; comment lexbuf )
-# 2623 "../ocaml/parsing/lexer.ml"
+# 2623 "parsing/lexer.ml"
 
   | 9 ->
-# 1050 "../ocaml/parsing/lexer.mll"
+# 1050 "parsing/lexer.mll"
       ( store_lexeme lexbuf; comment lexbuf )
-# 2628 "../ocaml/parsing/lexer.ml"
+# 2628 "parsing/lexer.ml"
 
   | 10 ->
-# 1052 "../ocaml/parsing/lexer.mll"
+# 1052 "parsing/lexer.mll"
       ( match !comment_start_loc with
         | [] -> assert false
         | loc :: _ ->
@@ -19727,20 +19727,20 @@ and __ocaml_lex_comment_rec lexbuf __ocaml_lex_state =
           comment_start_loc := [];
           raise (Error (Unterminated_comment start, loc))
       )
-# 2639 "../ocaml/parsing/lexer.ml"
+# 2639 "parsing/lexer.ml"
 
   | 11 ->
-# 1060 "../ocaml/parsing/lexer.mll"
+# 1060 "parsing/lexer.mll"
       ( update_loc lexbuf None 1 false 0;
         store_lexeme lexbuf;
         comment lexbuf
       )
-# 2647 "../ocaml/parsing/lexer.ml"
+# 2647 "parsing/lexer.ml"
 
   | 12 ->
-# 1065 "../ocaml/parsing/lexer.mll"
+# 1065 "parsing/lexer.mll"
       ( store_lexeme lexbuf; comment lexbuf )
-# 2652 "../ocaml/parsing/lexer.ml"
+# 2652 "parsing/lexer.ml"
 
   | __ocaml_lex_state -> lexbuf.Lexing.refill_buff lexbuf; 
       __ocaml_lex_comment_rec lexbuf __ocaml_lex_state
@@ -19750,42 +19750,42 @@ and string lexbuf =
 and __ocaml_lex_string_rec lexbuf __ocaml_lex_state =
   match Lexing.new_engine __ocaml_lex_tables __ocaml_lex_state lexbuf with
       | 0 ->
-# 1069 "../ocaml/parsing/lexer.mll"
+# 1069 "parsing/lexer.mll"
       ( () )
-# 2664 "../ocaml/parsing/lexer.ml"
+# 2664 "parsing/lexer.ml"
 
   | 1 ->
 let
-# 1070 "../ocaml/parsing/lexer.mll"
+# 1070 "parsing/lexer.mll"
                                   space
-# 2670 "../ocaml/parsing/lexer.ml"
+# 2670 "parsing/lexer.ml"
 = Lexing.sub_lexeme lexbuf lexbuf.Lexing.lex_mem.(0) lexbuf.Lexing.lex_curr_pos in
-# 1071 "../ocaml/parsing/lexer.mll"
+# 1071 "parsing/lexer.mll"
       ( update_loc lexbuf None 1 false (String.length space);
         string lexbuf
       )
-# 2676 "../ocaml/parsing/lexer.ml"
+# 2676 "parsing/lexer.ml"
 
   | 2 ->
-# 1075 "../ocaml/parsing/lexer.mll"
+# 1075 "parsing/lexer.mll"
       ( store_string_char(char_for_backslash(Lexing.lexeme_char lexbuf 1));
         string lexbuf )
-# 2682 "../ocaml/parsing/lexer.ml"
+# 2682 "parsing/lexer.ml"
 
   | 3 ->
-# 1078 "../ocaml/parsing/lexer.mll"
+# 1078 "parsing/lexer.mll"
       ( store_string_char(char_for_decimal_code lexbuf 1);
          string lexbuf )
-# 2688 "../ocaml/parsing/lexer.ml"
+# 2688 "parsing/lexer.ml"
 
   | 4 ->
-# 1081 "../ocaml/parsing/lexer.mll"
+# 1081 "parsing/lexer.mll"
       ( store_string_char(char_for_hexadecimal_code lexbuf 2);
          string lexbuf )
-# 2694 "../ocaml/parsing/lexer.ml"
+# 2694 "parsing/lexer.ml"
 
   | 5 ->
-# 1084 "../ocaml/parsing/lexer.mll"
+# 1084 "parsing/lexer.mll"
       ( if in_comment ()
         then string lexbuf
         else begin
@@ -19800,29 +19800,29 @@ let
           string lexbuf
         end
       )
-# 2712 "../ocaml/parsing/lexer.ml"
+# 2712 "parsing/lexer.ml"
 
   | 6 ->
-# 1099 "../ocaml/parsing/lexer.mll"
+# 1099 "parsing/lexer.mll"
       ( if not (in_comment ()) then
           Location.prerr_warning (Location.curr lexbuf) Warnings.Eol_in_string;
         update_loc lexbuf None 1 false 0;
         store_lexeme lexbuf;
         string lexbuf
       )
-# 2722 "../ocaml/parsing/lexer.ml"
+# 2722 "parsing/lexer.ml"
 
   | 7 ->
-# 1106 "../ocaml/parsing/lexer.mll"
+# 1106 "parsing/lexer.mll"
       ( is_in_string := false;
         raise (Error (Unterminated_string, !string_start_loc)) )
-# 2728 "../ocaml/parsing/lexer.ml"
+# 2728 "parsing/lexer.ml"
 
   | 8 ->
-# 1109 "../ocaml/parsing/lexer.mll"
+# 1109 "parsing/lexer.mll"
       ( store_string_char(Lexing.lexeme_char lexbuf 0);
         string lexbuf )
-# 2734 "../ocaml/parsing/lexer.ml"
+# 2734 "parsing/lexer.ml"
 
   | __ocaml_lex_state -> lexbuf.Lexing.refill_buff lexbuf; 
       __ocaml_lex_string_rec lexbuf __ocaml_lex_state
@@ -19832,34 +19832,34 @@ and quoted_string delim lexbuf =
 and __ocaml_lex_quoted_string_rec delim lexbuf __ocaml_lex_state =
   match Lexing.engine __ocaml_lex_tables __ocaml_lex_state lexbuf with
       | 0 ->
-# 1114 "../ocaml/parsing/lexer.mll"
+# 1114 "parsing/lexer.mll"
       ( update_loc lexbuf None 1 false 0;
         store_lexeme lexbuf;
         quoted_string delim lexbuf
       )
-# 2749 "../ocaml/parsing/lexer.ml"
+# 2749 "parsing/lexer.ml"
 
   | 1 ->
-# 1119 "../ocaml/parsing/lexer.mll"
+# 1119 "parsing/lexer.mll"
       ( is_in_string := false;
         raise (Error (Unterminated_string, !string_start_loc)) )
-# 2755 "../ocaml/parsing/lexer.ml"
+# 2755 "parsing/lexer.ml"
 
   | 2 ->
-# 1122 "../ocaml/parsing/lexer.mll"
+# 1122 "parsing/lexer.mll"
       (
         let edelim = Lexing.lexeme lexbuf in
         let edelim = String.sub edelim 1 (String.length edelim - 2) in
         if delim = edelim then ()
         else (store_lexeme lexbuf; quoted_string delim lexbuf)
       )
-# 2765 "../ocaml/parsing/lexer.ml"
+# 2765 "parsing/lexer.ml"
 
   | 3 ->
-# 1129 "../ocaml/parsing/lexer.mll"
+# 1129 "parsing/lexer.mll"
       ( store_string_char(Lexing.lexeme_char lexbuf 0);
         quoted_string delim lexbuf )
-# 2771 "../ocaml/parsing/lexer.ml"
+# 2771 "parsing/lexer.ml"
 
   | __ocaml_lex_state -> lexbuf.Lexing.refill_buff lexbuf; 
       __ocaml_lex_quoted_string_rec delim lexbuf __ocaml_lex_state
@@ -19869,26 +19869,26 @@ and skip_sharp_bang lexbuf =
 and __ocaml_lex_skip_sharp_bang_rec lexbuf __ocaml_lex_state =
   match Lexing.engine __ocaml_lex_tables __ocaml_lex_state lexbuf with
       | 0 ->
-# 1134 "../ocaml/parsing/lexer.mll"
+# 1134 "parsing/lexer.mll"
        ( update_loc lexbuf None 3 false 0 )
-# 2783 "../ocaml/parsing/lexer.ml"
+# 2783 "parsing/lexer.ml"
 
   | 1 ->
-# 1136 "../ocaml/parsing/lexer.mll"
+# 1136 "parsing/lexer.mll"
        ( update_loc lexbuf None 1 false 0 )
-# 2788 "../ocaml/parsing/lexer.ml"
+# 2788 "parsing/lexer.ml"
 
   | 2 ->
-# 1137 "../ocaml/parsing/lexer.mll"
+# 1137 "parsing/lexer.mll"
        ( () )
-# 2793 "../ocaml/parsing/lexer.ml"
+# 2793 "parsing/lexer.ml"
 
   | __ocaml_lex_state -> lexbuf.Lexing.refill_buff lexbuf; 
       __ocaml_lex_skip_sharp_bang_rec lexbuf __ocaml_lex_state
 
 ;;
 
-# 1139 "../ocaml/parsing/lexer.mll"
+# 1139 "parsing/lexer.mll"
  
 
   let at_bol lexbuf = 
@@ -20123,7 +20123,7 @@ and __ocaml_lex_skip_sharp_bang_rec lexbuf __ocaml_lex_state =
     preprocessor := Some (init, preprocess)
 
 
-# 3035 "../ocaml/parsing/lexer.ml"
+# 3035 "parsing/lexer.ml"
 
 end
 module Bs_conditional_initial : sig 

--- a/jscomp/bsb/bsb_build_schemas.ml
+++ b/jscomp/bsb/bsb_build_schemas.ml
@@ -45,3 +45,6 @@ let react_jsx = "react-jsx"
 let entries = "entries"
 let kind = "kind"
 let main = "main"
+
+let generators = "generators"
+let command = "command"

--- a/jscomp/bsb/bsb_build_ui.mli
+++ b/jscomp/bsb/bsb_build_ui.mli
@@ -29,18 +29,27 @@ type public =
     
 type dir_index = int 
 
+type build_generator = 
+  { input : string list ;
+    output : string list;
+    command : string}
+
 type  file_group = 
   { dir : string ; (* currently relative path expected for ninja file generation *)
     sources : Binary_cache.file_group_rouces ; 
     resources : string list ; (* relative path *)
     public : public;
     dir_index : dir_index; 
+    generators : build_generator list;
   } 
+
+
 
 type t = 
   { files :  file_group list ; 
     intervals :  Ext_file_pp.interval list ;
     globbed_dirs : string list ; 
+
   }
 
 val lib_dir_index : dir_index 

--- a/jscomp/bsb/bsb_ninja.ml
+++ b/jscomp/bsb/bsb_ninja.ml
@@ -36,7 +36,7 @@ let output_build
     ~input
     ~rule
     oc =
-  let rule = Rules.get_name rule  oc in (* Trigger building if not used *)
+  let rule = Bsb_rule.get_name rule  oc in (* Trigger building if not used *)
   output_string oc "build ";
   output_string oc output ;
   outputs |> List.iter (fun s -> output_string oc Ext_string.single_space ; output_string oc s  );
@@ -129,12 +129,13 @@ let output_kvs kvs oc =
 let (//) = Ext_filename.combine
 
 type info =
-  { all_config_deps : string list  ;
-    all_installs :  string list}
+  { all_config_deps : string list  ; (* Figure out [.d] files *)
+    (*all_installs :  string list*)
+    }
 
 let zero : info =
   { all_config_deps = [] ;
-    all_installs = []
+    (*all_installs = []*)
   }
 
 let (++) (us : info) (vs : info) =
@@ -144,7 +145,7 @@ let (++) (us : info) (vs : info) =
     {
       all_config_deps  = us.all_config_deps @ vs.all_config_deps
     ;
-      all_installs = us.all_installs @ vs.all_installs
+      (*all_installs = us.all_installs @ vs.all_installs*)
     }
 
 (** This set is stateful, we should make it functional in the future.
@@ -255,7 +256,9 @@ let handle_file_group oc ~package_specs ~js_post_build_cmd
               ~implicit_deps:deps
               ~rule:rule_name ;
             if installable then begin install_file file_input files_to_install end;
-            {all_config_deps = [output_mlastd]; all_installs = [output_cmi];  }
+            {all_config_deps = [output_mlastd]; 
+            (*all_installs = [output_cmi];  *)
+            }
 
           end
         | `Mli
@@ -284,7 +287,7 @@ let handle_file_group oc ~package_specs ~js_post_build_cmd
           if installable then begin install_file file_input files_to_install end ;
           {
             all_config_deps = [output_mliastd];
-            all_installs = [output_cmi] ;
+            (*all_installs = [output_cmi] ;*)
 
           }
 
@@ -313,9 +316,23 @@ let handle_file_group oc ~package_specs ~js_post_build_cmd
     end ++ info
 
   in
+  (*
+  group.generators
+  |> List.iter (fun  ({output; input; cmd}  : Bsb_build_ui.generator)-> 
+    output_build oc ~output:(Bsb_config.proj_rel output) 
+    ~input:(Bsb_config.proj_rel input)
+    ~rule:cmd 
+  ); 
+  *) (* we need create a rule for it --
+  {[
+    rule ocamllex 
+  ]}
+  *)
+  begin 
   String_map.fold (fun  k v  acc ->
       handle_module_info  oc k v acc
-    ) group.sources  acc
+    ) group.sources  acc ; 
+  end
 
 
 let handle_file_groups

--- a/jscomp/bsb/bsb_ninja.mli
+++ b/jscomp/bsb/bsb_ninja.mli
@@ -52,7 +52,7 @@ val output_kvs : (string * string) array -> out_channel -> unit
 
 type info = {
   all_config_deps : string list  ;
-  all_installs :  string list 
+  (*all_installs :  string list *)
 }
 
 val zero : info 

--- a/jscomp/common/binary_cache.mli
+++ b/jscomp/common/binary_cache.mli
@@ -56,8 +56,9 @@ val bsbuild_cache : string
 
 
 
-(** if not added, it is guaranteed the reference equality will 
-    be held
+(** 
+  Currently it is okay to have duplicated module, 
+  In the future, we may emit a warning 
 *)
 val map_update : 
   ?dir:string -> file_group_rouces ->  string -> file_group_rouces


### PR DESCRIPTION
A sample usage would be 

```js
{ ... ,
  "rules" :
   [ { "name" :   "ocamllex":  "command" : "ocamllex.opt $in $out"}], 
  ... 
  "dev-generators" : [
   { 
     "rule" : "ocamllex",
     "in" :  "test.mll"
     "out" : "test.ml" // consider different directories in the future
  ]
}
```
cc @mransan , does it cover your use case of protobuf?