### PR TITLE
Strip odoc markup from deprecation message

### DIFF
--- a/jscomp/others/js_json.mli
+++ b/jscomp/others/js_json.mli
@@ -119,7 +119,7 @@ external objectArray : t Js_dict.t array -> t = "%identity"
 (** {2 String conversion} *)
 
 external parse : string -> t = "JSON.parse" [@@bs.val]
-[@@ocaml.deprecated "Use {!Js.Json.parseExn} instead"]
+[@@ocaml.deprecated "Use Js.Json.parseExn instead"]
 
 external parseExn : string -> t = "JSON.parse" [@@bs.val]
 (** [parse s] parses the string [s] into a JSON data structure


### PR DESCRIPTION
The deprecation message of `Json.Js.parse` contains odoc markup.

```
File "/work/__tests__/json_test.ml", line 53, characters 67-80:
Warning 3: deprecated: Js.Json.parse
Use {!Js.Json.parseExn} instead
```

I remove this, because this is plain text area.
