### PR TITLE
Update minimal installation, docs contribution docs

### DIFF
--- a/docs/Manual.html
+++ b/docs/Manual.html
@@ -418,69 +418,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 .show-for-print{display:inherit!important}}
 </style>
 <style>
-.listingblock .pygments .hll { background-color: #ffffcc }
-.listingblock .pygments  { background: #f8f8f8; }
-.listingblock .pygments .tok-c { color: #408080; font-style: italic } /* Comment */
-.listingblock .pygments .tok-err { border: 1px solid #FF0000 } /* Error */
-.listingblock .pygments .tok-k { color: #008000; font-weight: bold } /* Keyword */
-.listingblock .pygments .tok-o { color: #666666 } /* Operator */
-.listingblock .pygments .tok-cm { color: #408080; font-style: italic } /* Comment.Multiline */
-.listingblock .pygments .tok-cp { color: #BC7A00 } /* Comment.Preproc */
-.listingblock .pygments .tok-c1 { color: #408080; font-style: italic } /* Comment.Single */
-.listingblock .pygments .tok-cs { color: #408080; font-style: italic } /* Comment.Special */
-.listingblock .pygments .tok-gd { color: #A00000 } /* Generic.Deleted */
-.listingblock .pygments .tok-ge { font-style: italic } /* Generic.Emph */
-.listingblock .pygments .tok-gr { color: #FF0000 } /* Generic.Error */
-.listingblock .pygments .tok-gh { color: #000080; font-weight: bold } /* Generic.Heading */
-.listingblock .pygments .tok-gi { color: #00A000 } /* Generic.Inserted */
-.listingblock .pygments .tok-go { color: #888888 } /* Generic.Output */
-.listingblock .pygments .tok-gp { color: #000080; font-weight: bold } /* Generic.Prompt */
-.listingblock .pygments .tok-gs { font-weight: bold } /* Generic.Strong */
-.listingblock .pygments .tok-gu { color: #800080; font-weight: bold } /* Generic.Subheading */
-.listingblock .pygments .tok-gt { color: #0044DD } /* Generic.Traceback */
-.listingblock .pygments .tok-kc { color: #008000; font-weight: bold } /* Keyword.Constant */
-.listingblock .pygments .tok-kd { color: #008000; font-weight: bold } /* Keyword.Declaration */
-.listingblock .pygments .tok-kn { color: #008000; font-weight: bold } /* Keyword.Namespace */
-.listingblock .pygments .tok-kp { color: #008000 } /* Keyword.Pseudo */
-.listingblock .pygments .tok-kr { color: #008000; font-weight: bold } /* Keyword.Reserved */
-.listingblock .pygments .tok-kt { color: #B00040 } /* Keyword.Type */
-.listingblock .pygments .tok-m { color: #666666 } /* Literal.Number */
-.listingblock .pygments .tok-s { color: #BA2121 } /* Literal.String */
-.listingblock .pygments .tok-na { color: #7D9029 } /* Name.Attribute */
-.listingblock .pygments .tok-nb { color: #008000 } /* Name.Builtin */
-.listingblock .pygments .tok-nc { color: #0000FF; font-weight: bold } /* Name.Class */
-.listingblock .pygments .tok-no { color: #880000 } /* Name.Constant */
-.listingblock .pygments .tok-nd { color: #AA22FF } /* Name.Decorator */
-.listingblock .pygments .tok-ni { color: #999999; font-weight: bold } /* Name.Entity */
-.listingblock .pygments .tok-ne { color: #D2413A; font-weight: bold } /* Name.Exception */
-.listingblock .pygments .tok-nf { color: #0000FF } /* Name.Function */
-.listingblock .pygments .tok-nl { color: #A0A000 } /* Name.Label */
-.listingblock .pygments .tok-nn { color: #0000FF; font-weight: bold } /* Name.Namespace */
-.listingblock .pygments .tok-nt { color: #008000; font-weight: bold } /* Name.Tag */
-.listingblock .pygments .tok-nv { color: #19177C } /* Name.Variable */
-.listingblock .pygments .tok-ow { color: #AA22FF; font-weight: bold } /* Operator.Word */
-.listingblock .pygments .tok-w { color: #bbbbbb } /* Text.Whitespace */
-.listingblock .pygments .tok-mb { color: #666666 } /* Literal.Number.Bin */
-.listingblock .pygments .tok-mf { color: #666666 } /* Literal.Number.Float */
-.listingblock .pygments .tok-mh { color: #666666 } /* Literal.Number.Hex */
-.listingblock .pygments .tok-mi { color: #666666 } /* Literal.Number.Integer */
-.listingblock .pygments .tok-mo { color: #666666 } /* Literal.Number.Oct */
-.listingblock .pygments .tok-sb { color: #BA2121 } /* Literal.String.Backtick */
-.listingblock .pygments .tok-sc { color: #BA2121 } /* Literal.String.Char */
-.listingblock .pygments .tok-sd { color: #BA2121; font-style: italic } /* Literal.String.Doc */
-.listingblock .pygments .tok-s2 { color: #BA2121 } /* Literal.String.Double */
-.listingblock .pygments .tok-se { color: #BB6622; font-weight: bold } /* Literal.String.Escape */
-.listingblock .pygments .tok-sh { color: #BA2121 } /* Literal.String.Heredoc */
-.listingblock .pygments .tok-si { color: #BB6688; font-weight: bold } /* Literal.String.Interpol */
-.listingblock .pygments .tok-sx { color: #008000 } /* Literal.String.Other */
-.listingblock .pygments .tok-sr { color: #BB6688 } /* Literal.String.Regex */
-.listingblock .pygments .tok-s1 { color: #BA2121 } /* Literal.String.Single */
-.listingblock .pygments .tok-ss { color: #19177C } /* Literal.String.Symbol */
-.listingblock .pygments .tok-bp { color: #008000 } /* Name.Builtin.Pseudo */
-.listingblock .pygments .tok-vc { color: #19177C } /* Name.Variable.Class */
-.listingblock .pygments .tok-vg { color: #19177C } /* Name.Variable.Global */
-.listingblock .pygments .tok-vi { color: #19177C } /* Name.Variable.Instance */
-.listingblock .pygments .tok-il { color: #666666 } /* Literal.Number.Integer.Long */
+/* Pygments styles disabled. Pygments is not available. */
 </style>
 </head>
 <body class="article toc2 toc-left">
@@ -962,7 +900,7 @@ version of the compiler:</p>
 <div class="content">
 <pre class="pygments highlight"><code data-lang="sh">opam update
 opam switch 4.02.3+buckle-master
-<span class="tok-nb">eval</span> <span class="tok-sb">`</span>opam config env<span class="tok-sb">`</span>
+eval `opam config env`
 npm install bs-platform</code></pre>
 </div>
 </div>
@@ -989,7 +927,7 @@ npm install bs-platform</code></pre>
 <div class="title">Instructions:</div>
 <div class="content">
 <pre class="pygments highlight"><code data-lang="sh">git clone https://github.com/bloomberg/bucklescript
-<span class="tok-nb">cd </span>bucklescript
+cd bucklescript
 npm install</code></pre>
 </div>
 </div>
@@ -1012,8 +950,8 @@ easily be done.</p>
 <div class="title">Build OCaml compiler</div>
 <div class="content">
 <pre class="pygments highlight"><code data-lang="sh">git clone --recursive https://github.com/bloomberg/bucklescript
-<span class="tok-nb">cd </span>bucklescript/ocaml
-./configure -prefix <span class="tok-sb">`</span><span class="tok-nb">pwd</span><span class="tok-sb">`</span> <span class="tok-c"># put your preferred directory</span>
+cd bucklescript/ocaml
+./configure -prefix `pwd` # put your preferred directory
 make world.opt
 make install</code></pre>
 </div>
@@ -1032,7 +970,8 @@ the previous section.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="sh">make world</code></pre>
+<pre class="pygments highlight"><code data-lang="sh">cd ../jscomp
+make world</code></pre>
 </div>
 </div>
 <hr>
@@ -1069,7 +1008,7 @@ The built compiler is not <em>relocatable</em> out of box, please don&#8217;t mo
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="sh">npm install -g bs-platform <span class="tok-o">&amp;&amp;</span> bsb -init hello <span class="tok-o">&amp;&amp;</span> <span class="tok-nb">cd </span>hello <span class="tok-o">&amp;&amp;</span> npm run build</code></pre>
+<pre class="pygments highlight"><code data-lang="sh">npm install -g bs-platform &amp;&amp; bsb -init hello &amp;&amp; cd hello &amp;&amp; npm run build</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -1082,7 +1021,7 @@ The built compiler is not <em>relocatable</em> out of box, please don&#8217;t mo
 <div class="content">
 <pre class="pygments highlight"><code data-lang="sh">hello&gt;tree -d .
 .
-<span class="tok-p">|</span>---.vscode
+|---.vscode
 ├── lib
 │   ├── bs
 │   │   └── src
@@ -1115,24 +1054,24 @@ as below:</p>
 <div class="listingblock">
 <div class="title">bsconfig.json</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-p">{</span>
-    <span class="tok-s2">&quot;name&quot;</span> <span class="tok-o">:</span> <span class="tok-s2">&quot;hello&quot;</span><span class="tok-p">,</span>
-    <span class="tok-s2">&quot;sources&quot;</span> <span class="tok-o">:</span> <span class="tok-p">{</span> <span class="tok-s2">&quot;dir&quot;</span> <span class="tok-o">:</span> <span class="tok-s2">&quot;src&quot;</span><span class="tok-p">}</span>
-<span class="tok-p">}</span></code></pre>
+<pre class="pygments highlight"><code data-lang="js">{
+    "name" : "hello",
+    "sources" : { "dir" : "src"}
+}</code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="title">package.json</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-p">{</span>
-    <span class="tok-s2">&quot;dependencies&quot;</span><span class="tok-o">:</span> <span class="tok-p">{</span>
-        <span class="tok-s2">&quot;bs-platform&quot;</span><span class="tok-o">:</span> <span class="tok-s2">&quot;1.7.0&quot;</span> <b class="conum">(1)</b>
-    <span class="tok-p">},</span>
-    <span class="tok-s2">&quot;scripts&quot;</span> <span class="tok-o">:</span> <span class="tok-p">{</span>
-        <span class="tok-s2">&quot;build&quot;</span> <span class="tok-o">:</span> <span class="tok-s2">&quot;bsb&quot;</span><span class="tok-p">,</span>
-        <span class="tok-s2">&quot;watch&quot;</span> <span class="tok-o">:</span> <span class="tok-s2">&quot;bsb -w&quot;</span> <b class="conum">(2)</b>
-    <span class="tok-p">}</span>
-<span class="tok-p">}</span></code></pre>
+<pre class="pygments highlight"><code data-lang="js">{
+    "dependencies": {
+        "bs-platform": "1.7.0" <b class="conum">(1)</b>
+    },
+    "scripts" : {
+        "build" : "bsb",
+        "watch" : "bsb -w" <b class="conum">(2)</b>
+    }
+}</code></pre>
 </div>
 </div>
 <div class="colist arabic">
@@ -1151,8 +1090,8 @@ as below:</p>
 <div class="listingblock">
 <div class="title">src/main_entry.ml</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-bp">()</span> <span class="tok-o">=</span>
-  <span class="tok-n">print_endline</span> <span class="tok-s2">&quot;hello world&quot;</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">let () =
+  print_endline "hello world"</code></pre>
 </div>
 </div>
 </li>
@@ -1172,13 +1111,13 @@ as below:</p>
 <div class="listingblock">
 <div class="title">lib/js/src/main_entry.js</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-c1">// GENERATED CODE BY BUCKLESCRIPT VERSION 1.0.1 , PLEASE EDIT WITH CARE</span>
-<span class="tok-s1">&#39;use strict&#39;</span><span class="tok-p">;</span>
+<pre class="pygments highlight"><code data-lang="js">// GENERATED CODE BY BUCKLESCRIPT VERSION 1.0.1 , PLEASE EDIT WITH CARE
+'use strict';
 
 
-<span class="tok-nx">console</span><span class="tok-p">.</span><span class="tok-nx">log</span><span class="tok-p">(</span><span class="tok-s2">&quot;hello world&quot;</span><span class="tok-p">);</span>
+console.log("hello world");
 
-<span class="tok-cm">/*  Not a pure module */</span> <b class="conum">(1)</b></code></pre>
+/*  Not a pure module */ <b class="conum">(1)</b></code></pre>
 </div>
 </div>
 <div class="colist arabic">
@@ -1223,24 +1162,24 @@ will call <code>fib</code>.</p>
 <div class="listingblock">
 <div class="title">bsconfig.json</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-p">{</span>
-    <span class="tok-s2">&quot;name&quot;</span> <span class="tok-o">:</span> <span class="tok-s2">&quot;helo&quot;</span><span class="tok-p">,</span>
-    <span class="tok-s2">&quot;sources&quot;</span> <span class="tok-o">:</span> <span class="tok-p">{</span> <span class="tok-s2">&quot;dir&quot;</span> <span class="tok-o">:</span> <span class="tok-s2">&quot;src&quot;</span><span class="tok-p">}</span>
-<span class="tok-p">}</span></code></pre>
+<pre class="pygments highlight"><code data-lang="js">{
+    "name" : "helo",
+    "sources" : { "dir" : "src"}
+}</code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="title">package.json</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-p">{</span>
-    <span class="tok-s2">&quot;dependencies&quot;</span><span class="tok-o">:</span> <span class="tok-p">{</span>
-        <span class="tok-s2">&quot;bs-platform&quot;</span><span class="tok-o">:</span> <span class="tok-s2">&quot;1.7.0&quot;</span>
-    <span class="tok-p">},</span>
-    <span class="tok-s2">&quot;scripts&quot;</span> <span class="tok-o">:</span> <span class="tok-p">{</span>
-        <span class="tok-s2">&quot;build&quot;</span> <span class="tok-o">:</span> <span class="tok-s2">&quot;bsb&quot;</span><span class="tok-p">,</span>
-        <span class="tok-s2">&quot;watch&quot;</span> <span class="tok-o">:</span> <span class="tok-s2">&quot;bsb -w&quot;</span>
-    <span class="tok-p">}</span>
-<span class="tok-p">}</span></code></pre>
+<pre class="pygments highlight"><code data-lang="js">{
+    "dependencies": {
+        "bs-platform": "1.7.0"
+    },
+    "scripts" : {
+        "build" : "bsb",
+        "watch" : "bsb -w"
+    }
+}</code></pre>
 </div>
 </div>
 </li>
@@ -1249,21 +1188,21 @@ will call <code>fib</code>.</p>
 <div class="listingblock">
 <div class="title">src/fib.ml</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">fib</span> <span class="tok-n">n</span> <span class="tok-o">=</span>
-  <span class="tok-k">let</span> <span class="tok-k">rec</span> <span class="tok-n">aux</span> <span class="tok-n">n</span> <span class="tok-n">a</span> <span class="tok-n">b</span> <span class="tok-o">=</span>
-    <span class="tok-k">if</span> <span class="tok-n">n</span> <span class="tok-o">=</span> <span class="tok-mi">0</span> <span class="tok-k">then</span> <span class="tok-n">a</span>
-    <span class="tok-k">else</span>
-      <span class="tok-n">aux</span> <span class="tok-o">(</span><span class="tok-n">n</span> <span class="tok-o">-</span> <span class="tok-mi">1</span><span class="tok-o">)</span> <span class="tok-n">b</span> <span class="tok-o">(</span><span class="tok-n">a</span><span class="tok-o">+</span><span class="tok-n">b</span><span class="tok-o">)</span>
-  <span class="tok-k">in</span> <span class="tok-n">aux</span> <span class="tok-n">n</span> <span class="tok-mi">1</span> <span class="tok-mi">1</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">let fib n =
+  let rec aux n a b =
+    if n = 0 then a
+    else
+      aux (n - 1) b (a+b)
+  in aux n 1 1</code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="title">src/main_entry.ml</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-bp">()</span> <span class="tok-o">=</span>
-  <span class="tok-k">for</span> <span class="tok-n">i</span> <span class="tok-o">=</span> <span class="tok-mi">0</span> <span class="tok-k">to</span> <span class="tok-mi">10</span> <span class="tok-k">do</span>
-    <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">log</span> <span class="tok-o">(</span><span class="tok-nn">Fib</span><span class="tok-p">.</span><span class="tok-n">fib</span> <span class="tok-n">i</span><span class="tok-o">)</span> <b class="conum">(1)</b>
-  <span class="tok-k">done</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">let () =
+  for i = 0 to 10 do
+    Js.log (Fib.fib i) <b class="conum">(1)</b>
+  done</code></pre>
 </div>
 </div>
 <div class="colist arabic">
@@ -1346,7 +1285,7 @@ directories, we have a flag</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="sh">bsc.exe -bs-package-name <span class="tok-nv">$npm_package_name</span> -bs-package-output modulesystem:path/to/your/js/dir -c a.ml</code></pre>
+<pre class="pygments highlight"><code data-lang="sh">bsc.exe -bs-package-name $npm_package_name -bs-package-output modulesystem:path/to/your/js/dir -c a.ml</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -1383,7 +1322,7 @@ pretty straightforward:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="sh">bsc.exe -I path/to/ocaml/package1/installed -I path/to/ocaml/package2/installed  -bs-package-name <span class="tok-nv">$npm_package_name</span> -bs-package-output commonjs:path/to/lib/js/ -c a.ml</code></pre>
+<pre class="pygments highlight"><code data-lang="sh">bsc.exe -I path/to/ocaml/package1/installed -I path/to/ocaml/package2/installed  -bs-package-name $npm_package_name -bs-package-output commonjs:path/to/lib/js/ -c a.ml</code></pre>
 </div>
 </div>
 </div>
@@ -1435,9 +1374,9 @@ we recommend users to export it as functions.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml">  <span class="tok-k">type</span> <span class="tok-n">t</span> <span class="tok-o">=</span>
-    <span class="tok-o">|</span> <span class="tok-nc">Cons</span> <span class="tok-k">of</span> <span class="tok-kt">int</span> <span class="tok-o">*</span> <span class="tok-n">t</span>
-    <span class="tok-o">|</span> <span class="tok-nc">Nil</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">  type t =
+    | Cons of int * t
+    | Nil</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -1446,8 +1385,8 @@ so that it can be constructed from the JS side.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">cons</span> <span class="tok-n">x</span> <span class="tok-n">y</span> <span class="tok-o">=</span> <span class="tok-nc">Cons</span> <span class="tok-o">(</span><span class="tok-n">x</span><span class="tok-o">,</span><span class="tok-n">y</span><span class="tok-o">)</span>
-<span class="tok-k">let</span> <span class="tok-n">nil</span> <span class="tok-o">=</span> <span class="tok-nc">Nil</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">let cons x y = Cons (x,y)
+let nil = Nil</code></pre>
 </div>
 </div>
 <div class="admonitionblock note">
@@ -1497,7 +1436,7 @@ improve the generated code.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">log</span> <span class="tok-s2">&quot;你好&quot;</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">Js.log "你好"</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -1505,7 +1444,7 @@ improve the generated code.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-nx">console</span><span class="tok-p">.</span><span class="tok-nx">log</span><span class="tok-p">(</span><span class="tok-s2">&quot;\xe4\xbd\xa0\xe5\xa5\xbd&quot;</span><span class="tok-p">);</span></code></pre>
+<pre class="pygments highlight"><code data-lang="js">console.log("\xe4\xbd\xa0\xe5\xa5\xbd");</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -1513,14 +1452,14 @@ improve the generated code.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">log</span> <span class="tok-o">{</span><span class="tok-n">js</span><span class="tok-o">|</span><span class="tok-err">你好，</span>
-<span class="tok-err">世界</span><span class="tok-o">|</span><span class="tok-n">js</span><span class="tok-o">}</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">Js.log {js|你好，
+世界|js}</code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="title">Output</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-nx">console</span><span class="tok-p">.</span><span class="tok-nx">log</span><span class="tok-p">(</span><span class="tok-s2">&quot;你好，\n世界&quot;</span><span class="tok-p">);</span></code></pre>
+<pre class="pygments highlight"><code data-lang="js">console.log("你好，\n世界");</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -1528,13 +1467,13 @@ improve the generated code.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">log</span> <span class="tok-o">{</span><span class="tok-n">js</span><span class="tok-o">|</span><span class="tok-err">\</span><span class="tok-n">x3f</span><span class="tok-err">\</span><span class="tok-n">u003f</span><span class="tok-err">\</span><span class="tok-n">b</span><span class="tok-err">\</span><span class="tok-n">t</span><span class="tok-err">\</span><span class="tok-n">n</span><span class="tok-err">\</span><span class="tok-n">v</span><span class="tok-err">\</span><span class="tok-n">f</span><span class="tok-err">\</span><span class="tok-n">r</span><span class="tok-err">\</span><span class="tok-mi">0</span><span class="tok-s2">&quot;&#39;|js}</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">Js.log {js|\x3f\u003f\b\t\n\v\f\r\0"'|js}</code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="title">Output</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-nx">console</span><span class="tok-p">.</span><span class="tok-nx">log</span><span class="tok-p">(</span><span class="tok-s2">&quot;\x3f\u003f\b\t\n\v\f\r\0\&quot;\&#39;&quot;</span><span class="tok-p">);</span></code></pre>
+<pre class="pygments highlight"><code data-lang="js">console.log("\x3f\u003f\b\t\n\v\f\r\0\"\'");</code></pre>
 </div>
 </div>
 <div class="sect3">
@@ -1547,8 +1486,8 @@ improve the generated code.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">world</span> <span class="tok-o">=</span> <span class="tok-o">{</span><span class="tok-n">j</span><span class="tok-o">|</span><span class="tok-err">世界</span><span class="tok-o">|</span><span class="tok-n">j</span><span class="tok-o">}</span>
-<span class="tok-k">let</span> <span class="tok-n">hello_world</span> <span class="tok-o">=</span> <span class="tok-o">{</span><span class="tok-n">j</span><span class="tok-o">|</span><span class="tok-err">你好，</span><span class="tok-o">$</span><span class="tok-n">world</span><span class="tok-o">|</span><span class="tok-n">j</span><span class="tok-o">}</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">let world = {j|世界|j}
+let hello_world = {j|你好，$world|j}</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -1556,7 +1495,7 @@ improve the generated code.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">hello_world</span> <span class="tok-o">=</span> <span class="tok-o">{</span><span class="tok-n">j</span><span class="tok-o">|</span><span class="tok-err">你好，</span><span class="tok-o">$(</span><span class="tok-n">world</span><span class="tok-o">)|</span><span class="tok-n">j</span><span class="tok-o">}</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">let hello_world = {j|你好，$(world)|j}</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -1566,8 +1505,8 @@ Its lexical convention is as below:</p>
 <div class="listingblock">
 <div class="content">
 <pre class="pygments highlight"><code data-lang="bnf">identifier := leading_identifier_char identifier_chars
-leading_identifier_char := &#39;a&#39; .. &#39;z&#39; | &#39;_&#39;
-identifier_chars := &#39;a&#39; .. &#39;z&#39; | &#39;A&#39; .. &#39;Z&#39; | &#39;0&#39; .. &#39;9&#39; | &#39;_&#39; | &#39;\&#39;</code></pre>
+leading_identifier_char := 'a' .. 'z' | '_'
+identifier_chars := 'a' .. 'z' | 'A' .. 'Z' | '0' .. '9' | '_' | '\'</code></pre>
 </div>
 </div>
 </div>
@@ -1613,8 +1552,8 @@ with syntax as described below:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">external</span> <span class="tok-k">value</span><span class="tok-o">-</span><span class="tok-n">name</span> <span class="tok-o">:</span> <span class="tok-n">typexpr</span> <span class="tok-o">=</span> <span class="tok-k">external</span><span class="tok-o">-</span><span class="tok-n">declaration</span> <span class="tok-n">attributes</span>
-<span class="tok-k">external</span><span class="tok-o">-</span><span class="tok-n">declaration</span> <span class="tok-o">:=</span> <span class="tok-kt">string</span><span class="tok-o">-</span><span class="tok-n">literal</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">external value-name : typexpr = external-declaration attributes
+external-declaration := string-literal</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -1626,10 +1565,10 @@ and provide customized <code>attributes</code>.</p>
 <h4 id="_binding_to_global_value_bs_val"><a class="anchor" href="#_binding_to_global_value_bs_val"></a>Binding to global value: bs.val</h4>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">external</span> <span class="tok-n">imul</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;Math.imul&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">val</span><span class="tok-o">]</span>
-<span class="tok-k">type</span> <span class="tok-n">dom</span>
-<span class="tok-c">(* Abstract type for the DOM *)</span>
-<span class="tok-k">external</span> <span class="tok-n">dom</span> <span class="tok-o">:</span> <span class="tok-n">dom</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;document&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">val</span><span class="tok-o">]</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">external imul : int -&gt; int -&gt; int = "Math.imul" [@@bs.val]
+type dom
+(* Abstract type for the DOM *)
+external dom : dom = "document" [@@bs.val]</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -1650,7 +1589,7 @@ it can be a function or plain value.</p>
 For example:</p>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">external</span> <span class="tok-n">document</span> <span class="tok-o">:</span> <span class="tok-n">dom</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">val</span><span class="tok-o">]</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">external document : dom = "" [@@bs.val]</code></pre>
 </div>
 </div>
 </li>
@@ -1660,8 +1599,8 @@ JavaScript functions, you can
 give the JavaScript foreign function a different name:</p>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">external</span> <span class="tok-n">imul</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">=</span>
-  <span class="tok-s2">&quot;c_imul&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">val</span> <span class="tok-s2">&quot;Math.imul&quot;</span><span class="tok-o">]</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">external imul : int -&gt; int -&gt; int =
+  "c_imul" [@@bs.val "Math.imul"]</code></pre>
 </div>
 </div>
 </li>
@@ -1683,22 +1622,22 @@ the user needs needs to type <code>commands</code> properly before typing <code>
 <div class="listingblock">
 <div class="title">Example</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">type</span> <span class="tok-n">param</span>
-<span class="tok-k">external</span> <span class="tok-n">executeCommands</span> <span class="tok-o">:</span> <span class="tok-kt">string</span> <span class="tok-o">-&gt;</span> <span class="tok-n">param</span> <span class="tok-kt">array</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">unit</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;&quot;</span>
-<span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">scope</span> <span class="tok-s2">&quot;commands&quot;</span><span class="tok-o">]</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">module</span> <span class="tok-s2">&quot;vscode&quot;</span><span class="tok-o">][@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">splice</span><span class="tok-o">]</span>
+<pre class="pygments highlight"><code data-lang="ocaml">type param
+external executeCommands : string -&gt; param array -&gt; unit = ""
+[@@bs.scope "commands"] [@@bs.module "vscode"][@@bs.splice]
 
-<span class="tok-k">let</span> <span class="tok-n">f</span> <span class="tok-n">a</span> <span class="tok-n">b</span> <span class="tok-n">c</span>  <span class="tok-o">=</span>
-  <span class="tok-n">executeCommands</span> <span class="tok-s2">&quot;hi&quot;</span>  <span class="tok-o">[|</span><span class="tok-n">a</span><span class="tok-o">;</span><span class="tok-n">b</span><span class="tok-o">;</span><span class="tok-n">c</span><span class="tok-o">|]</span></code></pre>
+let f a b c  =
+  executeCommands "hi"  [|a;b;c|]</code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="title">Output</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-kd">var</span> <span class="tok-nx">Vscode</span> <span class="tok-o">=</span> <span class="tok-nx">require</span><span class="tok-p">(</span><span class="tok-s2">&quot;vscode&quot;</span><span class="tok-p">);</span>
-<span class="tok-kd">function</span> <span class="tok-nx">f</span><span class="tok-p">(</span><span class="tok-nx">a</span><span class="tok-p">,</span> <span class="tok-nx">b</span><span class="tok-p">,</span> <span class="tok-nx">c</span><span class="tok-p">)</span> <span class="tok-p">{</span>
-  <span class="tok-nx">Vscode</span><span class="tok-p">.</span><span class="tok-nx">commands</span><span class="tok-p">.</span><span class="tok-nx">executeCommands</span><span class="tok-p">(</span><span class="tok-s2">&quot;hi&quot;</span><span class="tok-p">,</span> <span class="tok-nx">a</span><span class="tok-p">,</span> <span class="tok-nx">b</span><span class="tok-p">,</span> <span class="tok-nx">c</span><span class="tok-p">);</span>
-  <span class="tok-k">return</span> <span class="tok-nx">process</span><span class="tok-p">.</span><span class="tok-nx">env</span><span class="tok-p">;</span>
-<span class="tok-p">}</span></code></pre>
+<pre class="pygments highlight"><code data-lang="js">var Vscode = require("vscode");
+function f(a, b, c) {
+  Vscode.commands.executeCommands("hi", a, b, c);
+  return process.env;
+}</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -1707,30 +1646,30 @@ the user needs needs to type <code>commands</code> properly before typing <code>
 <div class="listingblock">
 <div class="title">Exmaple</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">external</span> <span class="tok-n">makeBuffer</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-n">buffer</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;Buffer&quot;</span>
-<span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">new</span><span class="tok-o">]</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">scope</span> <span class="tok-s2">&quot;global&quot;</span><span class="tok-o">]</span>
-<span class="tok-k">external</span> <span class="tok-n">hi</span> <span class="tok-o">:</span> <span class="tok-kt">string</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;&quot;</span>
-<span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">module</span> <span class="tok-s2">&quot;z&quot;</span><span class="tok-o">]</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">scope</span> <span class="tok-s2">&quot;a0&quot;</span><span class="tok-o">,</span> <span class="tok-s2">&quot;a1&quot;</span><span class="tok-o">,</span> <span class="tok-s2">&quot;a2&quot;</span><span class="tok-o">]</span>
-<span class="tok-k">external</span> <span class="tok-n">ho</span> <span class="tok-o">:</span> <span class="tok-kt">string</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;&quot;</span>
-<span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">val</span><span class="tok-o">]</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">scope</span> <span class="tok-s2">&quot;a0&quot;</span><span class="tok-o">,</span><span class="tok-s2">&quot;a1&quot;</span><span class="tok-o">,</span><span class="tok-s2">&quot;a2&quot;</span><span class="tok-o">]</span>
-<span class="tok-k">external</span> <span class="tok-n">imul</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;&quot;</span>
-<span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">val</span><span class="tok-o">]</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">scope</span> <span class="tok-s2">&quot;Math&quot;</span><span class="tok-o">]</span>
-<span class="tok-k">let</span> <span class="tok-n">f2</span> <span class="tok-bp">()</span>  <span class="tok-o">=</span>
-  <span class="tok-n">makeBuffer</span> <span class="tok-mi">20</span> <span class="tok-o">,</span> <span class="tok-n">hi</span> <span class="tok-o">,</span> <span class="tok-n">ho</span><span class="tok-o">,</span> <span class="tok-n">imul</span> <span class="tok-mi">1</span> <span class="tok-mi">2</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">external makeBuffer : int -&gt; buffer = "Buffer"
+[@@bs.new] [@@bs.scope "global"]
+external hi : string = ""
+[@@bs.module "z"] [@@bs.scope "a0", "a1", "a2"]
+external ho : string = ""
+[@@bs.val] [@@bs.scope "a0","a1","a2"]
+external imul : int -&gt; int -&gt; int = ""
+[@@bs.val] [@@bs.scope "Math"]
+let f2 ()  =
+  makeBuffer 20 , hi , ho, imul 1 2</code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="title">Output</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-kd">var</span> <span class="tok-nx">Z</span>      <span class="tok-o">=</span> <span class="tok-nx">require</span><span class="tok-p">(</span><span class="tok-s2">&quot;z&quot;</span><span class="tok-p">);</span>
-<span class="tok-kd">function</span> <span class="tok-nx">f2</span><span class="tok-p">()</span> <span class="tok-p">{</span>
-  <span class="tok-k">return</span> <span class="tok-cm">/* tuple */</span><span class="tok-p">[</span>
-          <span class="tok-k">new</span> <span class="tok-p">(</span><span class="tok-nx">global</span><span class="tok-p">.</span><span class="tok-nx">Buffer</span><span class="tok-p">)(</span><span class="tok-mi">20</span><span class="tok-p">),</span>
-          <span class="tok-nx">Z</span><span class="tok-p">.</span><span class="tok-nx">a0</span><span class="tok-p">.</span><span class="tok-nx">a1</span><span class="tok-p">.</span><span class="tok-nx">a2</span><span class="tok-p">.</span><span class="tok-nx">hi</span><span class="tok-p">,</span>
-          <span class="tok-nx">a0</span><span class="tok-p">.</span><span class="tok-nx">a1</span><span class="tok-p">.</span><span class="tok-nx">a2</span><span class="tok-p">.</span><span class="tok-nx">ho</span><span class="tok-p">,</span>
-          <span class="tok-nb">Math</span><span class="tok-p">.</span><span class="tok-nx">imul</span><span class="tok-p">(</span><span class="tok-mi">1</span><span class="tok-p">,</span> <span class="tok-mi">2</span><span class="tok-p">)</span>
-        <span class="tok-p">];</span>
-<span class="tok-p">}</span></code></pre>
+<pre class="pygments highlight"><code data-lang="js">var Z      = require("z");
+function f2() {
+  return /* tuple */[
+          new (global.Buffer)(20),
+          Z.a0.a1.a2.hi,
+          a0.a1.a2.ho,
+          Math.imul(1, 2)
+        ];
+}</code></pre>
 </div>
 </div>
 </div>
@@ -1741,14 +1680,14 @@ the user needs needs to type <code>commands</code> properly before typing <code>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">external</span> <span class="tok-n">create_date</span> <span class="tok-o">:</span> <span class="tok-kt">unit</span> <span class="tok-o">-&gt;</span> <span class="tok-n">t</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;Date&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">new</span><span class="tok-o">]</span>
-<span class="tok-k">let</span> <span class="tok-n">date</span> <span class="tok-o">=</span> <span class="tok-n">create_date</span> <span class="tok-bp">()</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">external create_date : unit -&gt; t = "Date" [@@bs.new]
+let date = create_date ()</code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="title">Output:</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-kd">var</span> <span class="tok-nx">date</span> <span class="tok-o">=</span> <span class="tok-k">new</span> <span class="tok-nb">Date</span><span class="tok-p">();</span></code></pre>
+<pre class="pygments highlight"><code data-lang="js">var date = new Date();</code></pre>
 </div>
 </div>
 </div>
@@ -1757,10 +1696,10 @@ the user needs needs to type <code>commands</code> properly before typing <code>
 <div class="listingblock">
 <div class="title">Input:</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">external</span> <span class="tok-n">add</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;add&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">module</span> <span class="tok-s2">&quot;x&quot;</span><span class="tok-o">]</span>
-<span class="tok-k">external</span> <span class="tok-n">add2</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;add2&quot;</span><span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">module</span> <span class="tok-s2">&quot;y&quot;</span><span class="tok-o">,</span> <span class="tok-s2">&quot;U&quot;</span><span class="tok-o">]</span> <b class="conum">(1)</b>
-<span class="tok-k">let</span> <span class="tok-n">f</span> <span class="tok-o">=</span> <span class="tok-n">add</span> <span class="tok-mi">3</span> <span class="tok-mi">4</span>
-<span class="tok-k">let</span> <span class="tok-n">g</span> <span class="tok-o">=</span> <span class="tok-n">add2</span> <span class="tok-mi">3</span> <span class="tok-mi">4</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">external add : int -&gt; int -&gt; int = "add" [@@bs.module "x"]
+external add2 : int -&gt; int -&gt; int = "add2"[@@bs.module "y", "U"] <b class="conum">(1)</b>
+let f = add 3 4
+let g = add2 3 4</code></pre>
 </div>
 </div>
 <div class="colist arabic">
@@ -1773,10 +1712,10 @@ the user needs needs to type <code>commands</code> properly before typing <code>
 <div class="listingblock">
 <div class="title">Output:</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-kd">var</span> <span class="tok-nx">U</span> <span class="tok-o">=</span> <span class="tok-nx">require</span><span class="tok-p">(</span><span class="tok-s2">&quot;y&quot;</span><span class="tok-p">);</span>
-<span class="tok-kd">var</span> <span class="tok-nx">X</span> <span class="tok-o">=</span> <span class="tok-nx">require</span><span class="tok-p">(</span><span class="tok-s2">&quot;x&quot;</span><span class="tok-p">);</span>
-<span class="tok-kd">var</span> <span class="tok-nx">f</span> <span class="tok-o">=</span> <span class="tok-nx">X</span><span class="tok-p">.</span><span class="tok-nx">add</span><span class="tok-p">(</span><span class="tok-mi">3</span><span class="tok-p">,</span> <span class="tok-mi">4</span><span class="tok-p">);</span>
-<span class="tok-kd">var</span> <span class="tok-nx">g</span> <span class="tok-o">=</span> <span class="tok-nx">U</span><span class="tok-p">.</span><span class="tok-nx">add2</span><span class="tok-p">(</span><span class="tok-mi">3</span><span class="tok-p">,</span> <span class="tok-mi">4</span><span class="tok-p">);</span></code></pre>
+<pre class="pygments highlight"><code data-lang="js">var U = require("y");
+var X = require("x");
+var f = X.add(3, 4);
+var g = U.add2(3, 4);</code></pre>
 </div>
 </div>
 <div class="admonitionblock note">
@@ -1792,7 +1731,7 @@ the user needs needs to type <code>commands</code> properly before typing <code>
 <p>if <code>external-declaration</code> is the same as value-name, it can be left empty, for example,</p>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">external</span> <span class="tok-n">add</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">module</span> <span class="tok-s2">&quot;x&quot;</span><span class="tok-o">]</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">external add : int -&gt; int -&gt; int = "" [@@bs.module "x"]</code></pre>
 </div>
 </div>
 </li>
@@ -1807,8 +1746,8 @@ the user needs needs to type <code>commands</code> properly before typing <code>
 <h4 id="_binding_the_whole_module_as_a_value_or_function"><a class="anchor" href="#_binding_the_whole_module_as_a_value_or_function"></a>Binding the whole module as a value or function</h4>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">type</span> <span class="tok-n">http</span>
-<span class="tok-k">external</span> <span class="tok-n">http</span> <span class="tok-o">:</span> <span class="tok-n">http</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;http&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">module</span><span class="tok-o">]</span> <b class="conum">(1)</b></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">type http
+external http : http = "http" [@@bs.module] <b class="conum">(1)</b></code></pre>
 </div>
 </div>
 <div class="colist arabic">
@@ -1831,7 +1770,7 @@ the user needs needs to type <code>commands</code> properly before typing <code>
 <p>if <code>external-declaration</code> is the same as value-name, it can be left empty, for example:</p>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">external</span> <span class="tok-n">http</span> <span class="tok-o">:</span> <span class="tok-n">http</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">module</span><span class="tok-o">]</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">external http : http = "" [@@bs.module]</code></pre>
 </div>
 </div>
 </li>
@@ -1849,9 +1788,9 @@ the user needs needs to type <code>commands</code> properly before typing <code>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">type</span> <span class="tok-n">id</span> <span class="tok-c">(** Abstract type for id object *)</span>
-<span class="tok-k">external</span> <span class="tok-n">get_by_id</span> <span class="tok-o">:</span> <span class="tok-n">dom</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">string</span> <span class="tok-o">-&gt;</span> <span class="tok-n">id</span> <span class="tok-o">=</span>
-  <span class="tok-s2">&quot;getElementById&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">send</span><span class="tok-o">]</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">type id (** Abstract type for id object *)
+external get_by_id : dom -&gt; string -&gt; id =
+  "getElementById" [@@bs.send]</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -1860,13 +1799,13 @@ the user needs needs to type <code>commands</code> properly before typing <code>
 <div class="listingblock">
 <div class="title">Input:</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-n">get_by_id</span> <span class="tok-n">dom</span> <span class="tok-s2">&quot;xx&quot;</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">get_by_id dom "xx"</code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="title">Output:</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-nx">dom</span><span class="tok-p">.</span><span class="tok-nx">getElementById</span><span class="tok-p">(</span><span class="tok-s2">&quot;xx&quot;</span><span class="tok-p">)</span></code></pre>
+<pre class="pygments highlight"><code data-lang="js">dom.getElementById("xx")</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -1875,14 +1814,14 @@ is put in the position of last argument to help user write in a <em>chaining sty
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">external</span> <span class="tok-n">map</span> <span class="tok-o">:</span> <span class="tok-o">(</span><span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">b</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">])</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">b</span> <span class="tok-kt">array</span> <span class="tok-o">=</span>
-  <span class="tok-s2">&quot;&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">send</span><span class="tok-o">.</span><span class="tok-n">pipe</span><span class="tok-o">:</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-kt">array</span><span class="tok-o">]</span> <b class="conum">(1)</b>
-<span class="tok-k">external</span> <span class="tok-n">forEach</span><span class="tok-o">:</span> <span class="tok-o">(</span><span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">unit</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">])</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-kt">array</span> <span class="tok-o">=</span>
-  <span class="tok-s2">&quot;&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">send</span><span class="tok-o">.</span><span class="tok-n">pipe</span><span class="tok-o">:</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-kt">array</span><span class="tok-o">]</span>
-<span class="tok-k">let</span> <span class="tok-n">test</span> <span class="tok-n">arr</span> <span class="tok-o">=</span>
-    <span class="tok-n">arr</span>
-    <span class="tok-o">|&gt;</span> <span class="tok-n">map</span> <span class="tok-o">(</span><span class="tok-k">fun</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">]</span> <span class="tok-n">x</span> <span class="tok-o">-&gt;</span> <span class="tok-n">x</span> <span class="tok-o">+</span> <span class="tok-mi">1</span><span class="tok-o">)</span>
-    <span class="tok-o">|&gt;</span> <span class="tok-n">forEach</span> <span class="tok-o">(</span><span class="tok-k">fun</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">]</span> <span class="tok-n">x</span> <span class="tok-o">-&gt;</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">log</span> <span class="tok-n">x</span><span class="tok-o">)</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">external map : ('a -&gt; 'b [@bs]) -&gt; 'b array =
+  "" [@@bs.send.pipe: 'a array] <b class="conum">(1)</b>
+external forEach: ('a -&gt; unit [@bs]) -&gt; 'a array =
+  "" [@@bs.send.pipe: 'a array]
+let test arr =
+    arr
+    |&gt; map (fun [@bs] x -&gt; x + 1)
+    |&gt; forEach (fun [@bs] x -&gt; Js.log x)</code></pre>
 </div>
 </div>
 <div class="colist arabic">
@@ -1905,8 +1844,8 @@ is put in the position of last argument to help user write in a <em>chaining sty
 <p>if <code>external-declaration</code> is the same as value-name, it can be left empty, for example:</p>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">external</span> <span class="tok-n">getElementById</span> <span class="tok-o">:</span> <span class="tok-n">dom</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">string</span> <span class="tok-o">-&gt;</span> <span class="tok-n">id</span> <span class="tok-o">=</span>
-  <span class="tok-s2">&quot;&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">send</span><span class="tok-o">]</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">external getElementById : dom -&gt; string -&gt; id =
+  "" [@@bs.send]</code></pre>
 </div>
 </div>
 </li>
@@ -1924,10 +1863,10 @@ is put in the position of last argument to help user write in a <em>chaining sty
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">type</span> <span class="tok-n">t</span>
-<span class="tok-k">external</span> <span class="tok-n">create</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-n">t</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;Int32Array&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">new</span><span class="tok-o">]</span>
-<span class="tok-k">external</span> <span class="tok-n">get</span> <span class="tok-o">:</span> <span class="tok-n">t</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">get_index</span><span class="tok-o">]</span>
-<span class="tok-k">external</span> <span class="tok-n">set</span> <span class="tok-o">:</span> <span class="tok-n">t</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">unit</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">set_index</span><span class="tok-o">]</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">type t
+external create : int -&gt; t = "Int32Array" [@@bs.new]
+external get : t -&gt; int -&gt; int = "" [@@bs.get_index]
+external set : t -&gt; int -&gt; int -&gt; unit = "" [@@bs.set_index]</code></pre>
 </div>
 </div>
 </div>
@@ -1938,9 +1877,9 @@ is put in the position of last argument to help user write in a <em>chaining sty
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">type</span> <span class="tok-n">textarea</span>
-<span class="tok-k">external</span> <span class="tok-n">set_name</span> <span class="tok-o">:</span> <span class="tok-n">textarea</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">string</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">unit</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;name&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">set</span><span class="tok-o">]</span>
-<span class="tok-k">external</span> <span class="tok-n">get_name</span> <span class="tok-o">:</span> <span class="tok-n">textarea</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">string</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;name&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">get</span><span class="tok-o">]</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">type textarea
+external set_name : textarea -&gt; string -&gt; unit = "name" [@@bs.set]
+external get_name : textarea -&gt; string = "name" [@@bs.get]</code></pre>
 </div>
 </div>
 </div>
@@ -1953,15 +1892,15 @@ BuckleScript supports typing homogeneous variadic arguments. For example,</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">external</span> <span class="tok-n">join</span> <span class="tok-o">:</span> <span class="tok-kt">string</span> <span class="tok-kt">array</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">string</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">module</span> <span class="tok-s2">&quot;path&quot;</span><span class="tok-o">]</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">splice</span><span class="tok-o">]</span>
-<span class="tok-k">let</span> <span class="tok-n">v</span> <span class="tok-o">=</span> <span class="tok-n">join</span> <span class="tok-o">[|</span> <span class="tok-s2">&quot;a&quot;</span><span class="tok-o">;</span> <span class="tok-s2">&quot;b&quot;</span><span class="tok-o">|]</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">external join : string array -&gt; string = "" [@@bs.module "path"] [@@bs.splice]
+let v = join [| "a"; "b"|]</code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="title">Output</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-kd">var</span> <span class="tok-nx">Path</span> <span class="tok-o">=</span> <span class="tok-nx">require</span><span class="tok-p">(</span><span class="tok-s2">&quot;path&quot;</span><span class="tok-p">)</span>
-<span class="tok-kd">var</span> <span class="tok-nx">v</span> <span class="tok-o">=</span> <span class="tok-nx">Path</span><span class="tok-p">.</span><span class="tok-nx">join</span><span class="tok-p">(</span><span class="tok-s2">&quot;a&quot;</span><span class="tok-p">,</span><span class="tok-s2">&quot;b&quot;</span><span class="tok-p">)</span></code></pre>
+<pre class="pygments highlight"><code data-lang="js">var Path = require("path")
+var v = Path.join("a","b")</code></pre>
 </div>
 </div>
 <div class="admonitionblock note">
@@ -1991,16 +1930,16 @@ way by using annotated polymorphic variant.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">external</span> <span class="tok-n">readFileSync</span> <span class="tok-o">:</span>
-  <span class="tok-n">name</span><span class="tok-o">:</span><span class="tok-kt">string</span> <span class="tok-o">-&gt;</span>
-  <span class="tok-o">([</span> <span class="tok-o">`</span><span class="tok-n">utf8</span>
-   <span class="tok-o">|</span> <span class="tok-o">`</span><span class="tok-n">my_name</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">as</span> <span class="tok-s2">&quot;ascii&quot;</span><span class="tok-o">]</span> <b class="conum">(1)</b>
-   <span class="tok-o">]</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-kt">string</span><span class="tok-o">])</span> <span class="tok-o">-&gt;</span>
-  <span class="tok-kt">string</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;&quot;</span>
-  <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">module</span> <span class="tok-s2">&quot;fs&quot;</span><span class="tok-o">]</span>
+<pre class="pygments highlight"><code data-lang="ocaml">external readFileSync :
+  name:string -&gt;
+  ([ `utf8
+   | `my_name [@bs.as "ascii"] <b class="conum">(1)</b>
+   ] [@bs.string]) -&gt;
+  string = ""
+  [@@bs.module "fs"]
 
-<span class="tok-k">let</span> <span class="tok-o">_</span> <span class="tok-o">=</span>
-  <span class="tok-n">readFileSync</span> <span class="tok-o">~</span><span class="tok-n">name</span><span class="tok-o">:</span><span class="tok-s2">&quot;xx.txt&quot;</span> <span class="tok-o">`</span><span class="tok-n">my_name</span></code></pre>
+let _ =
+  readFileSync ~name:"xx.txt" `my_name</code></pre>
 </div>
 </div>
 <div class="colist arabic">
@@ -2015,8 +1954,8 @@ way by using annotated polymorphic variant.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-kd">var</span> <span class="tok-nx">Fs</span> <span class="tok-o">=</span> <span class="tok-nx">require</span><span class="tok-p">(</span><span class="tok-s2">&quot;fs&quot;</span><span class="tok-p">);</span>
-<span class="tok-nx">Fs</span><span class="tok-p">.</span><span class="tok-nx">readFileSync</span><span class="tok-p">(</span><span class="tok-s2">&quot;xx.txt&quot;</span><span class="tok-p">,</span> <span class="tok-s2">&quot;ascii&quot;</span><span class="tok-p">);</span></code></pre>
+<pre class="pygments highlight"><code data-lang="js">var Fs = require("fs");
+Fs.readFileSync("xx.txt", "ascii");</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -2024,13 +1963,13 @@ way by using annotated polymorphic variant.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">external</span> <span class="tok-n">test_int_type</span> <span class="tok-o">:</span>
-  <span class="tok-o">([</span> <span class="tok-o">`</span><span class="tok-n">on_closed</span> <b class="conum">(1)</b>
-   <span class="tok-o">|</span> <span class="tok-o">`</span><span class="tok-n">on_open</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">as</span> <span class="tok-mi">3</span><span class="tok-o">]</span> <b class="conum">(2)</b>
-   <span class="tok-o">|</span> <span class="tok-o">`</span><span class="tok-n">in_bin</span> <b class="conum">(3)</b>
-   <span class="tok-o">]</span>
-   <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-kt">int</span><span class="tok-o">])</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">=</span>
-  <span class="tok-s2">&quot;&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">val</span><span class="tok-o">]</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">external test_int_type :
+  ([ `on_closed <b class="conum">(1)</b>
+   | `on_open [@bs.as 3] <b class="conum">(2)</b>
+   | `in_bin <b class="conum">(3)</b>
+   ]
+   [@bs.int]) -&gt; int =
+  "" [@@bs.val]</code></pre>
 </div>
 </div>
 <div class="colist arabic">
@@ -2054,18 +1993,18 @@ way by using annotated polymorphic variant.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">type</span> <span class="tok-n">readline</span>
-<span class="tok-k">external</span> <span class="tok-n">on</span> <span class="tok-o">:</span>
-    <span class="tok-o">(</span>
-    <span class="tok-o">[</span> <span class="tok-o">`</span><span class="tok-n">close</span> <span class="tok-k">of</span> <span class="tok-kt">unit</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">unit</span>
-    <span class="tok-o">|</span> <span class="tok-o">`</span><span class="tok-n">line</span> <span class="tok-k">of</span> <span class="tok-kt">string</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">unit</span>
-    <span class="tok-o">]</span> <b class="conum">(1)</b>
-    <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-kt">string</span><span class="tok-o">])</span>
-    <span class="tok-o">-&gt;</span> <span class="tok-n">readline</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">send</span><span class="tok-o">.</span><span class="tok-n">pipe</span><span class="tok-o">:</span> <span class="tok-n">readline</span><span class="tok-o">]</span>
-<span class="tok-k">let</span> <span class="tok-n">register</span> <span class="tok-n">rl</span> <span class="tok-o">=</span>
-  <span class="tok-n">rl</span>
-  <span class="tok-o">|&gt;</span> <span class="tok-n">on</span> <span class="tok-o">(`</span><span class="tok-n">close</span> <span class="tok-o">(</span><span class="tok-k">fun</span> <span class="tok-n">event</span> <span class="tok-o">-&gt;</span> <span class="tok-bp">()</span> <span class="tok-o">))</span>
-  <span class="tok-o">|&gt;</span> <span class="tok-n">on</span> <span class="tok-o">(`</span><span class="tok-n">line</span> <span class="tok-o">(</span><span class="tok-k">fun</span> <span class="tok-n">line</span> <span class="tok-o">-&gt;</span> <span class="tok-n">print_endline</span> <span class="tok-n">line</span><span class="tok-o">))</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">type readline
+external on :
+    (
+    [ `close of unit -&gt; unit
+    | `line of string -&gt; unit
+    ] <b class="conum">(1)</b>
+    [@bs.string])
+    -&gt; readline = "" [@@bs.send.pipe: readline]
+let register rl =
+  rl
+  |&gt; on (`close (fun event -&gt; () ))
+  |&gt; on (`line (fun line -&gt; print_endline line))</code></pre>
 </div>
 </div>
 <div class="colist arabic">
@@ -2078,15 +2017,15 @@ way by using annotated polymorphic variant.</p>
 <div class="listingblock">
 <div class="title">Output:</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-kd">function</span> <span class="tok-nx">register</span><span class="tok-p">(</span><span class="tok-nx">rl</span><span class="tok-p">)</span> <span class="tok-p">{</span>
-  <span class="tok-k">return</span> <span class="tok-nx">rl</span><span class="tok-p">.</span><span class="tok-nx">on</span><span class="tok-p">(</span><span class="tok-s2">&quot;close&quot;</span><span class="tok-p">,</span> <span class="tok-kd">function</span> <span class="tok-p">()</span> <span class="tok-p">{</span>
-                <span class="tok-k">return</span> <span class="tok-cm">/* () */</span><span class="tok-mi">0</span><span class="tok-p">;</span>
-              <span class="tok-p">})</span>
-           <span class="tok-p">.</span><span class="tok-nx">on</span><span class="tok-p">(</span><span class="tok-s2">&quot;line&quot;</span><span class="tok-p">,</span> <span class="tok-kd">function</span> <span class="tok-p">(</span><span class="tok-nx">line</span><span class="tok-p">)</span> <span class="tok-p">{</span>
-              <span class="tok-nx">console</span><span class="tok-p">.</span><span class="tok-nx">log</span><span class="tok-p">(</span><span class="tok-nx">line</span><span class="tok-p">);</span>
-              <span class="tok-k">return</span> <span class="tok-cm">/* () */</span><span class="tok-mi">0</span><span class="tok-p">;</span>
-            <span class="tok-p">});</span>
-<span class="tok-p">}</span></code></pre>
+<pre class="pygments highlight"><code data-lang="js">function register(rl) {
+  return rl.on("close", function () {
+                return /* () */0;
+              })
+           .on("line", function (line) {
+              console.log(line);
+              return /* () */0;
+            });
+}</code></pre>
 </div>
 </div>
 <div class="admonitionblock warning">
@@ -2128,9 +2067,9 @@ still be recorded.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">external</span> <span class="tok-n">add</span> <span class="tok-o">:</span> <span class="tok-o">(</span><span class="tok-kt">int</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">ignore</span><span class="tok-o">])</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;&quot;</span>
-<span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">val</span><span class="tok-o">]</span>
-<span class="tok-k">let</span> <span class="tok-n">v</span> <span class="tok-o">=</span> <span class="tok-n">add</span> <span class="tok-mi">0</span> <span class="tok-mi">1</span> <span class="tok-mi">2</span> <b class="conum">(1)</b></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">external add : (int [@bs.ignore]) -&gt; int -&gt; int = ""
+[@@bs.val]
+let v = add 0 1 2 <b class="conum">(1)</b></code></pre>
 </div>
 </div>
 <div class="colist arabic">
@@ -2143,7 +2082,7 @@ still be recorded.</p>
 <div class="listingblock">
 <div class="title">Output:</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="javascript"><span class="tok-kd">var</span> <span class="tok-nx">v</span> <span class="tok-o">=</span> <span class="tok-nx">add</span> <span class="tok-p">(</span><span class="tok-mi">1</span><span class="tok-p">,</span><span class="tok-mi">2</span><span class="tok-p">)</span></code></pre>
+<pre class="pygments highlight"><code data-lang="javascript">var v = add (1,2)</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -2151,14 +2090,14 @@ still be recorded.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">type</span> <span class="tok-o">_</span> <span class="tok-n">kind</span> <span class="tok-o">=</span>
-  <span class="tok-o">|</span> <span class="tok-nc">Float</span> <span class="tok-o">:</span> <span class="tok-kt">float</span> <span class="tok-n">kind</span>
-  <span class="tok-o">|</span> <span class="tok-nc">String</span> <span class="tok-o">:</span> <span class="tok-kt">string</span> <span class="tok-n">kind</span>
-<span class="tok-k">external</span> <span class="tok-n">add</span> <span class="tok-o">:</span> <span class="tok-o">(</span><span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-n">kind</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">ignore</span><span class="tok-o">])</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">val</span><span class="tok-o">]</span>
+<pre class="pygments highlight"><code data-lang="ocaml">type _ kind =
+  | Float : float kind
+  | String : string kind
+external add : ('a kind [@bs.ignore]) -&gt; 'a -&gt; 'a -&gt; 'a = "" [@@bs.val]
 
-<span class="tok-k">let</span> <span class="tok-bp">()</span> <span class="tok-o">=</span>
-  <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">log</span> <span class="tok-o">(</span><span class="tok-n">add</span> <span class="tok-nc">Float</span> <span class="tok-mi">3</span><span class="tok-o">.</span><span class="tok-mi">0</span> <span class="tok-mi">2</span><span class="tok-o">.</span><span class="tok-mi">0</span><span class="tok-o">);</span>
-  <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">log</span> <span class="tok-o">(</span><span class="tok-n">add</span> <span class="tok-nc">String</span> <span class="tok-s2">&quot;x&quot;</span> <span class="tok-s2">&quot;y&quot;</span><span class="tok-o">);</span></code></pre>
+let () =
+  Js.log (add Float 3.0 2.0);
+  Js.log (add String "x" "y");</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -2166,16 +2105,16 @@ still be recorded.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">string_of_kind</span> <span class="tok-o">(</span><span class="tok-k">type</span> <span class="tok-n">t</span><span class="tok-o">)</span> <span class="tok-o">(</span><span class="tok-n">kind</span> <span class="tok-o">:</span> <span class="tok-n">t</span> <span class="tok-n">kind</span><span class="tok-o">)</span> <span class="tok-o">=</span>
-  <span class="tok-k">match</span> <span class="tok-n">kind</span> <span class="tok-k">with</span>
-  <span class="tok-o">|</span> <span class="tok-nc">Float</span> <span class="tok-o">-&gt;</span> <span class="tok-s2">&quot;float&quot;</span>
-  <span class="tok-o">|</span> <span class="tok-nc">String</span> <span class="tok-o">-&gt;</span> <span class="tok-s2">&quot;string&quot;</span>
+<pre class="pygments highlight"><code data-lang="ocaml">let string_of_kind (type t) (kind : t kind) =
+  match kind with
+  | Float -&gt; "float"
+  | String -&gt; "string"
 
-<span class="tok-k">external</span> <span class="tok-n">add_dyn</span> <span class="tok-o">:</span> <span class="tok-o">(</span><span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-n">kind</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">ignore</span><span class="tok-o">])</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">string</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;&quot;</span>
-<span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">val</span><span class="tok-o">]</span>
+external add_dyn : ('a kind [@bs.ignore]) -&gt; string -&gt; 'a -&gt; 'a -&gt; 'a = ""
+[@@bs.val]
 
-<span class="tok-k">let</span> <span class="tok-n">add2</span> <span class="tok-n">k</span> <span class="tok-n">x</span> <span class="tok-n">y</span> <span class="tok-o">=</span>
-  <span class="tok-n">add_dyn</span> <span class="tok-n">k</span> <span class="tok-o">(</span><span class="tok-n">string_of_kind</span> <span class="tok-n">k</span><span class="tok-o">)</span> <span class="tok-n">x</span> <span class="tok-n">y</span></code></pre>
+let add2 k x y =
+  add_dyn k (string_of_kind k) x y</code></pre>
 </div>
 </div>
 </div>
@@ -2191,21 +2130,21 @@ data.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">external</span> <span class="tok-n">process_on_exit</span> <span class="tok-o">:</span> <span class="tok-o">(_</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">as</span> <span class="tok-s2">&quot;exit&quot;</span><span class="tok-o">])</span> <span class="tok-o">-&gt;</span> <span class="tok-o">(</span><span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">unit</span><span class="tok-o">)</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">unit</span> <span class="tok-o">=</span>
-  <span class="tok-s2">&quot;process.on&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">val</span><span class="tok-o">]</span>
+<pre class="pygments highlight"><code data-lang="ocaml">external process_on_exit : (_ [@bs.as "exit"]) -&gt; (int -&gt; unit) -&gt; unit =
+  "process.on" [@@bs.val]
 
-<span class="tok-k">let</span> <span class="tok-bp">()</span> <span class="tok-o">=</span>
-    <span class="tok-n">process_on_exit</span> <span class="tok-o">(</span><span class="tok-k">fun</span> <span class="tok-n">exit_code</span> <span class="tok-o">-&gt;</span>
-        <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">log</span><span class="tok-o">(</span> <span class="tok-s2">&quot;error code: &quot;</span> <span class="tok-o">^</span> <span class="tok-n">string_of_int</span> <span class="tok-n">exit_code</span> <span class="tok-o">))</span></code></pre>
+let () =
+    process_on_exit (fun exit_code -&gt;
+        Js.log( "error code: " ^ string_of_int exit_code ))</code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="title">Output</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-nx">process</span><span class="tok-p">.</span><span class="tok-nx">on</span><span class="tok-p">(</span><span class="tok-s2">&quot;exit&quot;</span><span class="tok-p">,</span> <span class="tok-kd">function</span> <span class="tok-p">(</span><span class="tok-nx">exit_code</span><span class="tok-p">)</span> <span class="tok-p">{</span>
-      <span class="tok-nx">console</span><span class="tok-p">.</span><span class="tok-nx">log</span><span class="tok-p">(</span><span class="tok-s2">&quot;error code: &quot;</span> <span class="tok-o">+</span> <span class="tok-nx">exit_code</span><span class="tok-p">);</span>
-      <span class="tok-k">return</span> <span class="tok-cm">/* () */</span><span class="tok-mi">0</span><span class="tok-p">;</span>
-    <span class="tok-p">});</span></code></pre>
+<pre class="pygments highlight"><code data-lang="js">process.on("exit", function (exit_code) {
+      console.log("error code: " + exit_code);
+      return /* () */0;
+    });</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -2213,41 +2152,41 @@ data.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">type</span> <span class="tok-n">process</span>
+<pre class="pygments highlight"><code data-lang="ocaml">type process
 
-<span class="tok-k">external</span> <span class="tok-n">on_exit</span> <span class="tok-o">:</span> <span class="tok-o">(_</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">as</span> <span class="tok-s2">&quot;exit&quot;</span><span class="tok-o">])</span> <span class="tok-o">-&gt;</span> <span class="tok-o">(</span><span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">unit</span><span class="tok-o">)</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">unit</span> <span class="tok-o">=</span>
-    <span class="tok-s2">&quot;on&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">send</span><span class="tok-o">.</span><span class="tok-n">pipe</span><span class="tok-o">:</span> <span class="tok-n">process</span><span class="tok-o">]</span>
-<span class="tok-k">let</span> <span class="tok-n">register</span> <span class="tok-o">(</span><span class="tok-n">p</span> <span class="tok-o">:</span> <span class="tok-n">process</span><span class="tok-o">)</span> <span class="tok-o">=</span>
-        <span class="tok-n">p</span> <span class="tok-o">|&gt;</span> <span class="tok-n">on_exit</span> <span class="tok-o">(</span><span class="tok-k">fun</span> <span class="tok-n">i</span> <span class="tok-o">-&gt;</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">log</span> <span class="tok-n">i</span><span class="tok-o">)</span></code></pre>
+external on_exit : (_ [@bs.as "exit"]) -&gt; (int -&gt; unit) -&gt; unit =
+    "on" [@@bs.send.pipe: process]
+let register (p : process) =
+        p |&gt; on_exit (fun i -&gt; Js.log i)</code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="title">Output</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-kd">function</span> <span class="tok-nx">register</span><span class="tok-p">(</span><span class="tok-nx">p</span><span class="tok-p">)</span> <span class="tok-p">{</span>
-  <span class="tok-k">return</span> <span class="tok-nx">p</span><span class="tok-p">.</span><span class="tok-nx">on</span><span class="tok-p">(</span><span class="tok-s2">&quot;exit&quot;</span><span class="tok-p">,</span> <span class="tok-kd">function</span> <span class="tok-p">(</span><span class="tok-nx">i</span><span class="tok-p">)</span> <span class="tok-p">{</span>
-              <span class="tok-nx">console</span><span class="tok-p">.</span><span class="tok-nx">log</span><span class="tok-p">(</span><span class="tok-nx">i</span><span class="tok-p">);</span>
-              <span class="tok-k">return</span> <span class="tok-cm">/* () */</span><span class="tok-mi">0</span><span class="tok-p">;</span>
-            <span class="tok-p">});</span>
-<span class="tok-p">}</span></code></pre>
+<pre class="pygments highlight"><code data-lang="js">function register(p) {
+  return p.on("exit", function (i) {
+              console.log(i);
+              return /* () */0;
+            });
+}</code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="title">Input</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">external</span> <span class="tok-n">io_config</span> <span class="tok-o">:</span>
-    <span class="tok-n">stdio</span><span class="tok-o">:(_</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">as</span> <span class="tok-s2">&quot;inherit&quot;</span><span class="tok-o">])</span> <span class="tok-o">-&gt;</span> <span class="tok-n">cwd</span><span class="tok-o">:</span><span class="tok-kt">string</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">unit</span> <span class="tok-o">-&gt;</span> <span class="tok-o">_</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">obj</span><span class="tok-o">]</span>
+<pre class="pygments highlight"><code data-lang="ocaml">external io_config :
+    stdio:(_ [@bs.as "inherit"]) -&gt; cwd:string -&gt; unit -&gt; _ = "" [@@bs.obj]
 
-<span class="tok-k">let</span> <span class="tok-n">config</span> <span class="tok-o">=</span> <span class="tok-n">io_config</span> <span class="tok-o">~</span><span class="tok-n">cwd</span><span class="tok-o">:</span><span class="tok-s2">&quot;.&quot;</span> <span class="tok-bp">()</span></code></pre>
+let config = io_config ~cwd:"." ()</code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="title">Output</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-kd">var</span> <span class="tok-nx">config</span> <span class="tok-o">=</span> <span class="tok-p">{</span>
-  <span class="tok-nx">stdio</span><span class="tok-o">:</span> <span class="tok-s2">&quot;inherit&quot;</span><span class="tok-p">,</span>
-  <span class="tok-nx">cwd</span><span class="tok-o">:</span> <span class="tok-s2">&quot;.&quot;</span>
-<span class="tok-p">};</span></code></pre>
+<pre class="pygments highlight"><code data-lang="js">var config = {
+  stdio: "inherit",
+  cwd: "."
+};</code></pre>
 </div>
 </div>
 </div>
@@ -2258,31 +2197,31 @@ data.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">external</span> <span class="tok-n">on_exit_slice5</span> <span class="tok-o">:</span>
-    <span class="tok-kt">int</span>
-    <span class="tok-o">-&gt;</span> <span class="tok-o">(_</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">as</span> <span class="tok-mi">3</span><span class="tok-o">])</span>
-    <span class="tok-o">-&gt;</span> <span class="tok-o">(_</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">as</span> <span class="tok-o">{</span><span class="tok-n">json</span><span class="tok-o">|</span><span class="tok-bp">true</span><span class="tok-o">|</span><span class="tok-n">json</span><span class="tok-o">}])</span>
-    <span class="tok-o">-&gt;</span> <span class="tok-o">(_</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">as</span> <span class="tok-o">{</span><span class="tok-n">json</span><span class="tok-o">|</span><span class="tok-bp">false</span><span class="tok-o">|</span><span class="tok-n">json</span><span class="tok-o">}])</span>
-    <span class="tok-o">-&gt;</span> <span class="tok-o">(_</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">as</span> <span class="tok-o">{</span><span class="tok-n">json</span><span class="tok-o">|</span><span class="tok-s2">&quot;你好&quot;</span><span class="tok-o">|</span><span class="tok-n">json</span><span class="tok-o">}])</span>
-    <span class="tok-o">-&gt;</span> <span class="tok-o">(_</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">as</span> <span class="tok-o">{</span><span class="tok-n">json</span><span class="tok-o">|</span> <span class="tok-o">[</span><span class="tok-s2">&quot;你好&quot;</span><span class="tok-o">,</span><span class="tok-mi">1</span><span class="tok-o">,</span><span class="tok-mi">2</span><span class="tok-o">,</span><span class="tok-mi">3</span><span class="tok-o">]</span> <span class="tok-o">|</span><span class="tok-n">json</span><span class="tok-o">}])</span>
-    <span class="tok-o">-&gt;</span> <span class="tok-o">(_</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">as</span> <span class="tok-o">{</span><span class="tok-n">json</span><span class="tok-o">|</span> <span class="tok-o">[{</span> <span class="tok-s2">&quot;arr&quot;</span> <span class="tok-o">:</span> <span class="tok-o">[</span><span class="tok-s2">&quot;你好&quot;</span><span class="tok-o">,</span><span class="tok-mi">1</span><span class="tok-o">,</span><span class="tok-mi">2</span><span class="tok-o">,</span><span class="tok-mi">3</span><span class="tok-o">],</span> <span class="tok-s2">&quot;encoding&quot;</span> <span class="tok-o">:</span> <span class="tok-s2">&quot;utf8&quot;</span><span class="tok-o">}]</span> <span class="tok-o">|</span><span class="tok-n">json</span><span class="tok-o">}])</span>
-    <span class="tok-o">-&gt;</span> <span class="tok-o">(_</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">as</span> <span class="tok-o">{</span><span class="tok-n">json</span><span class="tok-o">|</span> <span class="tok-o">[{</span> <span class="tok-s2">&quot;arr&quot;</span> <span class="tok-o">:</span> <span class="tok-o">[</span><span class="tok-s2">&quot;你好&quot;</span><span class="tok-o">,</span><span class="tok-mi">1</span><span class="tok-o">,</span><span class="tok-mi">2</span><span class="tok-o">,</span><span class="tok-mi">3</span><span class="tok-o">],</span> <span class="tok-s2">&quot;encoding&quot;</span> <span class="tok-o">:</span> <span class="tok-s2">&quot;utf8&quot;</span><span class="tok-o">}]</span> <span class="tok-o">|</span><span class="tok-n">json</span><span class="tok-o">}])</span>
-    <span class="tok-o">-&gt;</span> <span class="tok-o">(_</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">as</span> <span class="tok-s2">&quot;xxx&quot;</span><span class="tok-o">])</span>
-    <span class="tok-o">-&gt;</span> <span class="tok-o">([`</span><span class="tok-n">a</span><span class="tok-o">|`</span><span class="tok-n">b</span><span class="tok-o">|`</span><span class="tok-n">c</span><span class="tok-o">]</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-kt">int</span><span class="tok-o">])</span>
-    <span class="tok-o">-&gt;</span> <span class="tok-o">(_</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">as</span> <span class="tok-s2">&quot;yyy&quot;</span><span class="tok-o">])</span>
-    <span class="tok-o">-&gt;</span> <span class="tok-o">([`</span><span class="tok-n">a</span><span class="tok-o">|`</span><span class="tok-n">b</span><span class="tok-o">|`</span><span class="tok-n">c</span><span class="tok-o">]</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-kt">string</span><span class="tok-o">])</span>
-    <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-kt">array</span>
-    <span class="tok-o">-&gt;</span> <span class="tok-kt">unit</span>
-    <span class="tok-o">=</span>
-    <span class="tok-s2">&quot;xx&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">send</span><span class="tok-o">.</span><span class="tok-n">pipe</span><span class="tok-o">:</span> <span class="tok-n">t</span><span class="tok-o">]</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">splice</span><span class="tok-o">]</span>
+<pre class="pygments highlight"><code data-lang="ocaml">external on_exit_slice5 :
+    int
+    -&gt; (_ [@bs.as 3])
+    -&gt; (_ [@bs.as {json|true|json}])
+    -&gt; (_ [@bs.as {json|false|json}])
+    -&gt; (_ [@bs.as {json|"你好"|json}])
+    -&gt; (_ [@bs.as {json| ["你好",1,2,3] |json}])
+    -&gt; (_ [@bs.as {json| [{ "arr" : ["你好",1,2,3], "encoding" : "utf8"}] |json}])
+    -&gt; (_ [@bs.as {json| [{ "arr" : ["你好",1,2,3], "encoding" : "utf8"}] |json}])
+    -&gt; (_ [@bs.as "xxx"])
+    -&gt; ([`a|`b|`c] [@bs.int])
+    -&gt; (_ [@bs.as "yyy"])
+    -&gt; ([`a|`b|`c] [@bs.string])
+    -&gt; int array
+    -&gt; unit
+    =
+    "xx" [@@bs.send.pipe: t] [@@bs.splice]
 
-<span class="tok-k">let</span> <span class="tok-o">_</span> <span class="tok-o">=</span> <span class="tok-n">x</span> <span class="tok-o">|&gt;</span> <span class="tok-n">on_exit_slice5</span> <span class="tok-o">__</span><span class="tok-n">LINE__</span> <span class="tok-o">`</span><span class="tok-n">a</span> <span class="tok-o">`</span><span class="tok-n">b</span> <span class="tok-o">[|</span><span class="tok-mi">1</span><span class="tok-o">;</span><span class="tok-mi">2</span><span class="tok-o">;</span><span class="tok-mi">3</span><span class="tok-o">;</span><span class="tok-mi">4</span><span class="tok-o">;</span><span class="tok-mi">5</span><span class="tok-o">|]</span></code></pre>
+let _ = x |&gt; on_exit_slice5 __LINE__ `a `b [|1;2;3;4;5|]</code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="title">Output</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-nx">x</span><span class="tok-p">.</span><span class="tok-nx">xx</span><span class="tok-p">(</span><span class="tok-mi">114</span><span class="tok-p">,</span> <span class="tok-mi">3</span><span class="tok-p">,</span> <span class="tok-kc">true</span><span class="tok-p">,</span> <span class="tok-kc">false</span><span class="tok-p">,</span> <span class="tok-p">(</span><span class="tok-s2">&quot;你好&quot;</span><span class="tok-p">),</span> <span class="tok-p">(</span> <span class="tok-p">[</span><span class="tok-s2">&quot;你好&quot;</span><span class="tok-p">,</span><span class="tok-mi">1</span><span class="tok-p">,</span><span class="tok-mi">2</span><span class="tok-p">,</span><span class="tok-mi">3</span><span class="tok-p">]</span> <span class="tok-p">),</span> <span class="tok-p">(</span> <span class="tok-p">[{</span> <span class="tok-s2">&quot;arr&quot;</span> <span class="tok-o">:</span> <span class="tok-p">[</span><span class="tok-s2">&quot;你好&quot;</span><span class="tok-p">,</span><span class="tok-mi">1</span><span class="tok-p">,</span><span class="tok-mi">2</span><span class="tok-p">,</span><span class="tok-mi">3</span><span class="tok-p">],</span> <span class="tok-s2">&quot;encoding&quot;</span> <span class="tok-o">:</span> <span class="tok-s2">&quot;utf8&quot;</span><span class="tok-p">}]</span> <span class="tok-p">),</span> <span class="tok-p">(</span> <span class="tok-p">[{</span> <span class="tok-s2">&quot;arr&quot;</span> <span class="tok-o">:</span> <span class="tok-p">[</span><span class="tok-s2">&quot;你好&quot;</span><span class="tok-p">,</span><span class="tok-mi">1</span><span class="tok-p">,</span><span class="tok-mi">2</span><span class="tok-p">,</span><span class="tok-mi">3</span><span class="tok-p">],</span> <span class="tok-s2">&quot;encoding&quot;</span> <span class="tok-o">:</span> <span class="tok-s2">&quot;utf8&quot;</span><span class="tok-p">}]</span> <span class="tok-p">),</span> <span class="tok-s2">&quot;xxx&quot;</span><span class="tok-p">,</span> <span class="tok-mi">0</span><span class="tok-p">,</span> <span class="tok-s2">&quot;yyy&quot;</span><span class="tok-p">,</span> <span class="tok-s2">&quot;b&quot;</span><span class="tok-p">,</span> <span class="tok-mi">1</span><span class="tok-p">,</span> <span class="tok-mi">2</span><span class="tok-p">,</span> <span class="tok-mi">3</span><span class="tok-p">,</span> <span class="tok-mi">4</span><span class="tok-p">,</span> <span class="tok-mi">5</span><span class="tok-p">)</span></code></pre>
+<pre class="pygments highlight"><code data-lang="js">x.xx(114, 3, true, false, ("你好"), ( ["你好",1,2,3] ), ( [{ "arr" : ["你好",1,2,3], "encoding" : "utf8"}] ), ( [{ "arr" : ["你好",1,2,3], "encoding" : "utf8"}] ), "xxx", 0, "yyy", "b", 1, 2, 3, 4, 5)</code></pre>
 </div>
 </div>
 </div>
@@ -2297,10 +2236,10 @@ Their semantics are more like macros instead of functions.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">dirname</span> <span class="tok-o">:</span> <span class="tok-kt">string</span> <span class="tok-n">option</span> <span class="tok-o">=</span> <span class="tok-o">[%</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">node</span> <span class="tok-o">__</span><span class="tok-n">dirname</span><span class="tok-o">]</span>
-<span class="tok-k">let</span> <span class="tok-n">filename</span> <span class="tok-o">:</span> <span class="tok-kt">string</span> <span class="tok-n">option</span> <span class="tok-o">=</span> <span class="tok-o">[%</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">node</span> <span class="tok-o">__</span><span class="tok-n">filename</span><span class="tok-o">]</span>
-<span class="tok-k">let</span> <span class="tok-o">_</span><span class="tok-n">module</span> <span class="tok-o">:</span> <span class="tok-nn">Node</span><span class="tok-p">.</span><span class="tok-n">node_module</span> <span class="tok-n">option</span> <span class="tok-o">=</span> <span class="tok-o">[%</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">node</span> <span class="tok-o">_</span><span class="tok-n">module</span><span class="tok-o">]</span>
-<span class="tok-k">let</span> <span class="tok-n">require</span> <span class="tok-o">:</span> <span class="tok-nn">Node</span><span class="tok-p">.</span><span class="tok-n">node_require</span> <span class="tok-n">option</span> <span class="tok-o">=</span> <span class="tok-o">[%</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">node</span> <span class="tok-n">require</span><span class="tok-o">]</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">let dirname : string option = [%bs.node __dirname]
+let filename : string option = [%bs.node __filename]
+let _module : Node.node_module option = [%bs.node _module]
+let require : Node.node_require option = [%bs.node require]</code></pre>
 </div>
 </div>
 </div>
@@ -2313,14 +2252,14 @@ JS has a map function as below:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-kd">function</span> <span class="tok-nx">map</span> <span class="tok-p">(</span><span class="tok-nx">a</span><span class="tok-p">,</span> <span class="tok-nx">b</span><span class="tok-p">,</span> <span class="tok-nx">f</span><span class="tok-p">){</span>
-  <span class="tok-kd">var</span> <span class="tok-nx">i</span> <span class="tok-o">=</span> <span class="tok-nb">Math</span><span class="tok-p">.</span><span class="tok-nx">min</span><span class="tok-p">(</span><span class="tok-nx">a</span><span class="tok-p">.</span><span class="tok-nx">length</span><span class="tok-p">,</span> <span class="tok-nx">b</span><span class="tok-p">.</span><span class="tok-nx">length</span><span class="tok-p">);</span>
-  <span class="tok-kd">var</span> <span class="tok-nx">c</span> <span class="tok-o">=</span> <span class="tok-k">new</span> <span class="tok-nb">Array</span><span class="tok-p">(</span><span class="tok-nx">i</span><span class="tok-p">);</span>
-  <span class="tok-k">for</span><span class="tok-p">(</span><span class="tok-kd">var</span> <span class="tok-nx">j</span> <span class="tok-o">=</span> <span class="tok-mi">0</span><span class="tok-p">;</span> <span class="tok-nx">j</span> <span class="tok-o">&lt;</span> <span class="tok-nx">i</span><span class="tok-p">;</span> <span class="tok-o">++</span><span class="tok-nx">j</span><span class="tok-p">){</span>
-    <span class="tok-nx">c</span><span class="tok-p">[</span><span class="tok-nx">j</span><span class="tok-p">]</span> <span class="tok-o">=</span> <span class="tok-nx">f</span><span class="tok-p">(</span><span class="tok-nx">a</span><span class="tok-p">[</span><span class="tok-nx">i</span><span class="tok-p">],</span><span class="tok-nx">b</span><span class="tok-p">[</span><span class="tok-nx">i</span><span class="tok-p">])</span>
-  <span class="tok-p">}</span>
-  <span class="tok-k">return</span> <span class="tok-nx">c</span> <span class="tok-p">;</span>
-<span class="tok-p">}</span></code></pre>
+<pre class="pygments highlight"><code data-lang="js">function map (a, b, f){
+  var i = Math.min(a.length, b.length);
+  var c = new Array(i);
+  for(var j = 0; j &lt; i; ++j){
+    c[j] = f(a[i],b[i])
+  }
+  return c ;
+}</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -2328,7 +2267,7 @@ JS has a map function as below:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">external</span> <span class="tok-n">map</span> <span class="tok-o">:</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-kt">array</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">b</span> <span class="tok-kt">array</span> <span class="tok-o">-&gt;</span> <span class="tok-o">(</span><span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">b</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">c</span><span class="tok-o">)</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">c</span> <span class="tok-kt">array</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">val</span><span class="tok-o">]</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">external map : 'a array -&gt; 'b array -&gt; ('a -&gt; 'b -&gt; 'c) -&gt; 'c array = "" [@@bs.val]</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -2337,12 +2276,12 @@ reading the type <code>'a &#8594; 'b &#8594; 'c</code>, it can be in several cas
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">f</span> <span class="tok-n">x</span> <span class="tok-n">y</span> <span class="tok-o">=</span> <span class="tok-n">x</span> <span class="tok-o">+</span> <span class="tok-n">y</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">let f x y = x + y</code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">g</span> <span class="tok-n">x</span> <span class="tok-o">=</span> <span class="tok-k">let</span> <span class="tok-n">z</span> <span class="tok-o">=</span> <span class="tok-n">x</span> <span class="tok-o">+</span> <span class="tok-mi">1</span> <span class="tok-k">in</span> <span class="tok-k">fun</span> <span class="tok-n">y</span> <span class="tok-o">-&gt;</span> <span class="tok-n">x</span> <span class="tok-o">+</span> <span class="tok-n">z</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">let g x = let z = x + 1 in fun y -&gt; x + z</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -2355,22 +2294,22 @@ different arities.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">f</span> <span class="tok-o">=</span> <span class="tok-k">fun</span> <span class="tok-n">x</span> <span class="tok-o">-&gt;</span> <span class="tok-k">fun</span> <span class="tok-n">y</span> <span class="tok-o">-&gt;</span> <span class="tok-n">x</span> <span class="tok-o">+</span> <span class="tok-n">y</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">let f = fun x -&gt; fun y -&gt; x + y</code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-kd">function</span> <span class="tok-nx">f</span><span class="tok-p">(</span><span class="tok-nx">x</span><span class="tok-p">){</span>
-  <span class="tok-k">return</span> <span class="tok-kd">function</span> <span class="tok-p">(</span><span class="tok-nx">y</span><span class="tok-p">){</span>
-    <span class="tok-k">return</span> <span class="tok-nx">x</span> <span class="tok-o">+</span> <span class="tok-nx">y</span><span class="tok-p">;</span>
-  <span class="tok-p">}</span>
-<span class="tok-p">}</span>
-<span class="tok-kd">function</span> <span class="tok-nx">g</span><span class="tok-p">(</span><span class="tok-nx">x</span><span class="tok-p">){</span>
-  <span class="tok-kd">var</span> <span class="tok-nx">z</span> <span class="tok-o">=</span> <span class="tok-nx">x</span> <span class="tok-o">+</span> <span class="tok-mi">1</span> <span class="tok-p">;</span>
-  <span class="tok-k">return</span> <span class="tok-kd">function</span> <span class="tok-p">(</span><span class="tok-nx">y</span><span class="tok-p">){</span>
-    <span class="tok-k">return</span> <span class="tok-nx">x</span> <span class="tok-o">+</span> <span class="tok-nx">z</span> <span class="tok-p">;</span>
-  <span class="tok-p">}</span>
-<span class="tok-p">}</span></code></pre>
+<pre class="pygments highlight"><code data-lang="js">function f(x){
+  return function (y){
+    return x + y;
+  }
+}
+function g(x){
+  var z = x + 1 ;
+  return function (y){
+    return x + z ;
+  }
+}</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -2382,9 +2321,9 @@ however, we expect <em>its arity to be 2</em>.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-kd">function</span> <span class="tok-nx">f</span><span class="tok-p">(</span><span class="tok-nx">x</span><span class="tok-p">,</span><span class="tok-nx">y</span><span class="tok-p">){</span>
-  <span class="tok-k">return</span> <span class="tok-nx">x</span> <span class="tok-o">+</span> <span class="tok-nx">y</span> <span class="tok-p">;</span>
-<span class="tok-p">}</span></code></pre>
+<pre class="pygments highlight"><code data-lang="js">function f(x,y){
+  return x + y ;
+}</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -2399,8 +2338,8 @@ we support a special attribute <code>[@bs]</code> at the type level.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">external</span> <span class="tok-n">map</span> <span class="tok-o">:</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-kt">array</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">b</span> <span class="tok-kt">array</span> <span class="tok-o">-&gt;</span> <span class="tok-o">(</span><span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">b</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">c</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">])</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">c</span> <span class="tok-kt">array</span>
-<span class="tok-o">=</span> <span class="tok-s2">&quot;map&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">val</span><span class="tok-o">]</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">external map : 'a array -&gt; 'b array -&gt; ('a -&gt; 'b -&gt; 'c [@bs]) -&gt; 'c array
+= "map" [@@bs.val]</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -2416,9 +2355,9 @@ unknown.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">f</span> <span class="tok-o">:</span> <span class="tok-k">&#39;</span><span class="tok-n">a0</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">a1</span> <span class="tok-o">-&gt;</span> <span class="tok-o">..</span> <span class="tok-k">&#39;</span><span class="tok-n">b0</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">]</span> <span class="tok-o">=</span>
-  <span class="tok-k">fun</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">]</span> <span class="tok-n">a0</span> <span class="tok-n">a1</span> <span class="tok-o">..</span> <span class="tok-n">aN</span> <span class="tok-o">-&gt;</span> <span class="tok-n">b0</span>
-<span class="tok-k">let</span> <span class="tok-n">b</span> <span class="tok-o">:</span> <span class="tok-k">&#39;</span><span class="tok-n">b0</span> <span class="tok-o">=</span> <span class="tok-n">f</span> <span class="tok-n">a0</span> <span class="tok-n">a1</span> <span class="tok-n">a2</span> <span class="tok-o">..</span> <span class="tok-n">aN</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">]</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">let f : 'a0 -&gt; 'a1 -&gt; .. 'b0 [@bs] =
+  fun [@bs] a0 a1 .. aN -&gt; b0
+let b : 'b0 = f a0 a1 a2 .. aN [@bs]</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -2426,8 +2365,8 @@ unknown.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">f</span> <span class="tok-o">:</span> <span class="tok-kt">unit</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">b0</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">]</span> <span class="tok-o">=</span> <span class="tok-k">fun</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">]</span> <span class="tok-bp">()</span> <span class="tok-o">-&gt;</span> <span class="tok-n">b0</span>
-<span class="tok-k">let</span> <span class="tok-n">b</span> <span class="tok-o">:</span> <span class="tok-k">&#39;</span><span class="tok-n">b0</span> <span class="tok-o">=</span> <span class="tok-n">f</span> <span class="tok-bp">()</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">]</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">let f : unit -&gt; 'b0 [@bs] = fun [@bs] () -&gt; b0
+let b : 'b0 = f () [@bs]</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -2441,10 +2380,10 @@ will complain.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">type</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-n">return</span> <span class="tok-o">=</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">]</span>
-<span class="tok-k">type</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-n">u0</span> <span class="tok-o">=</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">string</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-n">return</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">]</span> <b class="conum">(1)</b>
-<span class="tok-k">type</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-n">u1</span> <span class="tok-o">=</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">string</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">]</span> <b class="conum">(2)</b>
-<span class="tok-k">type</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-n">u2</span> <span class="tok-o">=</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">string</span> <span class="tok-o">-&gt;</span> <span class="tok-o">(</span><span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">])</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">]</span> <b class="conum">(3)</b></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">type 'a return = int -&gt; 'a [@bs]
+type 'a u0 = int -&gt; string -&gt; 'a return [@bs] <b class="conum">(1)</b>
+type 'a u1 = int -&gt; string -&gt; int -&gt; 'a [@bs] <b class="conum">(2)</b>
+type 'a u2 = int -&gt; string -&gt; (int -&gt; 'a [@bs]) [@bs] <b class="conum">(3)</b></code></pre>
 </div>
 </div>
 <div class="colist arabic">
@@ -2473,8 +2412,8 @@ that it requires users to write <code>[@bs]</code> both in definition site and c
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">external</span> <span class="tok-n">map</span> <span class="tok-o">:</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-kt">array</span> <span class="tok-o">-&gt;</span> <span class="tok-o">(</span><span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">b</span><span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">])</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">b</span> <span class="tok-kt">array</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">send</span><span class="tok-o">]</span> <b class="conum">(1)</b>
-<span class="tok-n">map</span> <span class="tok-o">[|</span><span class="tok-mi">1</span><span class="tok-o">;</span><span class="tok-mi">2</span><span class="tok-o">;</span><span class="tok-mi">3</span><span class="tok-o">|]</span> <span class="tok-o">(</span><span class="tok-k">fun</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">]</span> <span class="tok-n">x</span> <span class="tok-o">-&gt;</span> <span class="tok-n">x</span> <span class="tok-o">+</span> <span class="tok-mi">1</span><span class="tok-o">)</span> <b class="conum">(2)</b></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">external map : 'a array -&gt; ('a -&gt; 'b[@bs]) -&gt; 'b array = "" [@@bs.send] <b class="conum">(1)</b>
+map [|1;2;3|] (fun [@bs] x -&gt; x + 1) <b class="conum">(2)</b></code></pre>
 </div>
 </div>
 <div class="colist arabic">
@@ -2493,8 +2432,8 @@ only once.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">external</span> <span class="tok-n">map</span> <span class="tok-o">:</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-kt">array</span> <span class="tok-o">-&gt;</span> <span class="tok-o">(</span><span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">b</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">uncurry</span><span class="tok-o">])</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">b</span> <span class="tok-kt">array</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">send</span><span class="tok-o">]</span> <b class="conum">(1)</b>
-<span class="tok-n">map</span> <span class="tok-o">[|</span><span class="tok-mi">1</span><span class="tok-o">;</span><span class="tok-mi">2</span><span class="tok-o">;</span><span class="tok-mi">3</span><span class="tok-o">|]</span> <span class="tok-o">(</span><span class="tok-k">fun</span> <span class="tok-n">x</span> <span class="tok-o">-&gt;</span> <span class="tok-n">x</span><span class="tok-o">+</span> <span class="tok-mi">1</span><span class="tok-o">)</span> <b class="conum">(2)</b></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">external map : 'a array -&gt; ('a -&gt; 'b [@bs.uncurry]) -&gt; 'b array = "" [@@bs.send] <b class="conum">(1)</b>
+map [|1;2;3|] (fun x -&gt; x+ 1) <b class="conum">(2)</b></code></pre>
 </div>
 </div>
 <div class="colist arabic">
@@ -2539,9 +2478,9 @@ the native compilation is very slow and expensive for all functions.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">f</span> <span class="tok-n">x</span> <span class="tok-n">y</span> <span class="tok-n">z</span> <span class="tok-o">=</span> <span class="tok-n">x</span> <span class="tok-o">+</span> <span class="tok-n">y</span> <span class="tok-o">+</span> <span class="tok-n">z</span>
-<span class="tok-k">let</span> <span class="tok-n">a</span> <span class="tok-o">=</span> <span class="tok-n">f</span> <span class="tok-mi">1</span> <span class="tok-mi">2</span> <span class="tok-mi">3</span>
-<span class="tok-k">let</span> <span class="tok-n">b</span> <span class="tok-o">=</span> <span class="tok-n">f</span> <span class="tok-mi">1</span> <span class="tok-mi">2</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">let f x y z = x + y + z
+let a = f 1 2 3
+let b = f 1 2</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -2549,15 +2488,15 @@ the native compilation is very slow and expensive for all functions.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-kd">function</span> <span class="tok-nx">f</span><span class="tok-p">(</span><span class="tok-nx">x</span><span class="tok-p">){</span>
-  <span class="tok-k">return</span> <span class="tok-kd">function</span> <span class="tok-p">(</span><span class="tok-nx">y</span><span class="tok-p">){</span>
-    <span class="tok-k">return</span> <span class="tok-kd">function</span> <span class="tok-p">(</span><span class="tok-nx">z</span><span class="tok-p">){</span>
-      <span class="tok-k">return</span> <span class="tok-nx">x</span> <span class="tok-o">+</span> <span class="tok-nx">y</span> <span class="tok-o">+</span> <span class="tok-nx">z</span>
-    <span class="tok-p">}</span>
-  <span class="tok-p">}</span>
-<span class="tok-p">}</span>
-<span class="tok-kd">var</span> <span class="tok-nx">a</span> <span class="tok-o">=</span> <span class="tok-nx">f</span> <span class="tok-p">(</span><span class="tok-mi">1</span><span class="tok-p">)</span> <span class="tok-p">(</span><span class="tok-mi">2</span><span class="tok-p">)</span> <span class="tok-p">(</span><span class="tok-mi">3</span><span class="tok-p">)</span>
-<span class="tok-kd">var</span> <span class="tok-nx">b</span> <span class="tok-o">=</span> <span class="tok-nx">f</span> <span class="tok-p">(</span><span class="tok-mi">1</span><span class="tok-p">)</span> <span class="tok-p">(</span><span class="tok-mi">2</span><span class="tok-p">)</span></code></pre>
+<pre class="pygments highlight"><code data-lang="js">function f(x){
+  return function (y){
+    return function (z){
+      return x + y + z
+    }
+  }
+}
+var a = f (1) (2) (3)
+var b = f (1) (2)</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -2566,9 +2505,9 @@ already <em>saw the source definition</em> of <code>f</code>, it can be optimize
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-kd">function</span> <span class="tok-nx">f</span><span class="tok-p">(</span><span class="tok-nx">x</span><span class="tok-p">,</span><span class="tok-nx">y</span><span class="tok-p">,</span><span class="tok-nx">z</span><span class="tok-p">)</span> <span class="tok-p">{</span><span class="tok-k">return</span> <span class="tok-nx">x</span> <span class="tok-o">+</span> <span class="tok-nx">y</span> <span class="tok-o">+</span> <span class="tok-nx">z</span><span class="tok-p">}</span>
-<span class="tok-kd">var</span> <span class="tok-nx">a</span> <span class="tok-o">=</span> <span class="tok-nx">f</span><span class="tok-p">(</span><span class="tok-mi">1</span><span class="tok-p">,</span><span class="tok-mi">2</span><span class="tok-p">,</span><span class="tok-mi">3</span><span class="tok-p">)</span>
-<span class="tok-kd">var</span> <span class="tok-nx">b</span> <span class="tok-o">=</span> <span class="tok-kd">function</span><span class="tok-p">(</span><span class="tok-nx">z</span><span class="tok-p">){</span><span class="tok-k">return</span> <span class="tok-nx">f</span><span class="tok-p">(</span><span class="tok-mi">1</span><span class="tok-p">,</span><span class="tok-mi">2</span><span class="tok-p">,</span><span class="tok-nx">z</span><span class="tok-p">)}</span></code></pre>
+<pre class="pygments highlight"><code data-lang="js">function f(x,y,z) {return x + y + z}
+var a = f(1,2,3)
+var b = function(z){return f(1,2,z)}</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -2586,7 +2525,7 @@ i.e, callbacks.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">app</span> <span class="tok-n">f</span> <span class="tok-n">x</span> <span class="tok-o">=</span> <span class="tok-n">f</span> <span class="tok-n">x</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">let app f x = f x</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -2596,9 +2535,9 @@ have to generate code as below:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-kd">function</span> <span class="tok-nx">app</span><span class="tok-p">(</span><span class="tok-nx">f</span><span class="tok-p">,</span><span class="tok-nx">x</span><span class="tok-p">){</span>
-  <span class="tok-k">return</span> <span class="tok-nx">Curry</span><span class="tok-p">.</span><span class="tok-nx">_1</span><span class="tok-p">(</span><span class="tok-nx">f</span><span class="tok-p">,</span><span class="tok-nx">x</span><span class="tok-p">);</span>
-<span class="tok-p">}</span></code></pre>
+<pre class="pygments highlight"><code data-lang="js">function app(f,x){
+  return Curry._1(f,x);
+}</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -2611,7 +2550,7 @@ as below</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">app</span> <span class="tok-n">f</span> <span class="tok-n">x</span> <span class="tok-o">=</span> <span class="tok-n">f</span> <span class="tok-n">x</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">]</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">let app f x = f x [@bs]</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -2620,9 +2559,9 @@ as below</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-kd">function</span> <span class="tok-nx">app</span><span class="tok-p">(</span><span class="tok-nx">f</span><span class="tok-p">,</span><span class="tok-nx">x</span><span class="tok-p">){</span>
-  <span class="tok-k">return</span> <span class="tok-nx">f</span><span class="tok-p">(</span><span class="tok-nx">x</span><span class="tok-p">)</span>
-<span class="tok-p">}</span></code></pre>
+<pre class="pygments highlight"><code data-lang="js">function app(f,x){
+  return f(x)
+}</code></pre>
 </div>
 </div>
 <div class="admonitionblock note">
@@ -2652,9 +2591,9 @@ example:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-nx">x</span><span class="tok-p">.</span><span class="tok-nx">onload</span> <span class="tok-o">=</span> <span class="tok-kd">function</span><span class="tok-p">(</span><span class="tok-nx">v</span><span class="tok-p">){</span>
-  <span class="tok-nx">console</span><span class="tok-p">.</span><span class="tok-nx">log</span><span class="tok-p">(</span><span class="tok-k">this</span><span class="tok-p">.</span><span class="tok-nx">response</span> <span class="tok-o">+</span> <span class="tok-nx">v</span> <span class="tok-p">)</span>
-<span class="tok-p">}</span></code></pre>
+<pre class="pygments highlight"><code data-lang="js">x.onload = function(v){
+  console.log(this.response + v )
+}</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -2666,21 +2605,21 @@ Instead, we introduced a special attribute
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">type</span> <span class="tok-n">x</span>
-<span class="tok-k">external</span> <span class="tok-n">set_onload</span> <span class="tok-o">:</span> <span class="tok-n">x</span> <span class="tok-o">-&gt;</span> <span class="tok-o">(</span><span class="tok-n">x</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">unit</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">this</span><span class="tok-o">])</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">unit</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;onload&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">set</span><span class="tok-o">]</span>
-<span class="tok-k">external</span> <span class="tok-n">resp</span> <span class="tok-o">:</span> <span class="tok-n">x</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;response&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">get</span><span class="tok-o">]</span>
-<span class="tok-n">set_onload</span> <span class="tok-n">x</span> <span class="tok-k">begin</span> <span class="tok-k">fun</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">this</span><span class="tok-o">]</span> <span class="tok-n">o</span> <span class="tok-n">v</span> <span class="tok-o">-&gt;</span>
-  <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">log</span><span class="tok-o">(</span><span class="tok-n">resp</span> <span class="tok-n">o</span> <span class="tok-o">+</span> <span class="tok-n">v</span> <span class="tok-o">)</span>
-<span class="tok-k">end</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">type x
+external set_onload : x -&gt; (x -&gt; int -&gt; unit [@bs.this]) -&gt; unit = "onload" [@@bs.set]
+external resp : x -&gt; int = "response" [@@bs.get]
+set_onload x begin fun [@bs.this] o v -&gt;
+  Js.log(resp o + v )
+end</code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="title">Output:</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-nx">x</span><span class="tok-p">.</span><span class="tok-nx">onload</span> <span class="tok-o">=</span> <span class="tok-kd">function</span><span class="tok-p">(</span><span class="tok-nx">v</span><span class="tok-p">){</span>
-  <span class="tok-kd">var</span> <span class="tok-nx">o</span> <span class="tok-o">=</span> <span class="tok-k">this</span> <span class="tok-p">;</span> <b class="conum">(1)</b>
-  <span class="tok-nx">console</span><span class="tok-p">.</span><span class="tok-nx">log</span><span class="tok-p">(</span><span class="tok-nx">o</span><span class="tok-p">.</span><span class="tok-nx">response</span> <span class="tok-o">+</span> <span class="tok-nx">v</span><span class="tok-p">);</span>
-<span class="tok-p">}</span></code></pre>
+<pre class="pygments highlight"><code data-lang="js">x.onload = function(v){
+  var o = this ; <b class="conum">(1)</b>
+  console.log(o.response + v);
+}</code></pre>
 </div>
 </div>
 <div class="colist arabic">
@@ -2696,10 +2635,10 @@ reserved for <code>this</code> and for arity of 0, there is no need for a redund
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">f</span> <span class="tok-o">:</span> <span class="tok-k">&#39;</span><span class="tok-n">obj</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">b</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">this</span><span class="tok-o">]</span> <span class="tok-o">=</span>
-  <span class="tok-k">fun</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">this</span><span class="tok-o">]</span> <span class="tok-n">obj</span> <span class="tok-o">-&gt;</span> <span class="tok-o">....</span>
-<span class="tok-k">let</span> <span class="tok-n">f1</span> <span class="tok-o">:</span> <span class="tok-k">&#39;</span><span class="tok-n">obj</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">a0</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">b</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">this</span><span class="tok-o">]</span> <span class="tok-o">=</span>
-  <span class="tok-k">fun</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">this</span><span class="tok-o">]</span> <span class="tok-n">obj</span> <span class="tok-n">a</span> <span class="tok-o">-&gt;</span> <span class="tok-o">...</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">let f : 'obj -&gt; 'b [@bs.this] =
+  fun [@bs.this] obj -&gt; ....
+let f1 : 'obj -&gt; 'a0 -&gt; 'b [@bs.this] =
+  fun [@bs.this] obj a -&gt; ...</code></pre>
 </div>
 </div>
 <div class="admonitionblock note">
@@ -2754,8 +2693,8 @@ which exports two properties: <code>height</code> and <code>width</code>:</p>
 <div class="listingblock">
 <div class="title">demo.js</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-nx">exports</span><span class="tok-p">.</span><span class="tok-nx">height</span> <span class="tok-o">=</span> <span class="tok-mi">3</span>
-<span class="tok-nx">exports</span><span class="tok-p">.</span><span class="tok-nx">width</span>  <span class="tok-o">=</span> <span class="tok-mi">3</span></code></pre>
+<pre class="pygments highlight"><code data-lang="js">exports.height = 3
+exports.width  = 3</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -2764,7 +2703,7 @@ here we use OCaml objects to model module <code>demo</code></p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">external</span> <span class="tok-n">demo</span> <span class="tok-o">:</span> <span class="tok-o">&lt;</span> <span class="tok-n">height</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">;</span> <span class="tok-n">width</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">&gt;</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">t</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">module</span><span class="tok-o">]</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">external demo : &lt; height : int ; width : int &gt; Js.t = "" [@@bs.module]</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -2776,10 +2715,10 @@ here we use OCaml objects to model module <code>demo</code></p>
 <p>normal type</p>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-o">&lt;</span> <span class="tok-n">label</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">&gt;</span>
-<span class="tok-o">&lt;</span> <span class="tok-n">label</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">&gt;</span>
-<span class="tok-o">&lt;</span> <span class="tok-n">label</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">]&gt;</span>
-<span class="tok-o">&lt;</span> <span class="tok-n">label</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">this</span><span class="tok-o">]&gt;</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">&lt; label : int &gt;
+&lt; label : int -&gt; int &gt;
+&lt; label : int -&gt; int [@bs]&gt;
+&lt; label : int -&gt; int [@bs.this]&gt;</code></pre>
 </div>
 </div>
 </li>
@@ -2787,7 +2726,7 @@ here we use OCaml objects to model module <code>demo</code></p>
 <p>method</p>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-o">&lt;</span> <span class="tok-n">label</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">meth</span><span class="tok-o">]</span> <span class="tok-o">&gt;</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">&lt; label : int -&gt; int [@bs.meth] &gt;</code></pre>
 </div>
 </div>
 </li>
@@ -2802,14 +2741,14 @@ its arguments all at the same time, since its semantics depends on <code>this</c
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">test</span> <span class="tok-n">f</span> <span class="tok-o">=</span>
-  <span class="tok-n">f</span><span class="tok-o">##</span><span class="tok-n">hi</span> <span class="tok-mi">1</span> <b class="conum">(1)</b>
-<span class="tok-k">let</span> <span class="tok-n">test2</span> <span class="tok-n">f</span> <span class="tok-o">=</span>
-  <span class="tok-k">let</span> <span class="tok-n">u</span> <span class="tok-o">=</span> <span class="tok-n">f</span><span class="tok-o">##</span><span class="tok-n">hi</span> <span class="tok-k">in</span>
-  <span class="tok-n">u</span> <span class="tok-mi">1</span>
-<span class="tok-k">let</span> <span class="tok-n">test3</span> <span class="tok-n">f</span> <span class="tok-o">=</span>
-  <span class="tok-k">let</span> <span class="tok-n">u</span> <span class="tok-o">=</span> <span class="tok-n">f</span><span class="tok-o">##</span><span class="tok-n">hi</span> <span class="tok-k">in</span>
-  <span class="tok-n">u</span> <span class="tok-mi">1</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">]</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">let test f =
+  f##hi 1 <b class="conum">(1)</b>
+let test2 f =
+  let u = f##hi in
+  u 1
+let test3 f =
+  let u = f##hi in
+  u 1 [@bs]</code></pre>
 </div>
 </div>
 <div class="colist arabic">
@@ -2824,9 +2763,9 @@ its arguments all at the same time, since its semantics depends on <code>this</c
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">val</span> <span class="tok-n">test</span> <span class="tok-o">:</span> <span class="tok-o">&lt;</span> <span class="tok-n">hi</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">meth</span><span class="tok-o">];</span> <span class="tok-o">..</span> <span class="tok-o">&gt;</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <b class="conum">(1)</b>
-<span class="tok-k">val</span> <span class="tok-n">test2</span> <span class="tok-o">:</span> <span class="tok-o">&lt;</span> <span class="tok-n">hi</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-o">;</span> <span class="tok-o">..</span> <span class="tok-o">&gt;</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span>
-<span class="tok-k">val</span> <span class="tok-n">test3</span> <span class="tok-o">:</span> <span class="tok-o">&lt;</span> <span class="tok-n">hi</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">];</span> <span class="tok-o">..</span> <span class="tok-o">&gt;</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">val test : &lt; hi : int -&gt; 'a [@bs.meth]; .. &gt; -&gt; 'a <b class="conum">(1)</b>
+val test2 : &lt; hi : int -&gt; 'a ; .. &gt; -&gt; 'a
+val test3 : &lt; hi : int -&gt; 'a [@bs]; .. &gt;</code></pre>
 </div>
 </div>
 <div class="colist arabic">
@@ -2844,12 +2783,12 @@ its arguments all at the same time, since its semantics depends on <code>this</c
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">class</span> <span class="tok-k">type</span> <span class="tok-o">_</span><span class="tok-n">rect</span> <span class="tok-o">=</span> <span class="tok-k">object</span>
-  <span class="tok-k">method</span> <span class="tok-n">height</span> <span class="tok-o">:</span> <span class="tok-kt">int</span>
-  <span class="tok-k">method</span> <span class="tok-n">width</span> <span class="tok-o">:</span> <span class="tok-kt">int</span>
-  <span class="tok-k">method</span> <span class="tok-n">draw</span> <span class="tok-o">:</span> <span class="tok-kt">unit</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">unit</span>
-<span class="tok-k">end</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">]</span> <b class="conum">(1)</b>
-<span class="tok-k">type</span> <span class="tok-n">rect</span> <span class="tok-o">=</span> <span class="tok-o">_</span><span class="tok-n">rect</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">t</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">class type _rect = object
+  method height : int
+  method width : int
+  method draw : unit -&gt; unit
+end [@bs] <b class="conum">(1)</b>
+type rect = _rect Js.t</code></pre>
 </div>
 </div>
 <div class="colist arabic">
@@ -2871,7 +2810,7 @@ are treated as properties.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">type</span> <span class="tok-n">rect</span> <span class="tok-o">=</span> <span class="tok-o">&lt;</span> <span class="tok-n">height</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">;</span> <span class="tok-n">wdith</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">;</span> <span class="tok-n">draw</span> <span class="tok-o">:</span> <span class="tok-kt">unit</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">unit</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">meth</span><span class="tok-o">]</span> <span class="tok-o">&gt;</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">t</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">type rect = &lt; height : int ; wdith : int ; draw : unit -&gt; unit [@bs.meth] &gt; Js.t</code></pre>
 </div>
 </div>
 </div>
@@ -2882,9 +2821,9 @@ are treated as properties.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-n">f</span><span class="tok-o">##</span><span class="tok-n">property</span> <b class="conum">(1)</b>
-<span class="tok-n">f</span><span class="tok-o">##</span><span class="tok-n">property</span> <span class="tok-o">#=</span> <span class="tok-n">v</span>
-<span class="tok-n">f</span><span class="tok-o">##</span><span class="tok-n">js_method</span> <span class="tok-n">args0</span> <span class="tok-n">args1</span> <span class="tok-n">args2</span> <b class="conum">(2)</b></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">f##property <b class="conum">(1)</b>
+f##property #= v
+f##js_method args0 args1 args2 <b class="conum">(2)</b></code></pre>
 </div>
 </div>
 <div class="colist arabic">
@@ -2910,9 +2849,9 @@ be guaranteed by OCaml&#8217;s type checker, a classic example shown below:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-nx">console</span><span class="tok-p">.</span><span class="tok-nx">log</span><span class="tok-p">(</span><span class="tok-s1">&#39;fine&#39;</span><span class="tok-p">)</span>
-<span class="tok-kd">var</span> <span class="tok-nx">log</span> <span class="tok-o">=</span> <span class="tok-nx">console</span><span class="tok-p">.</span><span class="tok-nx">log</span><span class="tok-p">;</span>
-<span class="tok-nx">log</span><span class="tok-p">(</span><span class="tok-s1">&#39;fine&#39;</span><span class="tok-p">)</span> <b class="conum">(1)</b></code></pre>
+<pre class="pygments highlight"><code data-lang="js">console.log('fine')
+var log = console.log;
+log('fine') <b class="conum">(1)</b></code></pre>
 </div>
 </div>
 <div class="colist arabic">
@@ -2931,9 +2870,9 @@ be guaranteed by OCaml&#8217;s type checker, a classic example shown below:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">fn</span> <span class="tok-o">=</span> <span class="tok-n">f0</span><span class="tok-o">##</span><span class="tok-n">f</span> <span class="tok-k">in</span>
-<span class="tok-k">let</span> <span class="tok-n">a</span> <span class="tok-o">=</span> <span class="tok-n">fn</span> <span class="tok-mi">1</span> <span class="tok-mi">2</span>
-<span class="tok-c">(* f##field a b would think `field` as a method *)</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">let fn = f0##f in
+let a = fn 1 2
+(* f##field a b would think `field` as a method *)</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -2941,7 +2880,7 @@ be guaranteed by OCaml&#8217;s type checker, a classic example shown below:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">b</span> <span class="tok-o">=</span> <span class="tok-n">f1</span><span class="tok-o">##</span><span class="tok-n">f</span> <span class="tok-mi">1</span> <span class="tok-mi">2</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">let b = f1##f 1 2</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -2949,8 +2888,8 @@ be guaranteed by OCaml&#8217;s type checker, a classic example shown below:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">val</span> <span class="tok-n">f0</span> <span class="tok-o">:</span> <span class="tok-o">&lt;</span> <span class="tok-n">f</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">&gt;</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">t</span>
-<span class="tok-k">val</span> <span class="tok-n">f1</span> <span class="tok-o">:</span> <span class="tok-o">&lt;</span> <span class="tok-n">f</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">meth</span><span class="tok-o">]</span> <span class="tok-o">&gt;</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">t</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">val f0 : &lt; f : int -&gt; int -&gt; int &gt; Js.t
+val f1 : &lt; f : int -&gt; int -&gt; int [@bs.meth] &gt; Js.t</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -2958,9 +2897,9 @@ be guaranteed by OCaml&#8217;s type checker, a classic example shown below:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-n">console</span><span class="tok-o">##</span><span class="tok-n">log</span> <span class="tok-s2">&quot;fine&quot;</span>
-<span class="tok-k">let</span> <span class="tok-n">u</span> <span class="tok-o">=</span> <span class="tok-n">console</span><span class="tok-o">##</span><span class="tok-n">log</span>
-<span class="tok-k">let</span> <span class="tok-bp">()</span> <span class="tok-o">=</span> <span class="tok-n">u</span> <span class="tok-s2">&quot;fine&quot;</span> <b class="conum">(1)</b></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">console##log "fine"
+let u = console##log
+let () = u "fine" <b class="conum">(1)</b></code></pre>
 </div>
 </div>
 <div class="colist arabic">
@@ -2995,21 +2934,21 @@ them as property getters/setters.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">type</span> <span class="tok-n">y</span> <span class="tok-o">=</span> <span class="tok-o">&lt;</span>
-  <span class="tok-n">height</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">set</span> <span class="tok-o">{</span><span class="tok-n">no_get</span><span class="tok-o">}]</span> <b class="conum">(1)</b>
-<span class="tok-o">&gt;</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">t</span>
-<span class="tok-k">type</span> <span class="tok-n">y0</span> <span class="tok-o">=</span> <span class="tok-o">&lt;</span>
-  <span class="tok-n">height</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">set</span><span class="tok-o">]</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">get</span> <span class="tok-o">{</span><span class="tok-n">null</span><span class="tok-o">}]</span> <b class="conum">(2)</b>
-<span class="tok-o">&gt;</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">t</span>
-<span class="tok-k">type</span> <span class="tok-n">y1</span> <span class="tok-o">=</span> <span class="tok-o">&lt;</span>
-  <span class="tok-n">height</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">set</span><span class="tok-o">]</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">get</span> <span class="tok-o">{</span><span class="tok-n">undefined</span><span class="tok-o">}]</span> <b class="conum">(3)</b>
-<span class="tok-o">&gt;</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">t</span>
-<span class="tok-k">type</span> <span class="tok-n">y2</span> <span class="tok-o">=</span> <span class="tok-o">&lt;</span>
-  <span class="tok-n">height</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">set</span><span class="tok-o">]</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">get</span> <span class="tok-o">{</span><span class="tok-n">undefined</span><span class="tok-o">;</span> <span class="tok-n">null</span><span class="tok-o">}]</span> <b class="conum">(4)</b>
-<span class="tok-o">&gt;</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">t</span>
-<span class="tok-k">type</span> <span class="tok-n">y3</span> <span class="tok-o">=</span> <span class="tok-o">&lt;</span>
-  <span class="tok-n">height</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">get</span> <span class="tok-o">{</span><span class="tok-n">undefined</span> <span class="tok-o">;</span> <span class="tok-n">null</span><span class="tok-o">}]</span> <b class="conum">(5)</b>
-<span class="tok-o">&gt;</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">t</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">type y = &lt;
+  height : int [@bs.set {no_get}] <b class="conum">(1)</b>
+&gt; Js.t
+type y0 = &lt;
+  height : int [@bs.set] [@bs.get {null}] <b class="conum">(2)</b>
+&gt; Js.t
+type y1 = &lt;
+  height : int [@bs.set] [@bs.get {undefined}] <b class="conum">(3)</b>
+&gt; Js.t
+type y2 = &lt;
+  height : int [@bs.set] [@bs.get {undefined; null}] <b class="conum">(4)</b>
+&gt; Js.t
+type y3 = &lt;
+  height : int [@bs.get {undefined ; null}] <b class="conum">(5)</b>
+&gt; Js.t</code></pre>
 </div>
 </div>
 <div class="colist arabic">
@@ -3053,7 +2992,7 @@ create JS objects in a type safe way on the OCaml side:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">u</span> <span class="tok-o">=</span> <span class="tok-o">[%</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">obj</span> <span class="tok-o">{</span> <span class="tok-n">x</span> <span class="tok-o">=</span> <span class="tok-o">{</span> <span class="tok-n">y</span> <span class="tok-o">=</span> <span class="tok-o">{</span> <span class="tok-n">z</span> <span class="tok-o">=</span> <span class="tok-mi">3</span><span class="tok-o">}}}</span> <span class="tok-o">]</span> <b class="conum">(1)</b></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">let u = [%bs.obj { x = { y = { z = 3}}} ] <b class="conum">(1)</b></code></pre>
 </div>
 </div>
 <div class="colist arabic">
@@ -3066,7 +3005,7 @@ create JS objects in a type safe way on the OCaml side:</p>
 <div class="listingblock">
 <div class="title">Output:</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-kd">var</span> <span class="tok-nx">u</span> <span class="tok-o">=</span> <span class="tok-p">{</span> <span class="tok-nx">x</span> <span class="tok-o">:</span> <span class="tok-p">{</span> <span class="tok-nx">y</span> <span class="tok-o">:</span> <span class="tok-p">{</span> <span class="tok-nx">z</span> <span class="tok-o">:</span> <span class="tok-mi">3</span> <span class="tok-p">}}}}</span></code></pre>
+<pre class="pygments highlight"><code data-lang="js">var u = { x : { y : { z : 3 }}}}</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -3074,7 +3013,7 @@ create JS objects in a type safe way on the OCaml side:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">val</span> <span class="tok-n">u</span> <span class="tok-o">:</span> <span class="tok-o">&lt;</span> <span class="tok-n">x</span> <span class="tok-o">:</span> <span class="tok-o">&lt;</span> <span class="tok-n">y</span> <span class="tok-o">:</span> <span class="tok-o">&lt;</span> <span class="tok-n">z</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">&gt;</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">t</span> <span class="tok-o">&gt;</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">t</span> <span class="tok-o">&gt;</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">t</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">val u : &lt; x : &lt; y : &lt; z : int &gt; Js.t &gt; Js.t &gt; Js.t</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -3083,7 +3022,7 @@ into the type level, so you can write:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">val</span> <span class="tok-n">u</span> <span class="tok-o">:</span> <span class="tok-o">[%</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">obj</span><span class="tok-o">:</span> <span class="tok-o">&lt;</span> <span class="tok-n">x</span> <span class="tok-o">:</span> <span class="tok-o">&lt;</span> <span class="tok-n">y</span> <span class="tok-o">:</span> <span class="tok-o">&lt;</span> <span class="tok-n">z</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">&gt;</span> <span class="tok-o">&gt;</span> <span class="tok-o">&gt;</span> <span class="tok-o">]</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">val u : [%bs.obj: &lt; x : &lt; y : &lt; z : int &gt; &gt; &gt; ]</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -3091,7 +3030,7 @@ into the type level, so you can write:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">u</span> <span class="tok-o">=</span> <span class="tok-o">[%</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">obj</span> <span class="tok-o">(</span> <span class="tok-o">{</span> <span class="tok-n">x</span> <span class="tok-o">=</span> <span class="tok-o">{</span> <span class="tok-n">y</span> <span class="tok-o">=</span> <span class="tok-o">{</span> <span class="tok-n">z</span> <span class="tok-o">=</span> <span class="tok-mi">3</span> <span class="tok-o">}}}</span> <span class="tok-o">:</span> <span class="tok-o">&lt;</span> <span class="tok-n">x</span> <span class="tok-o">:</span> <span class="tok-o">&lt;</span> <span class="tok-n">y</span> <span class="tok-o">:</span> <span class="tok-o">&lt;</span> <span class="tok-n">z</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">&gt;</span> <span class="tok-o">&gt;</span> <span class="tok-o">&gt;</span> <span class="tok-o">]</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">let u = [%bs.obj ( { x = { y = { z = 3 }}} : &lt; x : &lt; y : &lt; z : int &gt; &gt; &gt; ]</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -3099,15 +3038,15 @@ into the type level, so you can write:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">xs</span> <span class="tok-o">=</span> <span class="tok-o">[%</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">obj</span> <span class="tok-o">[|</span> <span class="tok-o">{</span> <span class="tok-n">x</span> <span class="tok-o">=</span> <span class="tok-mi">3</span> <span class="tok-o">}</span> <span class="tok-o">;</span> <span class="tok-o">{</span> <span class="tok-n">x</span> <span class="tok-o">=</span> <span class="tok-mi">3</span> <span class="tok-o">}</span> <span class="tok-o">|]</span> <span class="tok-o">:</span> <span class="tok-o">&lt;</span> <span class="tok-n">x</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">&gt;</span> <span class="tok-kt">array</span> <span class="tok-o">]</span>
-<span class="tok-k">let</span> <span class="tok-n">ys</span> <span class="tok-o">=</span> <span class="tok-o">[%</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">obj</span> <span class="tok-o">[|</span> <span class="tok-o">{</span> <span class="tok-n">x</span> <span class="tok-o">=</span> <span class="tok-mi">3</span> <span class="tok-o">}</span> <span class="tok-o">;</span> <span class="tok-o">{</span> <span class="tok-n">x</span> <span class="tok-o">=</span> <span class="tok-mi">4</span> <span class="tok-o">}</span> <span class="tok-o">|]</span> <span class="tok-o">]</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">let xs = [%bs.obj [| { x = 3 } ; { x = 3 } |] : &lt; x : int &gt; array ]
+let ys = [%bs.obj [| { x = 3 } ; { x = 4 } |] ]</code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="title">Output:</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-kd">var</span> <span class="tok-nx">xs</span> <span class="tok-o">=</span> <span class="tok-p">[</span> <span class="tok-p">{</span> <span class="tok-nx">x</span> <span class="tok-o">:</span> <span class="tok-mi">3</span> <span class="tok-p">}</span> <span class="tok-p">,</span> <span class="tok-p">{</span> <span class="tok-nx">x</span> <span class="tok-o">:</span> <span class="tok-mi">3</span> <span class="tok-p">}</span> <span class="tok-p">]</span>
-<span class="tok-kd">var</span> <span class="tok-nx">ys</span> <span class="tok-o">=</span> <span class="tok-p">[</span> <span class="tok-p">{</span> <span class="tok-nx">x</span> <span class="tok-o">:</span> <span class="tok-mi">3</span> <span class="tok-p">}</span> <span class="tok-p">,</span> <span class="tok-p">{</span> <span class="tok-nx">x</span> <span class="tok-o">:</span> <span class="tok-mi">4</span> <span class="tok-p">}</span> <span class="tok-p">]</span></code></pre>
+<pre class="pygments highlight"><code data-lang="js">var xs = [ { x : 3 } , { x : 3 } ]
+var ys = [ { x : 3 } , { x : 4 } ]</code></pre>
 </div>
 </div>
 </div>
@@ -3118,14 +3057,14 @@ into the type level, so you can write:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">external</span> <span class="tok-n">make_config</span> <span class="tok-o">:</span> <span class="tok-n">hi</span><span class="tok-o">:</span><span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-n">lo</span><span class="tok-o">:</span><span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">unit</span> <span class="tok-o">-&gt;</span> <span class="tok-n">t</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">obj</span><span class="tok-o">]</span>
-<span class="tok-k">let</span> <span class="tok-n">v</span> <span class="tok-o">=</span> <span class="tok-n">make_config</span> <span class="tok-o">~</span><span class="tok-n">hi</span><span class="tok-o">:</span><span class="tok-mi">2</span> <span class="tok-o">~</span><span class="tok-n">lo</span><span class="tok-o">:</span><span class="tok-mi">3</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">external make_config : hi:int -&gt; lo:int -&gt; unit -&gt; t = "" [@@bs.obj]
+let v = make_config ~hi:2 ~lo:3</code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="title">Output:</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-kd">var</span> <span class="tok-nx">v</span> <span class="tok-o">=</span> <span class="tok-p">{</span> <span class="tok-nx">hi</span> <span class="tok-o">:</span> <span class="tok-mi">2</span> <span class="tok-p">,</span> <span class="tok-nx">lo</span> <span class="tok-o">:</span> <span class="tok-mi">3</span> <span class="tok-p">}</span></code></pre>
+<pre class="pygments highlight"><code data-lang="js">var v = { hi : 2 , lo : 3 }</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -3133,9 +3072,9 @@ into the type level, so you can write:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">external</span> <span class="tok-n">make_config</span> <span class="tok-o">:</span> <span class="tok-n">hi</span><span class="tok-o">:</span><span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-o">?</span><span class="tok-n">lo</span><span class="tok-o">:</span><span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">unit</span> <span class="tok-o">-&gt;</span> <span class="tok-n">t</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">obj</span><span class="tok-o">]</span> <b class="conum">(1)</b>
-<span class="tok-k">let</span> <span class="tok-n">u</span> <span class="tok-o">=</span> <span class="tok-n">make_config</span> <span class="tok-o">~</span><span class="tok-n">hi</span><span class="tok-o">:</span><span class="tok-mi">3</span> <span class="tok-bp">()</span>
-<span class="tok-k">let</span> <span class="tok-n">v</span> <span class="tok-o">=</span> <span class="tok-n">make_config</span> <span class="tok-o">~</span><span class="tok-n">lo</span><span class="tok-o">:</span><span class="tok-mi">2</span> <span class="tok-o">~</span><span class="tok-n">hi</span><span class="tok-o">:</span><span class="tok-mi">3</span> <span class="tok-bp">()</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">external make_config : hi:int -&gt; ?lo:int -&gt; unit -&gt; t = "" [@@bs.obj] <b class="conum">(1)</b>
+let u = make_config ~hi:3 ()
+let v = make_config ~lo:2 ~hi:3 ()</code></pre>
 </div>
 </div>
 <div class="colist arabic">
@@ -3150,8 +3089,8 @@ are fulfilled (including optional arguments), it is common to have a <code>unit<
 <div class="listingblock">
 <div class="title">Output:</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-kd">var</span> <span class="tok-nx">u</span> <span class="tok-o">=</span> <span class="tok-p">{</span><span class="tok-nx">hi</span> <span class="tok-o">:</span> <span class="tok-mi">3</span><span class="tok-p">}</span>
-<span class="tok-kd">var</span> <span class="tok-nx">v</span> <span class="tok-o">=</span> <span class="tok-p">{</span><span class="tok-nx">hi</span> <span class="tok-o">:</span> <span class="tok-mi">3</span> <span class="tok-p">,</span> <span class="tok-nx">lo</span><span class="tok-o">:</span> <span class="tok-mi">2</span><span class="tok-p">}</span></code></pre>
+<pre class="pygments highlight"><code data-lang="js">var u = {hi : 3}
+var v = {hi : 3 , lo: 2}</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -3159,13 +3098,13 @@ are fulfilled (including optional arguments), it is common to have a <code>unit<
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">u</span> <span class="tok-o">=</span> <span class="tok-o">[%</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">obj</span> <span class="tok-o">{</span>
-  <span class="tok-n">x</span> <span class="tok-o">=</span> <span class="tok-o">{</span> <span class="tok-n">y</span> <span class="tok-o">=</span> <span class="tok-o">{</span> <span class="tok-n">z</span> <span class="tok-o">=</span> <span class="tok-mi">3</span> <span class="tok-o">}</span> <span class="tok-o">};</span>
-  <span class="tok-n">fn</span> <span class="tok-o">=</span> <span class="tok-k">fun</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">]</span> <span class="tok-n">u</span> <span class="tok-n">v</span> <span class="tok-o">-&gt;</span> <span class="tok-n">u</span> <span class="tok-o">+</span> <span class="tok-n">v</span> <b class="conum">(1)</b>
-  <span class="tok-o">}</span> <span class="tok-o">]</span>
-<span class="tok-k">let</span> <span class="tok-n">h</span> <span class="tok-o">=</span> <span class="tok-n">u</span><span class="tok-o">##</span><span class="tok-n">x</span><span class="tok-o">##</span><span class="tok-n">y</span><span class="tok-o">##</span><span class="tok-n">z</span>
-<span class="tok-k">let</span> <span class="tok-n">a</span> <span class="tok-o">=</span> <span class="tok-n">u</span><span class="tok-o">##</span><span class="tok-n">fn</span>
-<span class="tok-k">let</span> <span class="tok-n">b</span> <span class="tok-o">=</span> <span class="tok-n">a</span> <span class="tok-mi">1</span> <span class="tok-mi">2</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">]</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">let u = [%bs.obj {
+  x = { y = { z = 3 } };
+  fn = fun [@bs] u v -&gt; u + v <b class="conum">(1)</b>
+  } ]
+let h = u##x##y##z
+let a = u##fn
+let b = a 1 2 [@bs]</code></pre>
 </div>
 </div>
 <div class="colist arabic">
@@ -3179,10 +3118,10 @@ We will show how to create JS method in OCaml later.</p>
 <div class="listingblock">
 <div class="title">Output:</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-kd">var</span> <span class="tok-nx">u</span> <span class="tok-o">=</span> <span class="tok-p">{</span> <span class="tok-nx">x</span> <span class="tok-o">:</span> <span class="tok-p">{</span> <span class="tok-nx">y</span> <span class="tok-o">:</span> <span class="tok-p">{</span> <span class="tok-nx">z</span> <span class="tok-o">:</span> <span class="tok-mi">3</span> <span class="tok-p">}</span> <span class="tok-p">},</span> <span class="tok-nx">fn</span> <span class="tok-o">:</span> <span class="tok-kd">function</span> <span class="tok-p">(</span><span class="tok-nx">u</span><span class="tok-p">,</span> <span class="tok-nx">v</span><span class="tok-p">)</span> <span class="tok-p">{</span><span class="tok-k">return</span> <span class="tok-nx">u</span> <span class="tok-o">+</span> <span class="tok-nx">v</span><span class="tok-p">}}</span>
-<span class="tok-kd">var</span> <span class="tok-nx">h</span> <span class="tok-o">=</span> <span class="tok-nx">u</span><span class="tok-p">.</span><span class="tok-nx">x</span><span class="tok-p">.</span><span class="tok-nx">y</span><span class="tok-p">.</span><span class="tok-nx">z</span>
-<span class="tok-kd">var</span> <span class="tok-nx">a</span> <span class="tok-o">=</span> <span class="tok-nx">u</span><span class="tok-p">.</span><span class="tok-nx">fn</span>
-<span class="tok-kd">var</span> <span class="tok-nx">b</span> <span class="tok-o">=</span> <span class="tok-nx">a</span><span class="tok-p">(</span><span class="tok-mi">1</span><span class="tok-p">,</span><span class="tok-mi">2</span><span class="tok-p">)</span></code></pre>
+<pre class="pygments highlight"><code data-lang="js">var u = { x : { y : { z : 3 } }, fn : function (u, v) {return u + v}}
+var h = u.x.y.z
+var a = u.fn
+var b = a(1,2)</code></pre>
 </div>
 </div>
 <div class="admonitionblock note">
@@ -3198,14 +3137,14 @@ is available:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">b</span> <span class="tok-n">x</span> <span class="tok-n">y</span> <span class="tok-n">h</span> <span class="tok-o">=</span> <span class="tok-n">h</span><span class="tok-o">#@</span><span class="tok-n">fn</span> <span class="tok-n">x</span> <span class="tok-n">y</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">let b x y h = h#@fn x y</code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-kd">function</span> <span class="tok-nx">b</span> <span class="tok-p">(</span><span class="tok-nx">x</span><span class="tok-p">,</span><span class="tok-nx">y</span><span class="tok-p">,</span><span class="tok-nx">h</span><span class="tok-p">){</span>
-  <span class="tok-k">return</span> <span class="tok-nx">h</span><span class="tok-p">.</span><span class="tok-nx">fn</span><span class="tok-p">(</span><span class="tok-nx">x</span><span class="tok-p">,</span><span class="tok-nx">y</span><span class="tok-p">)</span>
-<span class="tok-p">}</span></code></pre>
+<pre class="pygments highlight"><code data-lang="js">function b (x,y,h){
+  return h.fn(x,y)
+}</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -3213,7 +3152,7 @@ is available:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">val</span> <span class="tok-n">b</span> <span class="tok-o">:</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">b</span> <span class="tok-o">-&gt;</span> <span class="tok-o">&lt;</span> <span class="tok-n">fn</span> <span class="tok-o">:</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">b</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">c</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">]</span> <span class="tok-o">&gt;</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">t</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">c</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">val b : 'a -&gt; 'b -&gt; &lt; fn : 'a -&gt; 'b -&gt; 'c [@bs] &gt; Js.t -&gt; 'c</code></pre>
 </div>
 </div>
 </td>
@@ -3229,13 +3168,13 @@ BuckleScript too.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">v2</span> <span class="tok-o">=</span>
-  <span class="tok-k">let</span> <span class="tok-n">x</span> <span class="tok-o">=</span> <span class="tok-mi">3</span><span class="tok-o">.</span> <span class="tok-k">in</span>
-  <span class="tok-k">object</span> <span class="tok-o">(</span><span class="tok-n">self</span><span class="tok-o">)</span> <b class="conum">(1)</b>
-    <span class="tok-k">method</span> <span class="tok-n">hi</span> <span class="tok-n">x</span> <span class="tok-n">y</span> <span class="tok-o">=</span> <span class="tok-n">self</span><span class="tok-o">##</span><span class="tok-n">say</span> <span class="tok-n">x</span> <span class="tok-o">+.</span> <span class="tok-n">y</span>
-    <span class="tok-k">method</span> <span class="tok-n">say</span> <span class="tok-n">x</span> <span class="tok-o">=</span> <span class="tok-n">x</span> <span class="tok-o">*.</span> <span class="tok-n">self</span><span class="tok-o">##</span><span class="tok-n">x</span> <span class="tok-bp">()</span>
-    <span class="tok-k">method</span> <span class="tok-n">x</span> <span class="tok-bp">()</span> <span class="tok-o">=</span> <span class="tok-n">x</span>
-  <span class="tok-k">end</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">]</span> <b class="conum">(2)</b></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">let v2 =
+  let x = 3. in
+  object (self) <b class="conum">(1)</b>
+    method hi x y = self##say x +. y
+    method say x = x *. self##x ()
+    method x () = x
+  end [@bs] <b class="conum">(2)</b></code></pre>
 </div>
 </div>
 <div class="colist arabic">
@@ -3251,19 +3190,19 @@ BuckleScript too.</p>
 <div class="listingblock">
 <div class="title">Output:</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-kd">var</span> <span class="tok-nx">v2</span> <span class="tok-o">=</span> <span class="tok-p">{</span>
-  <span class="tok-nx">hi</span><span class="tok-o">:</span> <span class="tok-kd">function</span> <span class="tok-p">(</span><span class="tok-nx">x</span><span class="tok-p">,</span> <span class="tok-nx">y</span><span class="tok-p">)</span> <span class="tok-p">{</span>
-    <span class="tok-kd">var</span> <span class="tok-nx">self</span> <span class="tok-o">=</span> <span class="tok-k">this</span> <span class="tok-p">;</span>
-    <span class="tok-k">return</span> <span class="tok-nx">self</span><span class="tok-p">.</span><span class="tok-nx">say</span><span class="tok-p">(</span><span class="tok-nx">x</span><span class="tok-p">)</span> <span class="tok-o">+</span> <span class="tok-nx">y</span><span class="tok-p">;</span>
-  <span class="tok-p">},</span>
-  <span class="tok-nx">say</span><span class="tok-o">:</span> <span class="tok-kd">function</span> <span class="tok-p">(</span><span class="tok-nx">x</span><span class="tok-p">)</span> <span class="tok-p">{</span>
-    <span class="tok-kd">var</span> <span class="tok-nx">self</span> <span class="tok-o">=</span> <span class="tok-k">this</span> <span class="tok-p">;</span>
-    <span class="tok-k">return</span> <span class="tok-nx">x</span> <span class="tok-o">*</span> <span class="tok-nx">self</span><span class="tok-p">.</span><span class="tok-nx">x</span><span class="tok-p">();</span>
-  <span class="tok-p">},</span>
-  <span class="tok-nx">x</span><span class="tok-o">:</span> <span class="tok-kd">function</span> <span class="tok-p">()</span> <span class="tok-p">{</span>
-    <span class="tok-k">return</span> <span class="tok-mi">3</span><span class="tok-p">;</span>
-  <span class="tok-p">}</span>
-<span class="tok-p">};</span></code></pre>
+<pre class="pygments highlight"><code data-lang="js">var v2 = {
+  hi: function (x, y) {
+    var self = this ;
+    return self.say(x) + y;
+  },
+  say: function (x) {
+    var self = this ;
+    return x * self.x();
+  },
+  x: function () {
+    return 3;
+  }
+};</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -3271,11 +3210,11 @@ BuckleScript too.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">val</span> <span class="tok-n">v2</span> <span class="tok-o">:</span> <span class="tok-o">&lt;</span>
-  <span class="tok-n">hi</span> <span class="tok-o">:</span> <span class="tok-kt">float</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">float</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">float</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">meth</span><span class="tok-o">];</span>
-  <span class="tok-n">say</span> <span class="tok-o">:</span> <span class="tok-kt">float</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">float</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">meth</span><span class="tok-o">];</span>
-  <span class="tok-n">x</span> <span class="tok-o">:</span> <span class="tok-kt">unit</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">float</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">meth</span><span class="tok-o">]</span>
-<span class="tok-o">&gt;</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">]</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">val v2 : &lt;
+  hi : float -&gt; float -&gt; float [@bs.meth];
+  say : float -&gt; float [@bs.meth];
+  x : unit -&gt; float [@bs.meth]
+&gt; [@bs]</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -3283,37 +3222,37 @@ BuckleScript too.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">f</span> <span class="tok-o">(</span><span class="tok-n">u</span> <span class="tok-o">:</span> <span class="tok-n">rect</span><span class="tok-o">)</span> <span class="tok-o">=</span>
-  <span class="tok-c">(* the type annotation is un-necessary,</span>
-<span class="tok-c">     but it gives better error message</span>
-<span class="tok-c">  *)</span>
-   <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">log</span> <span class="tok-n">u</span><span class="tok-o">##</span><span class="tok-n">height</span><span class="tok-o">;</span>
-   <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">log</span> <span class="tok-n">u</span><span class="tok-o">##</span><span class="tok-n">width</span><span class="tok-o">;</span>
-   <span class="tok-n">u</span><span class="tok-o">##</span><span class="tok-n">width</span> <span class="tok-o">#=</span> <span class="tok-mi">30</span><span class="tok-o">;</span>
-   <span class="tok-n">u</span><span class="tok-o">##</span><span class="tok-n">height</span> <span class="tok-o">#=</span> <span class="tok-mi">30</span><span class="tok-o">;</span>
-   <span class="tok-n">u</span><span class="tok-o">##</span><span class="tok-n">draw</span> <span class="tok-bp">()</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">let f (u : rect) =
+  (* the type annotation is un-necessary,
+     but it gives better error message
+  *)
+   Js.log u##height;
+   Js.log u##width;
+   u##width #= 30;
+   u##height #= 30;
+   u##draw ()</code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="title">Output:</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-kd">function</span> <span class="tok-nx">f</span><span class="tok-p">(</span><span class="tok-nx">u</span><span class="tok-p">){</span>
-  <span class="tok-nx">console</span><span class="tok-p">.</span><span class="tok-nx">log</span><span class="tok-p">(</span><span class="tok-nx">u</span><span class="tok-p">.</span><span class="tok-nx">height</span><span class="tok-p">);</span>
-  <span class="tok-nx">console</span><span class="tok-p">.</span><span class="tok-nx">log</span><span class="tok-p">(</span><span class="tok-nx">u</span><span class="tok-p">.</span><span class="tok-nx">width</span><span class="tok-p">);</span>
-  <span class="tok-nx">u</span><span class="tok-p">.</span><span class="tok-nx">width</span> <span class="tok-o">=</span> <span class="tok-mi">30</span><span class="tok-p">;</span>
-  <span class="tok-nx">u</span><span class="tok-p">.</span><span class="tok-nx">height</span> <span class="tok-o">=</span> <span class="tok-mi">30</span><span class="tok-p">;</span>
-  <span class="tok-k">return</span> <span class="tok-nx">u</span><span class="tok-p">.</span><span class="tok-nx">draw</span><span class="tok-p">()</span>
-<span class="tok-p">}</span></code></pre>
+<pre class="pygments highlight"><code data-lang="js">function f(u){
+  console.log(u.height);
+  console.log(u.width);
+  u.width = 30;
+  u.height = 30;
+  return u.draw()
+}</code></pre>
 </div>
 </div>
 <div class="sect4">
 <h5 id="_method_chaining"><a class="anchor" href="#_method_chaining"></a>Method chaining</h5>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-n">f</span>
-<span class="tok-o">##(</span><span class="tok-n">meth0</span> <span class="tok-bp">()</span><span class="tok-o">)</span>
-<span class="tok-o">##(</span><span class="tok-n">meth1</span> <span class="tok-n">a</span><span class="tok-o">)</span>
-<span class="tok-o">##(</span><span class="tok-n">meth2</span> <span class="tok-n">a</span> <span class="tok-n">b</span><span class="tok-o">)</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">f
+##(meth0 ())
+##(meth1 a)
+##(meth2 a b)</code></pre>
 </div>
 </div>
 </div>
@@ -3330,15 +3269,15 @@ error.</p>
 <div class="listingblock">
 <div class="title">Key-word method:</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-n">f</span><span class="tok-o">##_</span><span class="tok-n">open</span>
-<span class="tok-n">f</span><span class="tok-o">##_</span><span class="tok-n">MAX_LENGTH</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">f##_open
+f##_MAX_LENGTH</code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="title">OUTPUT:</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-nx">f</span><span class="tok-p">.</span><span class="tok-nx">open</span>
-<span class="tok-nx">f</span><span class="tok-p">.</span><span class="tok-nx">MAX_LENGTH</span></code></pre>
+<pre class="pygments highlight"><code data-lang="js">f.open
+f.MAX_LENGTH</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -3349,15 +3288,15 @@ object labels, which is <em>occasionally</em> useful as below</p>
 <div class="listingblock">
 <div class="title">Ad-hoc polymorphism</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-n">f</span><span class="tok-o">##</span><span class="tok-n">draw__cat</span> <span class="tok-o">(</span><span class="tok-n">x</span><span class="tok-o">,</span><span class="tok-n">y</span><span class="tok-o">)</span>
-<span class="tok-n">f</span><span class="tok-o">##</span><span class="tok-n">draw__dog</span> <span class="tok-o">(</span><span class="tok-n">x</span><span class="tok-o">,</span><span class="tok-n">y</span><span class="tok-o">)</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">f##draw__cat (x,y)
+f##draw__dog (x,y)</code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="title">OUTPUT:</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-nx">f</span><span class="tok-p">.</span><span class="tok-nx">draw</span><span class="tok-p">(</span><span class="tok-nx">x</span><span class="tok-p">,</span><span class="tok-nx">y</span><span class="tok-p">)</span> <span class="tok-c1">// f.draw in JS can accept different types</span>
-<span class="tok-nx">f</span><span class="tok-p">.</span><span class="tok-nx">draw</span><span class="tok-p">(</span><span class="tok-nx">x</span><span class="tok-p">,</span><span class="tok-nx">y</span><span class="tok-p">)</span></code></pre>
+<pre class="pygments highlight"><code data-lang="js">f.draw(x,y) // f.draw in JS can accept different types
+f.draw(x,y)</code></pre>
 </div>
 </div>
 <div class="admonitionblock note">
@@ -3433,16 +3372,16 @@ drop the first '_'</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">type</span> <span class="tok-n">element</span>
-<span class="tok-k">type</span> <span class="tok-n">dom</span>
-<span class="tok-k">external</span> <span class="tok-n">getElementById</span> <span class="tok-o">:</span> <span class="tok-kt">string</span> <span class="tok-o">-&gt;</span> <span class="tok-n">element</span> <span class="tok-n">option</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;&quot;</span>
-<span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">send</span><span class="tok-o">.</span><span class="tok-n">pipe</span><span class="tok-o">:</span><span class="tok-n">dom</span><span class="tok-o">]</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">return</span> <span class="tok-n">null_to_opt</span><span class="tok-o">]</span> <b class="conum">(1)</b>
+<pre class="pygments highlight"><code data-lang="ocaml">type element
+type dom
+external getElementById : string -&gt; element option = ""
+[@@bs.send.pipe:dom] [@@bs.return null_to_opt] <b class="conum">(1)</b>
 
-<span class="tok-k">let</span> <span class="tok-n">test</span> <span class="tok-n">dom</span> <span class="tok-o">=</span>
-    <span class="tok-k">let</span> <span class="tok-n">elem</span> <span class="tok-o">=</span> <span class="tok-n">dom</span> <span class="tok-o">|&gt;</span> <span class="tok-n">getElementById</span> <span class="tok-s2">&quot;haha&quot;</span> <span class="tok-k">in</span>
-    <span class="tok-k">match</span> <span class="tok-n">elem</span> <span class="tok-k">with</span>
-    <span class="tok-o">|</span> <span class="tok-nc">None</span> <span class="tok-o">-&gt;</span> <span class="tok-mi">1</span>
-    <span class="tok-o">|</span> <span class="tok-nc">Some</span> <span class="tok-n">ui</span> <span class="tok-o">-&gt;</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">log</span> <span class="tok-n">ui</span> <span class="tok-o">;</span> <span class="tok-mi">2</span></code></pre>
+let test dom =
+    let elem = dom |&gt; getElementById "haha" in
+    match elem with
+    | None -&gt; 1
+    | Some ui -&gt; Js.log ui ; 2</code></pre>
 </div>
 </div>
 <div class="colist arabic">
@@ -3455,16 +3394,16 @@ drop the first '_'</p>
 <div class="listingblock">
 <div class="title">Output</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-kd">function</span> <span class="tok-nx">test</span><span class="tok-p">(</span><span class="tok-nx">dom</span><span class="tok-p">)</span> <span class="tok-p">{</span>
-  <span class="tok-kd">var</span> <span class="tok-nx">elem</span> <span class="tok-o">=</span> <span class="tok-nx">dom</span><span class="tok-p">.</span><span class="tok-nx">getElementById</span><span class="tok-p">(</span><span class="tok-s2">&quot;haha&quot;</span><span class="tok-p">);</span>
-  <span class="tok-k">if</span> <span class="tok-p">(</span><span class="tok-nx">elem</span> <span class="tok-o">!==</span> <span class="tok-kc">null</span><span class="tok-p">)</span> <span class="tok-p">{</span> <b class="conum">(1)</b>
-    <span class="tok-nx">console</span><span class="tok-p">.</span><span class="tok-nx">log</span><span class="tok-p">(</span><span class="tok-nx">elem</span><span class="tok-p">);</span>
-    <span class="tok-k">return</span> <span class="tok-mi">2</span><span class="tok-p">;</span>
-  <span class="tok-p">}</span>
-  <span class="tok-k">else</span> <span class="tok-p">{</span>
-    <span class="tok-k">return</span> <span class="tok-mi">1</span><span class="tok-p">;</span>
-  <span class="tok-p">}</span>
-<span class="tok-p">}</span></code></pre>
+<pre class="pygments highlight"><code data-lang="js">function test(dom) {
+  var elem = dom.getElementById("haha");
+  if (elem !== null) { <b class="conum">(1)</b>
+    console.log(elem);
+    return 2;
+  }
+  else {
+    return 1;
+  }
+}</code></pre>
 </div>
 </div>
 <div class="colist arabic">
@@ -3543,50 +3482,50 @@ get the job done.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">test</span> <span class="tok-bp">()</span> <span class="tok-o">=</span>
-  <span class="tok-k">match</span> <span class="tok-o">[%</span><span class="tok-k">external</span> <span class="tok-o">__</span><span class="tok-n">DEV__</span><span class="tok-o">]</span> <span class="tok-k">with</span>
-  <span class="tok-o">|</span> <span class="tok-nc">Some</span> <span class="tok-o">_</span> <span class="tok-o">-&gt;</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">log</span> <span class="tok-s2">&quot;dev mode&quot;</span>
-  <span class="tok-o">|</span> <span class="tok-nc">None</span> <span class="tok-o">-&gt;</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">log</span> <span class="tok-s2">&quot;producton mode&quot;</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">let test () =
+  match [%external __DEV__] with
+  | Some _ -&gt; Js.log "dev mode"
+  | None -&gt; Js.log "producton mode"</code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="title">Output</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-kd">function</span> <span class="tok-nx">test</span><span class="tok-p">()</span> <span class="tok-p">{</span>
-  <span class="tok-kd">var</span> <span class="tok-nx">match</span> <span class="tok-o">=</span> <span class="tok-k">typeof</span> <span class="tok-p">(</span><span class="tok-nx">__DEV__</span><span class="tok-p">)</span> <span class="tok-o">===</span> <span class="tok-s2">&quot;undefined&quot;</span> <span class="tok-o">?</span> <span class="tok-kc">undefined</span> <span class="tok-o">:</span> <span class="tok-p">(</span><span class="tok-nx">__DEV__</span><span class="tok-p">);</span>
-  <span class="tok-k">if</span> <span class="tok-p">(</span><span class="tok-nx">match</span> <span class="tok-o">!==</span> <span class="tok-kc">undefined</span><span class="tok-p">)</span> <span class="tok-p">{</span>
-    <span class="tok-nx">console</span><span class="tok-p">.</span><span class="tok-nx">log</span><span class="tok-p">(</span><span class="tok-s2">&quot;dev mode&quot;</span><span class="tok-p">);</span>
-    <span class="tok-k">return</span> <span class="tok-cm">/* () */</span><span class="tok-mi">0</span><span class="tok-p">;</span>
-  <span class="tok-p">}</span>
-  <span class="tok-k">else</span> <span class="tok-p">{</span>
-    <span class="tok-nx">console</span><span class="tok-p">.</span><span class="tok-nx">log</span><span class="tok-p">(</span><span class="tok-s2">&quot;producton mode&quot;</span><span class="tok-p">);</span>
-    <span class="tok-k">return</span> <span class="tok-cm">/* () */</span><span class="tok-mi">0</span><span class="tok-p">;</span>
-  <span class="tok-p">}</span>
-<span class="tok-p">}</span></code></pre>
+<pre class="pygments highlight"><code data-lang="js">function test() {
+  var match = typeof (__DEV__) === "undefined" ? undefined : (__DEV__);
+  if (match !== undefined) {
+    console.log("dev mode");
+    return /* () */0;
+  }
+  else {
+    console.log("producton mode");
+    return /* () */0;
+  }
+}</code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">test2</span> <span class="tok-bp">()</span> <span class="tok-o">=</span>
-  <span class="tok-k">match</span> <span class="tok-o">[%</span><span class="tok-k">external</span> <span class="tok-o">__</span><span class="tok-n">filename</span><span class="tok-o">]</span> <span class="tok-k">with</span>
-  <span class="tok-o">|</span> <span class="tok-nc">Some</span> <span class="tok-n">f</span> <span class="tok-o">-&gt;</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">log</span> <span class="tok-n">f</span>
-  <span class="tok-o">|</span> <span class="tok-nc">None</span> <span class="tok-o">-&gt;</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">log</span> <span class="tok-s2">&quot;non node environment&quot;</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">let test2 () =
+  match [%external __filename] with
+  | Some f -&gt; Js.log f
+  | None -&gt; Js.log "non node environment"</code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="title">Output</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-kd">function</span> <span class="tok-nx">test2</span><span class="tok-p">()</span> <span class="tok-p">{</span>
-  <span class="tok-kd">var</span> <span class="tok-nx">match</span> <span class="tok-o">=</span> <span class="tok-k">typeof</span> <span class="tok-p">(</span><span class="tok-nx">__filename</span><span class="tok-p">)</span> <span class="tok-o">===</span> <span class="tok-s2">&quot;undefined&quot;</span> <span class="tok-o">?</span> <span class="tok-kc">undefined</span> <span class="tok-o">:</span> <span class="tok-p">(</span><span class="tok-nx">__filename</span><span class="tok-p">);</span>
-  <span class="tok-k">if</span> <span class="tok-p">(</span><span class="tok-nx">match</span> <span class="tok-o">!==</span> <span class="tok-kc">undefined</span><span class="tok-p">)</span> <span class="tok-p">{</span>
-    <span class="tok-nx">console</span><span class="tok-p">.</span><span class="tok-nx">log</span><span class="tok-p">(</span><span class="tok-nx">match</span><span class="tok-p">);</span>
-    <span class="tok-k">return</span> <span class="tok-cm">/* () */</span><span class="tok-mi">0</span><span class="tok-p">;</span>
-  <span class="tok-p">}</span>
-  <span class="tok-k">else</span> <span class="tok-p">{</span>
-    <span class="tok-nx">console</span><span class="tok-p">.</span><span class="tok-nx">log</span><span class="tok-p">(</span><span class="tok-s2">&quot;non node environment&quot;</span><span class="tok-p">);</span>
-    <span class="tok-k">return</span> <span class="tok-cm">/* () */</span><span class="tok-mi">0</span><span class="tok-p">;</span>
-  <span class="tok-p">}</span>
-<span class="tok-p">}</span></code></pre>
+<pre class="pygments highlight"><code data-lang="js">function test2() {
+  var match = typeof (__filename) === "undefined" ? undefined : (__filename);
+  if (match !== undefined) {
+    console.log(match);
+    return /* () */0;
+  }
+  else {
+    console.log("non node environment");
+    return /* () */0;
+  }
+}</code></pre>
 </div>
 </div>
 </div>
@@ -3594,8 +3533,8 @@ get the job done.</p>
 <h4 id="_embedding_arbitrary_js_code_as_an_expression"><a class="anchor" href="#_embedding_arbitrary_js_code_as_an_expression"></a>Embedding arbitrary JS code as an expression</h4>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">keys</span> <span class="tok-o">:</span> <span class="tok-n">t</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">string</span> <span class="tok-kt">array</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">]</span> <span class="tok-o">=</span> <span class="tok-o">[%</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">raw</span> <span class="tok-s2">&quot;Object.keys&quot;</span> <span class="tok-o">]</span>
-<span class="tok-k">let</span> <span class="tok-n">unsafe_lt</span> <span class="tok-o">:</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-o">-&gt;</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">boolean</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">]</span> <span class="tok-o">=</span> <span class="tok-o">[%</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">raw</span><span class="tok-o">{|</span><span class="tok-k">function</span><span class="tok-o">(</span><span class="tok-n">x</span><span class="tok-o">,</span><span class="tok-n">y</span><span class="tok-o">){</span><span class="tok-n">return</span> <span class="tok-n">x</span> <span class="tok-o">&lt;</span> <span class="tok-n">y</span><span class="tok-o">}|}]</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">let keys : t -&gt; string array [@bs] = [%bs.raw "Object.keys" ]
+let unsafe_lt : 'a -&gt; 'a -&gt; Js.boolean [@bs] = [%bs.raw{|function(x,y){return x &lt; y}|}]</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -3608,9 +3547,9 @@ refer to external OCaml symbols in raw JS code.</p>
 <h4 id="_embedding_raw_js_code_as_statements"><a class="anchor" href="#_embedding_raw_js_code_as_statements"></a>Embedding raw JS code as statements</h4>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-p">[</span><span class="tok-o">%%</span><span class="tok-nx">bs</span><span class="tok-p">.</span><span class="tok-nx">raw</span><span class="tok-p">{</span><span class="tok-o">|</span>
-  <span class="tok-nx">console</span><span class="tok-p">.</span><span class="tok-nx">log</span> <span class="tok-p">(</span><span class="tok-s2">&quot;hey&quot;</span><span class="tok-p">);</span>
-<span class="tok-o">|</span><span class="tok-p">}]</span></code></pre>
+<pre class="pygments highlight"><code data-lang="js">[%%bs.raw{|
+  console.log ("hey");
+|}]</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -3618,7 +3557,7 @@ refer to external OCaml symbols in raw JS code.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">x</span> <span class="tok-o">:</span> <span class="tok-kt">string</span> <span class="tok-o">=</span> <span class="tok-o">[%</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">raw</span><span class="tok-o">{|</span><span class="tok-s2">&quot;</span><span class="tok-se">\x01\x02</span><span class="tok-s2">&quot;</span><span class="tok-o">|}]</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">let x : string = [%bs.raw{|"\x01\x02"|}]</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -3626,7 +3565,7 @@ refer to external OCaml symbols in raw JS code.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-kd">var</span> <span class="tok-nx">x</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;\x01\x02&quot;</span></code></pre>
+<pre class="pygments highlight"><code data-lang="js">var x = "\x01\x02"</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -3634,12 +3573,12 @@ refer to external OCaml symbols in raw JS code.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml">   <span class="tok-o">[%%</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">raw</span><span class="tok-o">{|</span>
-   <span class="tok-o">//</span> <span class="tok-nn">Math</span><span class="tok-p">.</span><span class="tok-n">imul</span> <span class="tok-n">polyfill</span>
-   <span class="tok-k">if</span> <span class="tok-o">(!</span><span class="tok-nn">Math</span><span class="tok-p">.</span><span class="tok-n">imul</span><span class="tok-o">){</span>
-       <span class="tok-nn">Math</span><span class="tok-p">.</span><span class="tok-n">imul</span> <span class="tok-o">=</span> <span class="tok-k">function</span> <span class="tok-o">(..)</span> <span class="tok-o">{..}</span>
-    <span class="tok-o">}</span>
-   <span class="tok-o">|}]</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">   [%%bs.raw{|
+   // Math.imul polyfill
+   if (!Math.imul){
+       Math.imul = function (..) {..}
+    }
+   |}]</code></pre>
 </div>
 </div>
 <div class="admonitionblock warning">
@@ -3674,9 +3613,9 @@ that the order is correct.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml">  <span class="tok-k">let</span> <span class="tok-n">f</span> <span class="tok-n">x</span> <span class="tok-n">y</span> <span class="tok-o">=</span>
-    <span class="tok-o">[%</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">debugger</span><span class="tok-o">];</span>
-    <span class="tok-n">x</span> <span class="tok-o">+</span> <span class="tok-n">y</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">  let f x y =
+    [%bs.debugger];
+    x + y</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -3684,10 +3623,10 @@ that the order is correct.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js">  <span class="tok-kd">function</span> <span class="tok-nx">f</span> <span class="tok-p">(</span><span class="tok-nx">x</span><span class="tok-p">,</span><span class="tok-nx">y</span><span class="tok-p">)</span> <span class="tok-p">{</span>
-     <span class="tok-kr">debugger</span><span class="tok-p">;</span> <span class="tok-c1">// JavaScript developer tools will set an breakpoint and stop here</span>
-     <span class="tok-nx">x</span> <span class="tok-o">+</span> <span class="tok-nx">y</span><span class="tok-p">;</span>
-  <span class="tok-p">}</span></code></pre>
+<pre class="pygments highlight"><code data-lang="js">  function f (x,y) {
+     debugger; // JavaScript developer tools will set an breakpoint and stop here
+     x + y;
+  }</code></pre>
 </div>
 </div>
 </div>
@@ -3698,7 +3637,7 @@ that the order is correct.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">f</span> <span class="tok-o">=</span> <span class="tok-o">[%</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">re</span> <span class="tok-s2">&quot;/b/g&quot;</span><span class="tok-o">]</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">let f = [%bs.re "/b/g"]</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -3738,8 +3677,8 @@ more examples, please visit
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">external</span> <span class="tok-n">describe</span> <span class="tok-o">:</span> <span class="tok-kt">string</span> <span class="tok-o">-&gt;</span> <span class="tok-o">(</span><span class="tok-kt">unit</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">unit</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">])</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">unit</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">val</span><span class="tok-o">]</span>
-<span class="tok-k">external</span> <span class="tok-n">it</span> <span class="tok-o">:</span> <span class="tok-kt">string</span> <span class="tok-o">-&gt;</span> <span class="tok-o">(</span><span class="tok-kt">unit</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">unit</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">])</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">unit</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">val</span><span class="tok-o">]</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">external describe : string -&gt; (unit -&gt; unit [@bs]) -&gt; unit = "" [@@bs.val]
+external it : string -&gt; (unit -&gt; unit [@bs]) -&gt; unit = "" [@@bs.val]</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -3749,7 +3688,7 @@ more examples, please visit
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">external</span> <span class="tok-n">eq</span> <span class="tok-o">:</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">unit</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;deepEqual&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">module</span> <span class="tok-s2">&quot;assert&quot;</span><span class="tok-o">]</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">external eq : 'a -&gt; 'a -&gt; unit = "deepEqual" [@@bs.module "assert"]</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -3757,11 +3696,11 @@ more examples, please visit
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">assert_equal</span> <span class="tok-o">=</span> <span class="tok-n">eq</span>
-<span class="tok-k">let</span> <span class="tok-n">from_suites</span> <span class="tok-n">name</span> <span class="tok-n">suite</span> <span class="tok-o">=</span>
-    <span class="tok-n">describe</span> <span class="tok-n">name</span> <span class="tok-o">(</span><span class="tok-k">fun</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">]</span> <span class="tok-bp">()</span> <span class="tok-o">-&gt;</span>
-         <span class="tok-nn">List</span><span class="tok-p">.</span><span class="tok-n">iter</span> <span class="tok-o">(</span><span class="tok-k">fun</span> <span class="tok-o">(</span><span class="tok-n">name</span><span class="tok-o">,</span> <span class="tok-n">code</span><span class="tok-o">)</span> <span class="tok-o">-&gt;</span> <span class="tok-n">it</span> <span class="tok-n">name</span> <span class="tok-n">code</span><span class="tok-o">)</span> <span class="tok-n">suite</span>
-         <span class="tok-o">)</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">let assert_equal = eq
+let from_suites name suite =
+    describe name (fun [@bs] () -&gt;
+         List.iter (fun (name, code) -&gt; it name code) suite
+         )</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -3769,20 +3708,20 @@ more examples, please visit
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"> <span class="tok-kd">var</span> <span class="tok-nx">Assert</span> <span class="tok-o">=</span> <span class="tok-nx">require</span><span class="tok-p">(</span><span class="tok-s2">&quot;assert&quot;</span><span class="tok-p">);</span>
- <span class="tok-kd">var</span> <span class="tok-nx">List</span> <span class="tok-o">=</span> <span class="tok-nx">require</span><span class="tok-p">(</span><span class="tok-s2">&quot;bs-platform/lib/js/list&quot;</span><span class="tok-p">);</span>
+<pre class="pygments highlight"><code data-lang="js"> var Assert = require("assert");
+ var List = require("bs-platform/lib/js/list");
 
-<span class="tok-kd">function</span> <span class="tok-nx">assert_equal</span><span class="tok-p">(</span><span class="tok-nx">prim</span><span class="tok-p">,</span> <span class="tok-nx">prim$1</span><span class="tok-p">)</span> <span class="tok-p">{</span>
- <span class="tok-k">return</span> <span class="tok-nx">Assert</span><span class="tok-p">.</span><span class="tok-nx">deepEqual</span><span class="tok-p">(</span><span class="tok-nx">prim</span><span class="tok-p">,</span> <span class="tok-nx">prim$1</span><span class="tok-p">);</span>
- <span class="tok-p">}</span>
+function assert_equal(prim, prim$1) {
+ return Assert.deepEqual(prim, prim$1);
+ }
 
-<span class="tok-kd">function</span> <span class="tok-nx">from_suites</span><span class="tok-p">(</span><span class="tok-nx">name</span><span class="tok-p">,</span> <span class="tok-nx">suite</span><span class="tok-p">)</span> <span class="tok-p">{</span>
- <span class="tok-k">return</span> <span class="tok-nx">describe</span><span class="tok-p">(</span><span class="tok-nx">name</span><span class="tok-p">,</span> <span class="tok-kd">function</span> <span class="tok-p">()</span> <span class="tok-p">{</span>
-   <span class="tok-k">return</span> <span class="tok-nx">List</span><span class="tok-p">.</span><span class="tok-nx">iter</span><span class="tok-p">(</span><span class="tok-kd">function</span> <span class="tok-p">(</span><span class="tok-nx">param</span><span class="tok-p">)</span> <span class="tok-p">{</span>
-    <span class="tok-k">return</span> <span class="tok-nx">it</span><span class="tok-p">(</span><span class="tok-nx">param</span><span class="tok-p">[</span><span class="tok-mi">0</span><span class="tok-p">],</span> <span class="tok-nx">param</span><span class="tok-p">[</span><span class="tok-mi">1</span><span class="tok-p">]);</span>
-      <span class="tok-p">},</span> <span class="tok-nx">suite</span><span class="tok-p">);</span>
-  <span class="tok-p">});</span>
- <span class="tok-p">}</span></code></pre>
+function from_suites(name, suite) {
+ return describe(name, function () {
+   return List.iter(function (param) {
+    return it(param[0], param[1]);
+      }, suite);
+  });
+ }</code></pre>
 </div>
 </div>
 </div>
@@ -3802,16 +3741,16 @@ more examples, please visit
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">example1</span> <span class="tok-bp">()</span> <span class="tok-o">=</span>
-    <span class="tok-k">match</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-nn">Json</span><span class="tok-p">.</span><span class="tok-n">exnParse</span> <span class="tok-o">{|</span> <span class="tok-o">{</span><span class="tok-s2">&quot;x&quot;</span> <span class="tok-o">}|}</span> <span class="tok-k">with</span>
-    <span class="tok-o">|</span> <span class="tok-k">exception</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-nn">Exn</span><span class="tok-p">.</span><span class="tok-nc">Error</span> <span class="tok-n">err</span> <span class="tok-o">-&gt;</span>
-        <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">log</span> <span class="tok-o">@@</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-nn">Exn</span><span class="tok-p">.</span><span class="tok-n">stack</span> <span class="tok-n">err</span><span class="tok-o">;</span>
-        <span class="tok-nc">None</span>
-    <span class="tok-o">|</span> <span class="tok-n">v</span> <span class="tok-o">-&gt;</span> <span class="tok-nc">Some</span> <span class="tok-n">v</span>
+<pre class="pygments highlight"><code data-lang="ocaml">let example1 () =
+    match Js.Json.exnParse {| {"x" }|} with
+    | exception Js.Exn.Error err -&gt;
+        Js.log @@ Js.Exn.stack err;
+        None
+    | v -&gt; Some v
 
-<span class="tok-k">let</span> <span class="tok-n">example2</span> <span class="tok-bp">()</span> <span class="tok-o">=</span>
-    <span class="tok-k">try</span> <span class="tok-nc">Some</span> <span class="tok-o">(</span><span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-nn">Json</span><span class="tok-p">.</span><span class="tok-n">exnParse</span> <span class="tok-o">{|</span> <span class="tok-o">{</span><span class="tok-s2">&quot;x&quot;</span><span class="tok-o">}|})</span> <span class="tok-k">with</span>
-    <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-nn">Exn</span><span class="tok-p">.</span><span class="tok-nc">Error</span> <span class="tok-o">_</span> <span class="tok-o">-&gt;</span> <span class="tok-nc">None</span></code></pre>
+let example2 () =
+    try Some (Js.Json.exnParse {| {"x"}|}) with
+    Js.Exn.Error _ -&gt; None</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -3819,14 +3758,14 @@ more examples, please visit
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">type</span> <span class="tok-n">t</span> <span class="tok-o">=</span>
-  <span class="tok-o">&lt;</span> <span class="tok-n">stack</span> <span class="tok-o">:</span> <span class="tok-kt">string</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">undefined</span> <span class="tok-o">;</span>
-    <span class="tok-n">message</span> <span class="tok-o">:</span> <span class="tok-kt">string</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">undefined</span> <span class="tok-o">;</span>
-    <span class="tok-n">name</span> <span class="tok-o">:</span> <span class="tok-kt">string</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">undefined</span><span class="tok-o">;</span>
-    <span class="tok-n">fileName</span> <span class="tok-o">:</span> <span class="tok-kt">string</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">undefined</span>
-  <span class="tok-o">&gt;</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">t</span>
+<pre class="pygments highlight"><code data-lang="ocaml">type t =
+  &lt; stack : string Js.undefined ;
+    message : string Js.undefined ;
+    name : string Js.undefined;
+    fileName : string Js.undefined
+  &gt; Js.t
 
-<span class="tok-k">exception</span> <span class="tok-nc">Error</span> <span class="tok-k">of</span> <span class="tok-n">t</span></code></pre>
+exception Error of t</code></pre>
 </div>
 </div>
 </div>
@@ -3837,14 +3776,14 @@ more examples, please visit
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-c">(** Raise Js exception Error object with stacktrace *)</span>
-<span class="tok-k">val</span> <span class="tok-n">error</span> <span class="tok-o">:</span> <span class="tok-kt">string</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span>
-<span class="tok-k">val</span> <span class="tok-n">evalError</span> <span class="tok-o">:</span> <span class="tok-kt">string</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span>
-<span class="tok-k">val</span> <span class="tok-n">rangeError</span> <span class="tok-o">:</span> <span class="tok-kt">string</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span>
-<span class="tok-k">val</span> <span class="tok-n">referenceError</span> <span class="tok-o">:</span> <span class="tok-kt">string</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span>
-<span class="tok-k">val</span> <span class="tok-n">syntaxError</span> <span class="tok-o">:</span> <span class="tok-kt">string</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span>
-<span class="tok-k">val</span> <span class="tok-n">typeError</span> <span class="tok-o">:</span> <span class="tok-kt">string</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span>
-<span class="tok-k">val</span> <span class="tok-n">uriError</span> <span class="tok-o">:</span> <span class="tok-kt">string</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">(** Raise Js exception Error object with stacktrace *)
+val error : string -&gt; 'a
+val evalError : string -&gt; 'a
+val rangeError : string -&gt; 'a
+val referenceError : string -&gt; 'a
+val syntaxError : string -&gt; 'a
+val typeError : string -&gt; 'a
+val uriError : string -&gt; 'a</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -3870,12 +3809,12 @@ it preserves the type safety while allow uesrs to deal with mixed source.</p>
 <div class="listingblock">
 <div class="title">Example</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">handleData</span> <span class="tok-o">=</span> <span class="tok-k">function</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">open</span><span class="tok-o">]</span>
-   <span class="tok-o">|</span> <span class="tok-nc">Invalid_argument</span> <span class="tok-o">_</span> <span class="tok-o">-&gt;</span> <span class="tok-mi">0</span>
-   <span class="tok-o">|</span> <span class="tok-nc">Not_found</span> <span class="tok-o">-&gt;</span> <span class="tok-mi">1</span>
-   <span class="tok-o">|</span> <span class="tok-nc">Sys_error</span> <span class="tok-o">_</span> <span class="tok-o">-&gt;</span> <span class="tok-mi">2</span>
+<pre class="pygments highlight"><code data-lang="ocaml">let handleData = function [@bs.open]
+   | Invalid_argument _ -&gt; 0
+   | Not_found -&gt; 1
+   | Sys_error _ -&gt; 2
 
-<span class="tok-k">val</span> <span class="tok-n">handleData</span> <span class="tok-o">:</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-n">option</span> <b class="conum">(1)</b></code></pre>
+val handleData : 'a -&gt; int option <b class="conum">(1)</b></code></pre>
 </div>
 </div>
 <div class="colist arabic">
@@ -3892,17 +3831,17 @@ it preserves the type safety while allow uesrs to deal with mixed source.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">v</span> <span class="tok-o">=</span> <span class="tok-nn">Promise</span><span class="tok-p">.</span><span class="tok-n">reject</span> <span class="tok-nc">Not_found</span>
-<span class="tok-k">let</span> <span class="tok-n">handlePromiseFaiure</span> <span class="tok-o">=</span> <span class="tok-k">function</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">open</span><span class="tok-o">]</span>
-   <span class="tok-o">|</span> <span class="tok-nc">Not_found</span> <span class="tok-o">-&gt;</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">log</span> <span class="tok-s2">&quot;Not found&quot;</span><span class="tok-o">;</span> <span class="tok-o">(</span><span class="tok-nn">Promise</span><span class="tok-p">.</span><span class="tok-n">resolve</span> <span class="tok-bp">()</span><span class="tok-o">)</span>
+<pre class="pygments highlight"><code data-lang="ocaml">let v = Promise.reject Not_found
+let handlePromiseFaiure = function [@bs.open]
+   | Not_found -&gt; Js.log "Not found"; (Promise.resolve ())
 
-<span class="tok-k">let</span> <span class="tok-bp">()</span> <span class="tok-o">=</span>
-   <span class="tok-n">v</span>
-   <span class="tok-o">|&gt;</span> <span class="tok-nn">Promise</span><span class="tok-p">.</span><span class="tok-n">catch</span> <span class="tok-o">(</span><span class="tok-k">fun</span> <span class="tok-n">error</span> <span class="tok-o">-&gt;</span>
-        <span class="tok-k">match</span> <span class="tok-n">handlePromiseFaiure</span> <span class="tok-n">error</span> <span class="tok-k">with</span>
-        <span class="tok-o">|</span> <span class="tok-nc">Some</span> <span class="tok-n">x</span> <span class="tok-o">-&gt;</span> <span class="tok-n">x</span>
-        <span class="tok-o">|</span> <span class="tok-nc">None</span> <span class="tok-o">-&gt;</span> <span class="tok-k">raise</span> <span class="tok-nc">UnhandledPromise</span>
-    <span class="tok-o">)</span></code></pre>
+let () =
+   v
+   |&gt; Promise.catch (fun error -&gt;
+        match handlePromiseFaiure error with
+        | Some x -&gt; x
+        | None -&gt; raise UnhandledPromise
+    )</code></pre>
 </div>
 </div>
 </div>
@@ -3935,15 +3874,15 @@ want to use them with. For this purpose BuckleScript defines the type <code>'a J
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">external</span> <span class="tok-n">get_prop_name_maybe</span> <span class="tok-o">:</span> <span class="tok-kt">unit</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">string</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">null</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">val</span><span class="tok-o">]</span>
-<span class="tok-k">external</span> <span class="tok-n">set_or_unset_prop</span> <span class="tok-o">:</span> <span class="tok-kt">string</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">null</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">unit</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">val</span><span class="tok-o">]</span>
+<pre class="pygments highlight"><code data-lang="ocaml">external get_prop_name_maybe : unit -&gt; string Js.null = "" [@@bs.val]
+external set_or_unset_prop : string -&gt; int Js.null -&gt; unit = "" [@@bs.val]
 
-<span class="tok-c">(* unset property if fond *)</span>
-<span class="tok-k">let</span> <span class="tok-n">s</span> <span class="tok-o">=</span> <span class="tok-n">get_prop_name_maybe</span> <span class="tok-bp">()</span>
-<span class="tok-k">let</span> <span class="tok-o">_</span> <span class="tok-o">=</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-nn">Null</span><span class="tok-p">.</span><span class="tok-n">iter</span> <span class="tok-n">s</span> <span class="tok-o">(</span><span class="tok-k">function</span> <span class="tok-n">name</span> <span class="tok-o">-&gt;</span> <span class="tok-n">set_or_unset_prop</span> <span class="tok-n">name</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-nn">Null</span><span class="tok-p">.</span><span class="tok-n">empty</span><span class="tok-o">)</span>
+(* unset property if fond *)
+let s = get_prop_name_maybe ()
+let _ = Js.Null.iter s (function name -&gt; set_or_unset_prop name Js.Null.empty)
 
-<span class="tok-c">(* set some other property *)</span>
-<span class="tok-k">let</span> <span class="tok-o">_</span> <span class="tok-o">=</span> <span class="tok-n">set_or_unset_prop</span> <span class="tok-s2">&quot;some_other_property&quot;</span> <span class="tok-o">(</span><span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-nn">Null</span><span class="tok-p">.</span><span class="tok-n">return</span> <span class="tok-s2">&quot;&quot;</span><span class="tok-o">)</span></code></pre>
+(* set some other property *)
+let _ = set_or_unset_prop "some_other_property" (Js.Null.return "")</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -3953,10 +3892,10 @@ to maintain:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">external</span> <span class="tok-n">try_some_thing</span> <span class="tok-o">:</span> <span class="tok-kt">string</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">null</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">null</span> <span class="tok-o">=</span> <span class="tok-o">...</span>
+<pre class="pygments highlight"><code data-lang="ocaml">external try_some_thing : string Js.null -&gt; int Js.null = ...
 
-<span class="tok-k">let</span> <span class="tok-n">try_some_thing_maybe</span> <span class="tok-o">(</span> <span class="tok-n">v</span> <span class="tok-o">:</span> <span class="tok-kt">string</span> <span class="tok-n">option</span><span class="tok-o">)</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-n">option</span> <span class="tok-o">=</span>
-  <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-nn">Null</span><span class="tok-p">.</span><span class="tok-n">to_opt</span> <span class="tok-o">(</span><span class="tok-n">try_some_thing</span> <span class="tok-o">(</span><span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-nn">Null</span><span class="tok-p">.</span><span class="tok-n">from_opt</span> <span class="tok-n">v</span><span class="tok-o">))</span></code></pre>
+let try_some_thing_maybe ( v : string option) : int option =
+  Js.Null.to_opt (try_some_thing (Js.Null.from_opt v))</code></pre>
 </div>
 </div>
 </div>
@@ -4225,33 +4164,33 @@ TypeScript. This is still experimental.</p>
 <div class="listingblock">
 <div class="title">Example</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="sh">bsc.exe -dparsetree -drawlambda -bs-eval <span class="tok-s1">&#39;Js.log &quot;hello&quot;&#39;</span></code></pre>
+<pre class="pygments highlight"><code data-lang="sh">bsc.exe -dparsetree -drawlambda -bs-eval 'Js.log "hello"'</code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-o">[</span> <b class="conum">(1)</b>
-  <span class="tok-n">structure_item</span> <span class="tok-o">(//</span><span class="tok-n">toplevel</span><span class="tok-o">//[</span><span class="tok-mi">1</span><span class="tok-o">,</span><span class="tok-mi">0</span><span class="tok-o">+</span><span class="tok-mi">0</span><span class="tok-o">]..[</span><span class="tok-mi">1</span><span class="tok-o">,</span><span class="tok-mi">0</span><span class="tok-o">+</span><span class="tok-mi">14</span><span class="tok-o">])</span>
-    <span class="tok-nc">Pstr_eval</span>
-    <span class="tok-n">expression</span> <span class="tok-o">(//</span><span class="tok-n">toplevel</span><span class="tok-o">//[</span><span class="tok-mi">1</span><span class="tok-o">,</span><span class="tok-mi">0</span><span class="tok-o">+</span><span class="tok-mi">0</span><span class="tok-o">]..[</span><span class="tok-mi">1</span><span class="tok-o">,</span><span class="tok-mi">0</span><span class="tok-o">+</span><span class="tok-mi">14</span><span class="tok-o">])</span>
-      <span class="tok-nc">Pexp_apply</span>
-      <span class="tok-n">expression</span> <span class="tok-o">(//</span><span class="tok-n">toplevel</span><span class="tok-o">//[</span><span class="tok-mi">1</span><span class="tok-o">,</span><span class="tok-mi">0</span><span class="tok-o">+</span><span class="tok-mi">0</span><span class="tok-o">]..[</span><span class="tok-mi">1</span><span class="tok-o">,</span><span class="tok-mi">0</span><span class="tok-o">+</span><span class="tok-mi">6</span><span class="tok-o">])</span>
-        <span class="tok-nc">Pexp_ident</span> <span class="tok-s2">&quot;Js.log&quot;</span> <span class="tok-o">(//</span><span class="tok-n">toplevel</span><span class="tok-o">//[</span><span class="tok-mi">1</span><span class="tok-o">,</span><span class="tok-mi">0</span><span class="tok-o">+</span><span class="tok-mi">0</span><span class="tok-o">]..[</span><span class="tok-mi">1</span><span class="tok-o">,</span><span class="tok-mi">0</span><span class="tok-o">+</span><span class="tok-mi">6</span><span class="tok-o">])</span>
-      <span class="tok-o">[</span>
-        <span class="tok-o">&lt;</span><span class="tok-n">label</span><span class="tok-o">&gt;</span> <span class="tok-s2">&quot;&quot;</span>
-          <span class="tok-n">expression</span> <span class="tok-o">(//</span><span class="tok-n">toplevel</span><span class="tok-o">//[</span><span class="tok-mi">1</span><span class="tok-o">,</span><span class="tok-mi">0</span><span class="tok-o">+</span><span class="tok-mi">7</span><span class="tok-o">]..[</span><span class="tok-mi">1</span><span class="tok-o">,</span><span class="tok-mi">0</span><span class="tok-o">+</span><span class="tok-mi">14</span><span class="tok-o">])</span>
-            <span class="tok-nc">Pexp_constant</span> <span class="tok-nc">Const_string</span><span class="tok-o">(</span><span class="tok-s2">&quot;hello&quot;</span><span class="tok-o">,</span><span class="tok-nc">None</span><span class="tok-o">)</span>
-      <span class="tok-o">]</span>
-<span class="tok-o">]</span>
+<pre class="pygments highlight"><code data-lang="ocaml">[ <b class="conum">(1)</b>
+  structure_item (//toplevel//[1,0+0]..[1,0+14])
+    Pstr_eval
+    expression (//toplevel//[1,0+0]..[1,0+14])
+      Pexp_apply
+      expression (//toplevel//[1,0+0]..[1,0+6])
+        Pexp_ident "Js.log" (//toplevel//[1,0+0]..[1,0+6])
+      [
+        &lt;label&gt; ""
+          expression (//toplevel//[1,0+7]..[1,0+14])
+            Pexp_constant Const_string("hello",None)
+      ]
+]
 <b class="conum">(2)</b>
-<span class="tok-o">(</span><span class="tok-n">setglobal</span> <span class="tok-nc">Bs_internal_eval</span><span class="tok-o">!</span> <span class="tok-o">(</span><span class="tok-n">seq</span> <span class="tok-o">(</span><span class="tok-n">js_dump</span> <span class="tok-s2">&quot;hello&quot;</span><span class="tok-o">)</span> <span class="tok-o">(</span><span class="tok-n">makeblock</span> <span class="tok-mi">0</span><span class="tok-o">)))</span>
-<span class="tok-o">//</span> <span class="tok-nc">Generated</span> <span class="tok-n">by</span> <span class="tok-nc">BUCKLESCRIPT</span> <span class="tok-nc">VERSION</span> <span class="tok-mi">1</span><span class="tok-o">.</span><span class="tok-mi">0</span><span class="tok-o">.</span><span class="tok-mi">2</span> <span class="tok-o">,</span> <span class="tok-nc">PLEASE</span> <span class="tok-nc">EDIT</span> <span class="tok-nc">WITH</span> <span class="tok-nc">CARE</span>
-<span class="tok-k">&#39;</span><span class="tok-n">use</span> <span class="tok-n">strict&#39;</span><span class="tok-o">;</span>
+(setglobal Bs_internal_eval! (seq (js_dump "hello") (makeblock 0)))
+// Generated by BUCKLESCRIPT VERSION 1.0.2 , PLEASE EDIT WITH CARE
+'use strict';
 
 
-<span class="tok-n">console</span><span class="tok-o">.</span><span class="tok-n">log</span><span class="tok-o">(</span><span class="tok-s2">&quot;hello&quot;</span><span class="tok-o">);</span>
+console.log("hello");
 
-<span class="tok-o">/*</span>  <span class="tok-nc">Not</span> <span class="tok-n">a</span> <span class="tok-n">pure</span> <span class="tok-k">module</span> <span class="tok-o">*/</span></code></pre>
+/*  Not a pure module */</code></pre>
 </div>
 </div>
 <div class="colist arabic">
@@ -4277,7 +4216,7 @@ Another use case is that users can use <code>-ppx</code> explicitly as below:</p
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-n">bsc</span><span class="tok-o">.</span><span class="tok-n">exe</span> <span class="tok-o">-</span><span class="tok-n">c</span> <span class="tok-o">-</span><span class="tok-n">ppx</span> <span class="tok-n">bsppx</span><span class="tok-o">.</span><span class="tok-n">exe</span> <span class="tok-o">-</span><span class="tok-n">bs</span><span class="tok-o">-</span><span class="tok-n">no</span><span class="tok-o">-</span><span class="tok-n">builtin</span><span class="tok-o">-</span><span class="tok-n">ppx</span><span class="tok-o">-</span><span class="tok-n">ml</span> <span class="tok-n">c</span><span class="tok-o">.</span><span class="tok-n">ml</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">bsc.exe -c -ppx bsppx.exe -bs-no-builtin-ppx-ml c.ml</code></pre>
 </div>
 </div>
 </div>
@@ -4499,13 +4438,13 @@ it would be string</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-n">semver</span> <span class="tok-nn">Location</span><span class="tok-p">.</span><span class="tok-n">none</span> <span class="tok-s2">&quot;1.2.3&quot;</span> <span class="tok-s2">&quot;~1.3.0&quot;</span> <span class="tok-o">=</span> <span class="tok-bp">false</span><span class="tok-o">;;</span>
-<span class="tok-n">semver</span> <span class="tok-nn">Location</span><span class="tok-p">.</span><span class="tok-n">none</span> <span class="tok-s2">&quot;1.2.3&quot;</span> <span class="tok-s2">&quot;^1.3.0&quot;</span> <span class="tok-o">=</span> <span class="tok-bp">true</span> <span class="tok-o">;;</span>
-<span class="tok-n">semver</span> <span class="tok-nn">Location</span><span class="tok-p">.</span><span class="tok-n">none</span> <span class="tok-s2">&quot;1.2.3&quot;</span> <span class="tok-s2">&quot;&gt;1.3.0&quot;</span> <span class="tok-o">=</span> <span class="tok-bp">false</span> <span class="tok-o">;;</span>
-<span class="tok-n">semver</span> <span class="tok-nn">Location</span><span class="tok-p">.</span><span class="tok-n">none</span> <span class="tok-s2">&quot;1.2.3&quot;</span> <span class="tok-s2">&quot;&gt;=1.3.0&quot;</span> <span class="tok-o">=</span> <span class="tok-bp">false</span> <span class="tok-o">;;</span>
-<span class="tok-n">semver</span> <span class="tok-nn">Location</span><span class="tok-p">.</span><span class="tok-n">none</span> <span class="tok-s2">&quot;1.2.3&quot;</span> <span class="tok-s2">&quot;&lt;1.3.0&quot;</span> <span class="tok-o">=</span> <span class="tok-bp">true</span> <span class="tok-o">;;</span>
-<span class="tok-n">semver</span> <span class="tok-nn">Location</span><span class="tok-p">.</span><span class="tok-n">none</span> <span class="tok-s2">&quot;1.2.3&quot;</span> <span class="tok-s2">&quot;&lt;=1.3.0&quot;</span> <span class="tok-o">=</span> <span class="tok-bp">true</span> <span class="tok-o">;;</span>
-<span class="tok-n">semver</span> <span class="tok-nn">Location</span><span class="tok-p">.</span><span class="tok-n">none</span> <span class="tok-s2">&quot;1.2.3&quot;</span> <span class="tok-s2">&quot;1.2.3&quot;</span> <span class="tok-o">=</span> <span class="tok-bp">true</span><span class="tok-o">;;</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">semver Location.none "1.2.3" "~1.3.0" = false;;
+semver Location.none "1.2.3" "^1.3.0" = true ;;
+semver Location.none "1.2.3" "&gt;1.3.0" = false ;;
+semver Location.none "1.2.3" "&gt;=1.3.0" = false ;;
+semver Location.none "1.2.3" "&lt;1.3.0" = true ;;
+semver Location.none "1.2.3" "&lt;=1.3.0" = true ;;
+semver Location.none "1.2.3" "1.2.3" = true;;</code></pre>
 </div>
 </div>
 </div>
@@ -4514,26 +4453,26 @@ it would be string</p>
 <div class="listingblock">
 <div class="title">lwt_unix.mli</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">type</span> <span class="tok-n">open_flag</span> <span class="tok-o">=</span>
-    <span class="tok-nn">Unix</span><span class="tok-p">.</span><span class="tok-n">open_flag</span> <span class="tok-o">=</span>
-  <span class="tok-o">|</span> <span class="tok-nc">O_RDONLY</span>
-  <span class="tok-o">|</span> <span class="tok-nc">O_WRONLY</span>
-  <span class="tok-o">|</span> <span class="tok-nc">O_RDWR</span>
-  <span class="tok-o">|</span> <span class="tok-nc">O_NONBLOCK</span>
-  <span class="tok-o">|</span> <span class="tok-nc">O_APPEND</span>
-  <span class="tok-o">|</span> <span class="tok-nc">O_CREAT</span>
-  <span class="tok-o">|</span> <span class="tok-nc">O_TRUNC</span>
-  <span class="tok-o">|</span> <span class="tok-nc">O_EXCL</span>
-  <span class="tok-o">|</span> <span class="tok-nc">O_NOCTTY</span>
-  <span class="tok-o">|</span> <span class="tok-nc">O_DSYNC</span>
-  <span class="tok-o">|</span> <span class="tok-nc">O_SYNC</span>
-  <span class="tok-o">|</span> <span class="tok-nc">O_RSYNC</span>
-<span class="tok-o">#</span><span class="tok-k">if</span> <span class="tok-nc">OCAML_VERSION</span> <span class="tok-o">=~</span> <span class="tok-s2">&quot;&gt;=3.13&quot;</span> <span class="tok-k">then</span>
-  <span class="tok-o">|</span> <span class="tok-nc">O_SHARE_DELETE</span>
-<span class="tok-o">#</span><span class="tok-k">end</span>
-<span class="tok-o">#</span><span class="tok-k">if</span> <span class="tok-nc">OCAML_VERSION</span> <span class="tok-o">=~</span> <span class="tok-s2">&quot;&gt;=4.01&quot;</span> <span class="tok-k">then</span>
-  <span class="tok-o">|</span> <span class="tok-nc">O_CLOEXEC</span>
-<span class="tok-o">#</span><span class="tok-k">end</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">type open_flag =
+    Unix.open_flag =
+  | O_RDONLY
+  | O_WRONLY
+  | O_RDWR
+  | O_NONBLOCK
+  | O_APPEND
+  | O_CREAT
+  | O_TRUNC
+  | O_EXCL
+  | O_NOCTTY
+  | O_DSYNC
+  | O_SYNC
+  | O_RSYNC
+#if OCAML_VERSION =~ "&gt;=3.13" then
+  | O_SHARE_DELETE
+#end
+#if OCAML_VERSION =~ "&gt;=4.01" then
+  | O_CLOEXEC
+#end</code></pre>
 </div>
 </div>
 </div>
@@ -4541,15 +4480,15 @@ it would be string</p>
 <h3 id="_built_in_variables_and_custom_variables"><a class="anchor" href="#_built_in_variables_and_custom_variables"></a>Built in variables and custom variables</h3>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="sh">ocamlscript&gt;bsc.exe -bs-D <span class="tok-nv">CUSTOM_A</span><span class="tok-o">=</span><span class="tok-s2">&quot;ghsigh&quot;</span> -bs-list-conditionals
-OCAML_PATCH <span class="tok-s2">&quot;BS&quot;</span>
-BS_VERSION <span class="tok-s2">&quot;1.2.1&quot;</span>
-OS_TYPE <span class="tok-s2">&quot;Unix&quot;</span>
-BS <span class="tok-nb">true</span>
-CUSTOM_A <span class="tok-s2">&quot;ghsigh&quot;</span>
+<pre class="pygments highlight"><code data-lang="sh">ocamlscript&gt;bsc.exe -bs-D CUSTOM_A="ghsigh" -bs-list-conditionals
+OCAML_PATCH "BS"
+BS_VERSION "1.2.1"
+OS_TYPE "Unix"
+BS true
+CUSTOM_A "ghsigh"
 WORD_SIZE 64
-OCAML_VERSION <span class="tok-s2">&quot;4.02.3+BS&quot;</span>
-BIG_ENDIAN <span class="tok-nb">false</span></code></pre>
+OCAML_VERSION "4.02.3+BS"
+BIG_ENDIAN false</code></pre>
 </div>
 </div>
 </div>
@@ -4566,8 +4505,8 @@ so that it even works without compilation.</p>
 <div class="title">Example</div>
 <div class="content">
 <pre class="pygments highlight"><code data-lang="sh">bsc.exe -c lwt_unix.mli
-ocamlc -pp <span class="tok-s1">&#39;bspp.exe&#39;</span> -c lwt_unix.mli
-ocamlc -pp <span class="tok-s1">&#39;ocaml -w -a bspp.ml&#39;</span> -c lwt_unix.mli</code></pre>
+ocamlc -pp 'bspp.exe' -c lwt_unix.mli
+ocamlc -pp 'ocaml -w -a bspp.ml' -c lwt_unix.mli</code></pre>
 </div>
 </div>
 <div class="admonitionblock warning">
@@ -4582,9 +4521,9 @@ ocamlc -pp <span class="tok-s1">&#39;ocaml -w -a bspp.ml&#39;</span> -c lwt_unix
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">f</span> <span class="tok-n">x</span> <span class="tok-o">=</span>
-  <span class="tok-n">x</span>
-<span class="tok-o">#</span><span class="tok-n">elif</span> <b class="conum">(1)</b></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">let f x =
+  x
+#elif <b class="conum">(1)</b></code></pre>
 </div>
 </div>
 <div class="colist arabic">
@@ -4643,17 +4582,17 @@ below is a configuration to help you get auto-completion and validation for free
 <div class="listingblock">
 <div class="title">settings.json</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-p">{</span>
-    <span class="tok-s2">&quot;json.schemas&quot;</span><span class="tok-o">:</span> <span class="tok-p">[</span>
-        <span class="tok-p">{</span>
-            <span class="tok-s2">&quot;fileMatch&quot;</span><span class="tok-o">:</span> <span class="tok-p">[</span>
-                <span class="tok-s2">&quot;bsconfig.json&quot;</span>
-            <span class="tok-p">],</span>
-            <span class="tok-s2">&quot;url&quot;</span> <span class="tok-o">:</span> <span class="tok-s2">&quot;file:///path/to/bucklescript/docs/docson/build-schema.json&quot;</span> <b class="conum">(1)</b>
-        <span class="tok-p">}</span>
-    <span class="tok-p">],</span>
-    <span class="tok-c1">// ....</span>
-<span class="tok-p">}</span></code></pre>
+<pre class="pygments highlight"><code data-lang="js">{
+    "json.schemas": [
+        {
+            "fileMatch": [
+                "bsconfig.json"
+            ],
+            "url" : "file:///path/to/bucklescript/docs/docson/build-schema.json" <b class="conum">(1)</b>
+        }
+    ],
+    // ....
+}</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -4667,10 +4606,10 @@ either <code>bsb</code> (slightly higher latency but symlinked into <code>.bin</
 <div class="listingblock">
 <div class="title">bsconfig.json</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-p">{</span>
-  <span class="tok-s2">&quot;name&quot;</span><span class="tok-o">:</span> <span class="tok-s2">&quot;test&quot;</span><span class="tok-p">,</span> <span class="tok-c1">// package name, required </span><b class="conum">(1)</b>
-  <span class="tok-s2">&quot;sources&quot;</span><span class="tok-o">:</span> <span class="tok-s2">&quot;src&quot;</span> <b class="conum">(2)</b>
-<span class="tok-p">}</span></code></pre>
+<pre class="pygments highlight"><code data-lang="js">{
+  "name": "test", // package name, required <b class="conum">(1)</b>
+  "sources": "src" <b class="conum">(2)</b>
+}</code></pre>
 </div>
 </div>
 <div class="colist arabic">
@@ -4752,17 +4691,17 @@ bsb -w <b class="conum">(2)</b></code></pre>
 <div class="listingblock">
 <div class="title">bsconfig.json</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-p">{</span>
-    <span class="tok-s2">&quot;name&quot;</span><span class="tok-o">:</span> <span class="tok-s2">&quot;bs-string&quot;</span><span class="tok-p">,</span>
-    <span class="tok-s2">&quot;version&quot;</span><span class="tok-o">:</span> <span class="tok-s2">&quot;0.1.3&quot;</span><span class="tok-p">,</span>
-    <span class="tok-s2">&quot;bs-dependencies&quot;</span><span class="tok-o">:</span> <span class="tok-p">[</span>
-        <span class="tok-s2">&quot;bs-mocha&quot;</span> <b class="conum">(1)</b>
-    <span class="tok-p">],</span>
-    <span class="tok-s2">&quot;sources&quot;</span><span class="tok-o">:</span> <span class="tok-p">[</span>
-       <span class="tok-p">..</span> <span class="tok-p">.</span>
-    <span class="tok-p">],</span>
-    <span class="tok-s2">&quot;generate-merlin&quot;</span> <span class="tok-o">:</span> <span class="tok-kc">false</span> <b class="conum">(2)</b>
-<span class="tok-p">}</span></code></pre>
+<pre class="pygments highlight"><code data-lang="js">{
+    "name": "bs-string",
+    "version": "0.1.3",
+    "bs-dependencies": [
+        "bs-mocha" <b class="conum">(1)</b>
+    ],
+    "sources": [
+       .. .
+    ],
+    "generate-merlin" : false <b class="conum">(2)</b>
+}</code></pre>
 </div>
 </div>
 <div class="colist arabic">
@@ -4778,12 +4717,12 @@ bsb -w <b class="conum">(2)</b></code></pre>
 <div class="listingblock">
 <div class="title">package.json</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-p">{</span>
- <span class="tok-s2">&quot;dependencies&quot;</span><span class="tok-o">:</span> <span class="tok-p">{</span>
-    <span class="tok-s2">&quot;bs-mocha&quot;</span><span class="tok-o">:</span> <span class="tok-s2">&quot;0.1.5&quot;</span>
-    <span class="tok-p">},</span>
-  <span class="tok-p">...</span>
-<span class="tok-p">}</span></code></pre>
+<pre class="pygments highlight"><code data-lang="js">{
+ "dependencies": {
+    "bs-mocha": "0.1.5"
+    },
+  ...
+}</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -4827,12 +4766,12 @@ to build. In that case you can mark it as dev only:</p>
 <div class="listingblock">
 <div class="title">bsconfig.json</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-p">{</span>
-        <span class="tok-s2">&quot;sources&quot;</span> <span class="tok-o">:</span> <span class="tok-p">{</span>
-                <span class="tok-s2">&quot;dir&quot;</span> <span class="tok-o">:</span> <span class="tok-s2">&quot;test&quot;</span><span class="tok-p">,</span>
-                <span class="tok-s2">&quot;type&quot;</span> <span class="tok-o">:</span> <span class="tok-s2">&quot;dev&quot;</span> <b class="conum">(1)</b>
-        <span class="tok-p">}</span>
-<span class="tok-p">}</span></code></pre>
+<pre class="pygments highlight"><code data-lang="js">{
+        "sources" : {
+                "dir" : "test",
+                "type" : "dev" <b class="conum">(1)</b>
+        }
+}</code></pre>
 </div>
 </div>
 <div class="colist arabic">
@@ -4852,17 +4791,17 @@ to build. In that case you can mark it as dev only:</p>
 <div class="listingblock">
 <div class="title">bsconfig.json</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-p">{</span>
-  <span class="tok-s2">&quot;name&quot;</span><span class="tok-o">:</span> <span class="tok-s2">&quot;bucklescript-tea&quot;</span><span class="tok-p">,</span>
-  <span class="tok-s2">&quot;version&quot;</span><span class="tok-o">:</span> <span class="tok-s2">&quot;0.1.3&quot;</span><span class="tok-p">,</span>
-  <span class="tok-s2">&quot;sources&quot;</span><span class="tok-o">:</span> <span class="tok-p">[</span>
-   <span class="tok-s2">&quot;src&quot;</span><span class="tok-p">,</span> <b class="conum">(1)</b>
-    <span class="tok-p">{</span>
-      <span class="tok-s2">&quot;dir&quot;</span><span class="tok-o">:</span> <span class="tok-s2">&quot;test&quot;</span><span class="tok-p">,</span>
-      <span class="tok-s2">&quot;type&quot;</span><span class="tok-o">:</span> <span class="tok-s2">&quot;dev&quot;</span> <b class="conum">(2)</b>
-    <span class="tok-p">}</span>
-  <span class="tok-p">]</span>
-<span class="tok-p">}</span></code></pre>
+<pre class="pygments highlight"><code data-lang="js">{
+  "name": "bucklescript-tea",
+  "version": "0.1.3",
+  "sources": [
+   "src", <b class="conum">(1)</b>
+    {
+      "dir": "test",
+      "type": "dev" <b class="conum">(2)</b>
+    }
+  ]
+}</code></pre>
 </div>
 </div>
 <div class="colist arabic">
@@ -4878,19 +4817,19 @@ to build. In that case you can mark it as dev only:</p>
 <div class="listingblock">
 <div class="title">package.json</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-p">{</span>
-  <span class="tok-s2">&quot;name&quot;</span><span class="tok-o">:</span> <span class="tok-s2">&quot;bucklescript-tea&quot;</span><span class="tok-p">,</span>
-  <span class="tok-s2">&quot;version&quot;</span><span class="tok-o">:</span> <span class="tok-s2">&quot;0.1.3&quot;</span><span class="tok-p">,</span>
-  <span class="tok-s2">&quot;description&quot;</span><span class="tok-o">:</span> <span class="tok-s2">&quot;TEA for Bucklescript&quot;</span><span class="tok-p">,</span>
-  <span class="tok-s2">&quot;scripts&quot;</span><span class="tok-o">:</span> <span class="tok-p">{</span>
-    <span class="tok-s2">&quot;build&quot;</span><span class="tok-o">:</span> <span class="tok-s2">&quot;bsb&quot;</span><span class="tok-p">,</span>
-    <span class="tok-s2">&quot;watch&quot;</span><span class="tok-o">:</span> <span class="tok-s2">&quot;bsb -w&quot;</span><span class="tok-p">,</span>
-    <span class="tok-s2">&quot;test&quot;</span><span class="tok-o">:</span> <span class="tok-s2">&quot;echo \&quot;Error: no test specified\&quot; &amp;&amp; exit 1&quot;</span>
-  <span class="tok-p">},</span>
-  <span class="tok-s2">&quot;peerDependencies&quot;</span><span class="tok-o">:</span> <span class="tok-p">{</span>
-    <span class="tok-s2">&quot;bs-platform&quot;</span><span class="tok-o">:</span> <span class="tok-s2">&quot;^1.7.0&quot;</span> <b class="conum">(1)</b>
-  <span class="tok-p">}</span>
-<span class="tok-p">}</span></code></pre>
+<pre class="pygments highlight"><code data-lang="js">{
+  "name": "bucklescript-tea",
+  "version": "0.1.3",
+  "description": "TEA for Bucklescript",
+  "scripts": {
+    "build": "bsb",
+    "watch": "bsb -w",
+    "test": "echo \"Error: no test specified\" &amp;&amp; exit 1"
+  },
+  "peerDependencies": {
+    "bs-platform": "^1.7.0" <b class="conum">(1)</b>
+  }
+}</code></pre>
 </div>
 </div>
 <div class="colist arabic">
@@ -4906,24 +4845,24 @@ to build. In that case you can mark it as dev only:</p>
 <div class="listingblock">
 <div class="title">bsconfig.json</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-p">{</span>
-    <span class="tok-s2">&quot;name&quot;</span> <span class="tok-o">:</span> <span class="tok-s2">&quot;bucklescript-have-tea&quot;</span><span class="tok-p">,</span>
-    <span class="tok-s2">&quot;sources&quot;</span> <span class="tok-o">:</span> <span class="tok-s2">&quot;src&quot;</span><span class="tok-p">,</span>
-    <span class="tok-s2">&quot;bs-dependencies&quot;</span><span class="tok-o">:</span> <span class="tok-p">[</span>
-      <span class="tok-s2">&quot;bucklescript-tea&quot;</span>
-    <span class="tok-p">]</span>
-<span class="tok-p">}</span></code></pre>
+<pre class="pygments highlight"><code data-lang="js">{
+    "name" : "bucklescript-have-tea",
+    "sources" : "src",
+    "bs-dependencies": [
+      "bucklescript-tea"
+    ]
+}</code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="title">package.json</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-p">{</span>
-    <span class="tok-s2">&quot;name&quot;</span> <span class="tok-o">:</span> <span class="tok-s2">&quot;bucklescript-have-tea&quot;</span><span class="tok-p">,</span>
-    <span class="tok-s2">&quot;version&quot;</span> <span class="tok-o">:</span> <span class="tok-s2">&quot;0.1.0&quot;</span><span class="tok-p">,</span>
-    <span class="tok-s2">&quot;dependencies&quot;</span> <span class="tok-o">:</span> <span class="tok-p">{</span> <span class="tok-s2">&quot;bucklescript-tea&quot;</span> <span class="tok-o">:</span> <span class="tok-s2">&quot;^0.1.2&quot;</span> <span class="tok-p">},</span> <b class="conum">(1)</b>
-    <span class="tok-s2">&quot;peerDependencies&quot;</span> <span class="tok-o">:</span> <span class="tok-p">{</span> <span class="tok-s2">&quot;bs-platform&quot;</span> <span class="tok-o">:</span> <span class="tok-s2">&quot;^1.7.0&quot;</span> <span class="tok-p">}</span> <b class="conum">(2)</b>
-<span class="tok-p">}</span></code></pre>
+<pre class="pygments highlight"><code data-lang="js">{
+    "name" : "bucklescript-have-tea",
+    "version" : "0.1.0",
+    "dependencies" : { "bucklescript-tea" : "^0.1.2" }, <b class="conum">(1)</b>
+    "peerDependencies" : { "bs-platform" : "^1.7.0" } <b class="conum">(2)</b>
+}</code></pre>
 </div>
 </div>
 <div class="colist arabic">
@@ -4964,11 +4903,11 @@ npm install bs-platform <b class="conum">(2)</b>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-p">{</span>
-  <span class="tok-p">...</span> <span class="tok-p">,</span>
-  <span class="tok-s2">&quot;package-specs&quot;</span> <span class="tok-o">:</span> <span class="tok-p">[</span><span class="tok-s2">&quot;amdjs&quot;</span><span class="tok-p">,</span> <span class="tok-s2">&quot;commonjs&quot;</span><span class="tok-p">],</span>
-  <span class="tok-p">...</span>
-<span class="tok-p">}</span></code></pre>
+<pre class="pygments highlight"><code data-lang="js">{
+  ... ,
+  "package-specs" : ["amdjs", "commonjs"],
+  ...
+}</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -5009,21 +4948,21 @@ are <em>curious</em> about how the build works.</p>
 <div class="listingblock">
 <div class="title">Makefile</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="make"><span class="tok-nv">OCAMLC</span><span class="tok-o">=</span>bsc.exe <b class="conum">(1)</b>
-<span class="tok-nv">OCAMLDEP</span><span class="tok-o">=</span>bsdep.exe <b class="conum">(2)</b>
-<span class="tok-nv">SOURCE_LIST</span> <span class="tok-o">:=</span> src_a src_b
-<span class="tok-nv">SOURCE_MLI</span> <span class="tok-o">=</span> <span class="tok-k">$(</span>addsuffix .mli, <span class="tok-k">$(</span>SOURCE_LIST<span class="tok-k">))</span>
-<span class="tok-nv">SOURCE_ML</span>  <span class="tok-o">=</span> <span class="tok-k">$(</span>addsuffix .ml, <span class="tok-k">$(</span>SOURCE_LIST<span class="tok-k">))</span>
-<span class="tok-nv">TARGETS</span> <span class="tok-o">:=</span> <span class="tok-k">$(</span>addsuffix .cmj, <span class="tok-k">$(</span>SOURCE_LIST<span class="tok-k">))</span>
-<span class="tok-nv">INCLUDES</span><span class="tok-o">=</span>
-<span class="tok-nf">all</span><span class="tok-o">:</span> <span class="tok-k">$(</span><span class="tok-nv">TARGETS</span><span class="tok-k">)</span>
-<span class="tok-nf">.mli</span><span class="tok-o">:</span>.<span class="tok-n">cmi</span>
-        <span class="tok-k">$(</span>OCAMLC<span class="tok-k">)</span> <span class="tok-k">$(</span>INCLUDES<span class="tok-k">)</span> <span class="tok-k">$(</span>COMPFLAGS<span class="tok-k">)</span> -c <span class="tok-nv">$&lt;</span>
-<span class="tok-nf">.ml</span><span class="tok-o">:</span>.<span class="tok-n">cmj</span>:
-        <span class="tok-k">$(</span>OCAMLC<span class="tok-k">)</span> <span class="tok-k">$(</span>INCLUDES<span class="tok-k">)</span> <span class="tok-k">$(</span>COMPFLAGS<span class="tok-k">)</span> -c <span class="tok-nv">$&lt;</span>
-<span class="tok-cp">-include .depend</span>
-<span class="tok-nf">depend</span><span class="tok-o">:</span>
-        <span class="tok-k">$(</span>OCAMLDEP<span class="tok-k">)</span> <span class="tok-k">$(</span>INCLUDES<span class="tok-k">)</span> <span class="tok-k">$(</span>SOURCE_ML<span class="tok-k">)</span> <span class="tok-k">$(</span>SOURCE_MLI<span class="tok-k">)</span> &gt; .depend</code></pre>
+<pre class="pygments highlight"><code data-lang="make">OCAMLC=bsc.exe <b class="conum">(1)</b>
+OCAMLDEP=bsdep.exe <b class="conum">(2)</b>
+SOURCE_LIST := src_a src_b
+SOURCE_MLI = $(addsuffix .mli, $(SOURCE_LIST))
+SOURCE_ML  = $(addsuffix .ml, $(SOURCE_LIST))
+TARGETS := $(addsuffix .cmj, $(SOURCE_LIST))
+INCLUDES=
+all: $(TARGETS)
+.mli:.cmi
+        $(OCAMLC) $(INCLUDES) $(COMPFLAGS) -c $&lt;
+.ml:.cmj:
+        $(OCAMLC) $(INCLUDES) $(COMPFLAGS) -c $&lt;
+-include .depend
+depend:
+        $(OCAMLDEP) $(INCLUDES) $(SOURCE_ML) $(SOURCE_MLI) &gt; .depend</code></pre>
 </div>
 </div>
 <div class="colist arabic">
@@ -5047,14 +4986,14 @@ such as <a href="https://facebook.github.io/watchman/">watchman</a> for example,
 <div class="listingblock">
 <div class="title">build.json</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="json"><span class="tok-p">[</span>
-    <span class="tok-s2">&quot;trigger&quot;</span><span class="tok-p">,</span> <span class="tok-s2">&quot;.&quot;</span><span class="tok-p">,</span> <span class="tok-p">{</span>
-        <span class="tok-nt">&quot;name&quot;</span><span class="tok-p">:</span> <span class="tok-s2">&quot;build&quot;</span><span class="tok-p">,</span>
-        <span class="tok-nt">&quot;expression&quot;</span><span class="tok-p">:</span> <span class="tok-p">[</span><span class="tok-s2">&quot;pcre&quot;</span><span class="tok-p">,</span> <span class="tok-s2">&quot;(\\.(ml|mll|mly|mli|sh|sh)$|Makefile)&quot;</span><span class="tok-p">],</span> <b class="conum">(1)</b>
-        <span class="tok-nt">&quot;command&quot;</span><span class="tok-p">:</span> <span class="tok-p">[</span><span class="tok-s2">&quot;./build.sh&quot;</span><span class="tok-p">],</span>
-        <span class="tok-nt">&quot;append_files&quot;</span> <span class="tok-p">:</span> <span class="tok-kc">true</span>
-    <span class="tok-p">}</span>
-<span class="tok-p">]</span></code></pre>
+<pre class="pygments highlight"><code data-lang="json">[
+    "trigger", ".", {
+        "name": "build",
+        "expression": ["pcre", "(\\.(ml|mll|mly|mli|sh|sh)$|Makefile)"], <b class="conum">(1)</b>
+        "command": ["./build.sh"],
+        "append_files" : true
+    }
+]</code></pre>
 </div>
 </div>
 <div class="colist arabic">
@@ -5442,8 +5381,8 @@ We might encode it as buffer in NodeJS.
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">type</span> <span class="tok-n">t</span> <span class="tok-o">=</span> <span class="tok-o">{</span> <span class="tok-n">x</span> <span class="tok-o">:</span> <span class="tok-kt">int</span><span class="tok-o">;</span> <span class="tok-n">y</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">}</span>
-<span class="tok-k">let</span> <span class="tok-n">v</span> <span class="tok-o">=</span> <span class="tok-o">{</span><span class="tok-n">x</span> <span class="tok-o">=</span> <span class="tok-mi">1</span><span class="tok-o">;</span> <span class="tok-n">y</span> <span class="tok-o">=</span> <span class="tok-mi">2</span><span class="tok-o">}</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">type t = { x : int; y : int }
+let v = {x = 1; y = 2}</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -5451,7 +5390,7 @@ We might encode it as buffer in NodeJS.
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"><span class="tok-kd">var</span> <span class="tok-nx">v</span> <span class="tok-o">=</span> <span class="tok-p">[</span><span class="tok-mi">1</span><span class="tok-p">,</span><span class="tok-mi">2</span><span class="tok-p">]</span></code></pre>
+<pre class="pygments highlight"><code data-lang="js">var v = [1,2]</code></pre>
 </div>
 </div></div></td>
 </tr>
@@ -5522,11 +5461,11 @@ We might encode it as buffer in NodeJS.
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">type</span> <span class="tok-n">tree</span> <span class="tok-o">=</span>
-  <span class="tok-o">|</span> <span class="tok-nc">Leaf</span>
-  <span class="tok-o">|</span> <span class="tok-nc">Node</span> <span class="tok-k">of</span> <span class="tok-kt">int</span> <span class="tok-o">*</span> <span class="tok-n">tree</span> <span class="tok-o">*</span> <span class="tok-n">tree</span>
-<span class="tok-c">(* Leaf --&gt; 0 *)</span>
-<span class="tok-c">(* Node(a,b,c) --&gt; [a,b,c]*)</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">type tree =
+  | Leaf
+  | Node of int * tree * tree
+(* Leaf --&gt; 0 *)
+(* Node(a,b,c) --&gt; [a,b,c]*)</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -5534,11 +5473,11 @@ We might encode it as buffer in NodeJS.
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">type</span> <span class="tok-n">u</span> <span class="tok-o">=</span>
-     <span class="tok-o">|</span> <span class="tok-nc">A</span> <span class="tok-k">of</span> <span class="tok-kt">string</span>
-     <span class="tok-o">|</span> <span class="tok-nc">B</span> <span class="tok-k">of</span> <span class="tok-kt">int</span>
-<span class="tok-c">(* A a --&gt; [a].tag=0 -- tag 0 assignment is optional *)</span>
-<span class="tok-c">(* B b --&gt; [b].tag=1 *)</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">type u =
+     | A of string
+     | B of int
+(* A a --&gt; [a].tag=0 -- tag 0 assignment is optional *)
+(* B b --&gt; [b].tag=1 *)</code></pre>
 </div>
 </div></div></td>
 </tr>
@@ -5549,8 +5488,8 @@ We might encode it as buffer in NodeJS.
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-o">`</span><span class="tok-n">a</span> <span class="tok-c">(* 97 *)</span>
-<span class="tok-o">`</span><span class="tok-n">a</span> <span class="tok-mi">1</span> <span class="tok-mi">2</span> <span class="tok-c">(* [97, [1,2] ]*)</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">`a (* 97 *)
+`a 1 2 (* [97, [1,2] ]*)</code></pre>
 </div>
 </div></div></td>
 </tr>
@@ -5587,8 +5526,8 @@ We might encode it as buffer in NodeJS.
 <div class="listingblock">
 <div class="title">Js module</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">type</span> <span class="tok-n">boolean</span>
-<span class="tok-k">val</span> <span class="tok-n">to_bool</span><span class="tok-o">:</span> <span class="tok-n">boolean</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">bool</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">type boolean
+val to_bool: boolean -&gt; bool</code></pre>
 </div>
 </div>
 <div class="listingblock">
@@ -5606,10 +5545,10 @@ We might encode it as buffer in NodeJS.
 <div class="listingblock">
 <div class="title">Js.Null module</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">val</span> <span class="tok-n">to_opt</span> <span class="tok-o">:</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-n">t</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-n">option</span>
-<span class="tok-k">val</span> <span class="tok-n">from_opt</span> <span class="tok-o">:</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-n">option</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-n">t</span>
-<span class="tok-k">val</span> <span class="tok-n">return</span> <span class="tok-o">:</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-n">t</span>
-<span class="tok-k">val</span> <span class="tok-n">test</span> <span class="tok-o">:</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-n">t</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">bool</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">val to_opt : 'a t -&gt; 'a option
+val from_opt : 'a option -&gt; 'a t
+val return : 'a -&gt; 'a t
+val test : 'a t -&gt; bool</code></pre>
 </div>
 </div></div></td>
 </tr>
@@ -5670,11 +5609,11 @@ We are working to provide a ppx extension as below:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">type</span> <span class="tok-n">t</span> <span class="tok-o">=</span>
-  <span class="tok-o">|</span> <span class="tok-nc">A</span>
-  <span class="tok-o">|</span> <span class="tok-nc">B</span> <span class="tok-k">of</span> <span class="tok-kt">int</span> <span class="tok-o">*</span> <span class="tok-kt">int</span>
-  <span class="tok-o">|</span> <span class="tok-nc">C</span> <span class="tok-k">of</span> <span class="tok-kt">int</span> <span class="tok-o">*</span> <span class="tok-kt">int</span>
-  <span class="tok-o">|</span> <span class="tok-nc">D</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">deriving</span><span class="tok-o">{</span><span class="tok-n">export</span><span class="tok-o">}]</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">type t =
+  | A
+  | B of int * int
+  | C of int * int
+  | D [@@bs.deriving{export}]</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -5683,15 +5622,15 @@ We are working to provide a ppx extension as below:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">val</span> <span class="tok-n">a</span> <span class="tok-o">:</span> <span class="tok-n">t</span>
-<span class="tok-k">val</span> <span class="tok-n">b</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-n">t</span>
-<span class="tok-k">val</span> <span class="tok-n">c</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-n">t</span>
-<span class="tok-k">val</span> <span class="tok-n">d</span> <span class="tok-o">:</span> <span class="tok-kt">int</span>
+<pre class="pygments highlight"><code data-lang="ocaml">val a : t
+val b : int -&gt; int -&gt; t
+val c : int -&gt; int -&gt; t
+val d : int
 
-<span class="tok-k">val</span> <span class="tok-n">a_of_t</span> <span class="tok-o">:</span> <span class="tok-n">t</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">bool</span>
-<span class="tok-k">val</span> <span class="tok-n">d_of_t</span> <span class="tok-o">:</span> <span class="tok-n">t</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">bool</span>
-<span class="tok-k">val</span> <span class="tok-n">b_of_t</span> <span class="tok-o">:</span> <span class="tok-n">t</span> <span class="tok-o">-&gt;</span> <span class="tok-o">(</span><span class="tok-kt">int</span> <span class="tok-o">*</span> <span class="tok-kt">int</span> <span class="tok-o">)</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-nn">Null</span><span class="tok-p">.</span><span class="tok-n">t</span>
-<span class="tok-k">val</span> <span class="tok-n">c_of_t</span> <span class="tok-o">:</span> <span class="tok-n">t</span> <span class="tok-o">-&gt;</span> <span class="tok-o">(</span><span class="tok-kt">int</span> <span class="tok-o">*</span> <span class="tok-kt">int</span> <span class="tok-o">)</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-nn">Null</span><span class="tok-p">.</span><span class="tok-n">t</span></code></pre>
+val a_of_t : t -&gt; bool
+val d_of_t : t -&gt; bool
+val b_of_t : t -&gt; (int * int ) Js.Null.t
+val c_of_t : t -&gt; (int * int ) Js.Null.t</code></pre>
 </div>
 </div>
 </div>
@@ -5791,7 +5730,7 @@ so the user does not need install those tools.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="sh">make snapshotml <span class="tok-c"># see the diffs in jscomp/bin</span></code></pre>
+<pre class="pygments highlight"><code data-lang="sh">make snapshotml # see the diffs in jscomp/bin</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -5802,12 +5741,12 @@ so the user does not need install those tools.</p>
 <h3 id="_contributing_to_code_bsc_exe_code"><a class="anchor" href="#_contributing_to_code_bsc_exe_code"></a>Contributing to <code>bsc.exe</code></h3>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="sh">make -C bin bsc.exe <span class="tok-c"># build the compiler in dev mode</span></code></pre>
+<pre class="pygments highlight"><code data-lang="sh">make -C bin bsc.exe # build the compiler in dev mode</code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="sh">make libs <span class="tok-c"># build all libs using the dev compiler</span></code></pre>
+<pre class="pygments highlight"><code data-lang="sh">make libs # build all libs using the dev compiler</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -5860,13 +5799,13 @@ the compiler you modified.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">suites</span> <span class="tok-o">:</span> <span class="tok-o">_</span> <span class="tok-nn">Mt</span><span class="tok-p">.</span><span class="tok-n">pair_suites</span> <span class="tok-o">=</span>
-   <span class="tok-o">[</span><span class="tok-s2">&quot;hey&quot;</span><span class="tok-o">,</span> <span class="tok-o">(</span><span class="tok-k">fun</span> <span class="tok-o">_</span> <span class="tok-o">-&gt;</span> <span class="tok-nc">Eq</span><span class="tok-o">(</span><span class="tok-bp">true</span><span class="tok-o">,</span> <span class="tok-mi">3</span> <span class="tok-o">&gt;</span> <span class="tok-mi">2</span><span class="tok-o">));</span>
-       <span class="tok-s2">&quot;hi&quot;</span><span class="tok-o">,</span> <span class="tok-o">(</span><span class="tok-k">fun</span> <span class="tok-o">_</span> <span class="tok-o">-&gt;</span> <span class="tok-nc">Neq</span><span class="tok-o">(</span><span class="tok-mi">2</span><span class="tok-o">,</span><span class="tok-mi">3</span><span class="tok-o">));</span>
-       <span class="tok-s2">&quot;hello&quot;</span><span class="tok-o">,</span> <span class="tok-o">(</span><span class="tok-k">fun</span> <span class="tok-o">_</span> <span class="tok-o">-&gt;</span> <span class="tok-nc">Approx</span><span class="tok-o">(</span><span class="tok-mi">3</span><span class="tok-o">.</span><span class="tok-mi">0</span><span class="tok-o">,</span> <span class="tok-mi">3</span><span class="tok-o">.</span><span class="tok-mi">0</span><span class="tok-o">));</span>
-       <span class="tok-s2">&quot;throw&quot;</span><span class="tok-o">,</span> <span class="tok-o">(</span><span class="tok-k">fun</span> <span class="tok-o">_</span> <span class="tok-o">-&gt;</span> <span class="tok-nc">ThrowAny</span><span class="tok-o">(</span><span class="tok-k">fun</span> <span class="tok-o">_</span> <span class="tok-o">-&gt;</span> <span class="tok-k">raise</span> <span class="tok-mi">3</span><span class="tok-o">))</span>
-       <span class="tok-o">]</span>
-<span class="tok-k">let</span> <span class="tok-bp">()</span> <span class="tok-o">=</span> <span class="tok-nn">Mt</span><span class="tok-p">.</span><span class="tok-n">from_pair_suites</span> <span class="tok-o">__</span><span class="tok-n">FILE__</span> <span class="tok-n">suites</span></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">let suites : _ Mt.pair_suites =
+   ["hey", (fun _ -&gt; Eq(true, 3 &gt; 2));
+       "hi", (fun _ -&gt; Neq(2,3));
+       "hello", (fun _ -&gt; Approx(3.0, 3.0));
+       "throw", (fun _ -&gt; ThrowAny(fun _ -&gt; raise 3))
+       ]
+let () = Mt.from_pair_suites __FILE__ suites</code></pre>
 </div>
 </div>
 <div class="ulist">
@@ -5902,7 +5841,9 @@ the compiler you modified.</p>
 <div class="sect2">
 <h3 id="_contributing_to_the_documentation"><a class="anchor" href="#_contributing_to_the_documentation"></a>Contributing to the documentation</h3>
 <div class="paragraph">
-<p>You&#8217;ll need <a href="http://asciidoctor.org/">Asciidoctor</a> installed. Modify the section you want in <code>site/docsource/</code>, then run <code>site/docsource/build.sh</code>.</p>
+<p>You&#8217;ll need <a href="http://asciidoctor.org/">Asciidoctor</a> installed and on your <code>PATH</code>.
+Go into <code>site/docsource/</code>, modify the section you want, and run <code>build.sh</code>.
+You can check the <code>build.compile</code> file in the project root for debug output.</p>
 </div>
 </div>
 <div class="sect2">

--- a/docs/Manual.html
+++ b/docs/Manual.html
@@ -418,7 +418,69 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 .show-for-print{display:inherit!important}}
 </style>
 <style>
-/* Pygments styles disabled. Pygments is not available. */
+.listingblock .pygments .hll { background-color: #ffffcc }
+.listingblock .pygments  { background: #f8f8f8; }
+.listingblock .pygments .tok-c { color: #408080; font-style: italic } /* Comment */
+.listingblock .pygments .tok-err { border: 1px solid #FF0000 } /* Error */
+.listingblock .pygments .tok-k { color: #008000; font-weight: bold } /* Keyword */
+.listingblock .pygments .tok-o { color: #666666 } /* Operator */
+.listingblock .pygments .tok-cm { color: #408080; font-style: italic } /* Comment.Multiline */
+.listingblock .pygments .tok-cp { color: #BC7A00 } /* Comment.Preproc */
+.listingblock .pygments .tok-c1 { color: #408080; font-style: italic } /* Comment.Single */
+.listingblock .pygments .tok-cs { color: #408080; font-style: italic } /* Comment.Special */
+.listingblock .pygments .tok-gd { color: #A00000 } /* Generic.Deleted */
+.listingblock .pygments .tok-ge { font-style: italic } /* Generic.Emph */
+.listingblock .pygments .tok-gr { color: #FF0000 } /* Generic.Error */
+.listingblock .pygments .tok-gh { color: #000080; font-weight: bold } /* Generic.Heading */
+.listingblock .pygments .tok-gi { color: #00A000 } /* Generic.Inserted */
+.listingblock .pygments .tok-go { color: #888888 } /* Generic.Output */
+.listingblock .pygments .tok-gp { color: #000080; font-weight: bold } /* Generic.Prompt */
+.listingblock .pygments .tok-gs { font-weight: bold } /* Generic.Strong */
+.listingblock .pygments .tok-gu { color: #800080; font-weight: bold } /* Generic.Subheading */
+.listingblock .pygments .tok-gt { color: #0044DD } /* Generic.Traceback */
+.listingblock .pygments .tok-kc { color: #008000; font-weight: bold } /* Keyword.Constant */
+.listingblock .pygments .tok-kd { color: #008000; font-weight: bold } /* Keyword.Declaration */
+.listingblock .pygments .tok-kn { color: #008000; font-weight: bold } /* Keyword.Namespace */
+.listingblock .pygments .tok-kp { color: #008000 } /* Keyword.Pseudo */
+.listingblock .pygments .tok-kr { color: #008000; font-weight: bold } /* Keyword.Reserved */
+.listingblock .pygments .tok-kt { color: #B00040 } /* Keyword.Type */
+.listingblock .pygments .tok-m { color: #666666 } /* Literal.Number */
+.listingblock .pygments .tok-s { color: #BA2121 } /* Literal.String */
+.listingblock .pygments .tok-na { color: #7D9029 } /* Name.Attribute */
+.listingblock .pygments .tok-nb { color: #008000 } /* Name.Builtin */
+.listingblock .pygments .tok-nc { color: #0000FF; font-weight: bold } /* Name.Class */
+.listingblock .pygments .tok-no { color: #880000 } /* Name.Constant */
+.listingblock .pygments .tok-nd { color: #AA22FF } /* Name.Decorator */
+.listingblock .pygments .tok-ni { color: #999999; font-weight: bold } /* Name.Entity */
+.listingblock .pygments .tok-ne { color: #D2413A; font-weight: bold } /* Name.Exception */
+.listingblock .pygments .tok-nf { color: #0000FF } /* Name.Function */
+.listingblock .pygments .tok-nl { color: #A0A000 } /* Name.Label */
+.listingblock .pygments .tok-nn { color: #0000FF; font-weight: bold } /* Name.Namespace */
+.listingblock .pygments .tok-nt { color: #008000; font-weight: bold } /* Name.Tag */
+.listingblock .pygments .tok-nv { color: #19177C } /* Name.Variable */
+.listingblock .pygments .tok-ow { color: #AA22FF; font-weight: bold } /* Operator.Word */
+.listingblock .pygments .tok-w { color: #bbbbbb } /* Text.Whitespace */
+.listingblock .pygments .tok-mb { color: #666666 } /* Literal.Number.Bin */
+.listingblock .pygments .tok-mf { color: #666666 } /* Literal.Number.Float */
+.listingblock .pygments .tok-mh { color: #666666 } /* Literal.Number.Hex */
+.listingblock .pygments .tok-mi { color: #666666 } /* Literal.Number.Integer */
+.listingblock .pygments .tok-mo { color: #666666 } /* Literal.Number.Oct */
+.listingblock .pygments .tok-sb { color: #BA2121 } /* Literal.String.Backtick */
+.listingblock .pygments .tok-sc { color: #BA2121 } /* Literal.String.Char */
+.listingblock .pygments .tok-sd { color: #BA2121; font-style: italic } /* Literal.String.Doc */
+.listingblock .pygments .tok-s2 { color: #BA2121 } /* Literal.String.Double */
+.listingblock .pygments .tok-se { color: #BB6622; font-weight: bold } /* Literal.String.Escape */
+.listingblock .pygments .tok-sh { color: #BA2121 } /* Literal.String.Heredoc */
+.listingblock .pygments .tok-si { color: #BB6688; font-weight: bold } /* Literal.String.Interpol */
+.listingblock .pygments .tok-sx { color: #008000 } /* Literal.String.Other */
+.listingblock .pygments .tok-sr { color: #BB6688 } /* Literal.String.Regex */
+.listingblock .pygments .tok-s1 { color: #BA2121 } /* Literal.String.Single */
+.listingblock .pygments .tok-ss { color: #19177C } /* Literal.String.Symbol */
+.listingblock .pygments .tok-bp { color: #008000 } /* Name.Builtin.Pseudo */
+.listingblock .pygments .tok-vc { color: #19177C } /* Name.Variable.Class */
+.listingblock .pygments .tok-vg { color: #19177C } /* Name.Variable.Global */
+.listingblock .pygments .tok-vi { color: #19177C } /* Name.Variable.Instance */
+.listingblock .pygments .tok-il { color: #666666 } /* Literal.Number.Integer.Long */
 </style>
 </head>
 <body class="article toc2 toc-left">
@@ -900,7 +962,7 @@ version of the compiler:</p>
 <div class="content">
 <pre class="pygments highlight"><code data-lang="sh">opam update
 opam switch 4.02.3+buckle-master
-eval `opam config env`
+<span class="tok-nb">eval</span> <span class="tok-sb">`</span>opam config env<span class="tok-sb">`</span>
 npm install bs-platform</code></pre>
 </div>
 </div>
@@ -927,7 +989,7 @@ npm install bs-platform</code></pre>
 <div class="title">Instructions:</div>
 <div class="content">
 <pre class="pygments highlight"><code data-lang="sh">git clone https://github.com/bloomberg/bucklescript
-cd bucklescript
+<span class="tok-nb">cd </span>bucklescript
 npm install</code></pre>
 </div>
 </div>
@@ -950,8 +1012,8 @@ easily be done.</p>
 <div class="title">Build OCaml compiler</div>
 <div class="content">
 <pre class="pygments highlight"><code data-lang="sh">git clone --recursive https://github.com/bloomberg/bucklescript
-cd bucklescript/ocaml
-./configure -prefix `pwd` # put your preferred directory
+<span class="tok-nb">cd </span>bucklescript/ocaml
+./configure -prefix <span class="tok-sb">`</span><span class="tok-nb">pwd</span><span class="tok-sb">`</span> <span class="tok-c"># put your preferred directory</span>
 make world.opt
 make install</code></pre>
 </div>
@@ -970,8 +1032,7 @@ the previous section.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="sh">cd ../jscomp
-make world</code></pre>
+<pre class="pygments highlight"><code data-lang="sh">make world</code></pre>
 </div>
 </div>
 <hr>
@@ -1008,7 +1069,7 @@ The built compiler is not <em>relocatable</em> out of box, please don&#8217;t mo
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="sh">npm install -g bs-platform &amp;&amp; bsb -init hello &amp;&amp; cd hello &amp;&amp; npm run build</code></pre>
+<pre class="pygments highlight"><code data-lang="sh">npm install -g bs-platform <span class="tok-o">&amp;&amp;</span> bsb -init hello <span class="tok-o">&amp;&amp;</span> <span class="tok-nb">cd </span>hello <span class="tok-o">&amp;&amp;</span> npm run build</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -1021,7 +1082,7 @@ The built compiler is not <em>relocatable</em> out of box, please don&#8217;t mo
 <div class="content">
 <pre class="pygments highlight"><code data-lang="sh">hello&gt;tree -d .
 .
-|---.vscode
+<span class="tok-p">|</span>---.vscode
 ├── lib
 │   ├── bs
 │   │   └── src
@@ -1054,24 +1115,24 @@ as below:</p>
 <div class="listingblock">
 <div class="title">bsconfig.json</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js">{
-    "name" : "hello",
-    "sources" : { "dir" : "src"}
-}</code></pre>
+<pre class="pygments highlight"><code data-lang="js"><span class="tok-p">{</span>
+    <span class="tok-s2">&quot;name&quot;</span> <span class="tok-o">:</span> <span class="tok-s2">&quot;hello&quot;</span><span class="tok-p">,</span>
+    <span class="tok-s2">&quot;sources&quot;</span> <span class="tok-o">:</span> <span class="tok-p">{</span> <span class="tok-s2">&quot;dir&quot;</span> <span class="tok-o">:</span> <span class="tok-s2">&quot;src&quot;</span><span class="tok-p">}</span>
+<span class="tok-p">}</span></code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="title">package.json</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js">{
-    "dependencies": {
-        "bs-platform": "1.7.0" <b class="conum">(1)</b>
-    },
-    "scripts" : {
-        "build" : "bsb",
-        "watch" : "bsb -w" <b class="conum">(2)</b>
-    }
-}</code></pre>
+<pre class="pygments highlight"><code data-lang="js"><span class="tok-p">{</span>
+    <span class="tok-s2">&quot;dependencies&quot;</span><span class="tok-o">:</span> <span class="tok-p">{</span>
+        <span class="tok-s2">&quot;bs-platform&quot;</span><span class="tok-o">:</span> <span class="tok-s2">&quot;1.7.0&quot;</span> <b class="conum">(1)</b>
+    <span class="tok-p">},</span>
+    <span class="tok-s2">&quot;scripts&quot;</span> <span class="tok-o">:</span> <span class="tok-p">{</span>
+        <span class="tok-s2">&quot;build&quot;</span> <span class="tok-o">:</span> <span class="tok-s2">&quot;bsb&quot;</span><span class="tok-p">,</span>
+        <span class="tok-s2">&quot;watch&quot;</span> <span class="tok-o">:</span> <span class="tok-s2">&quot;bsb -w&quot;</span> <b class="conum">(2)</b>
+    <span class="tok-p">}</span>
+<span class="tok-p">}</span></code></pre>
 </div>
 </div>
 <div class="colist arabic">
@@ -1090,8 +1151,8 @@ as below:</p>
 <div class="listingblock">
 <div class="title">src/main_entry.ml</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml">let () =
-  print_endline "hello world"</code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-bp">()</span> <span class="tok-o">=</span>
+  <span class="tok-n">print_endline</span> <span class="tok-s2">&quot;hello world&quot;</span></code></pre>
 </div>
 </div>
 </li>
@@ -1111,13 +1172,13 @@ as below:</p>
 <div class="listingblock">
 <div class="title">lib/js/src/main_entry.js</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js">// GENERATED CODE BY BUCKLESCRIPT VERSION 1.0.1 , PLEASE EDIT WITH CARE
-'use strict';
+<pre class="pygments highlight"><code data-lang="js"><span class="tok-c1">// GENERATED CODE BY BUCKLESCRIPT VERSION 1.0.1 , PLEASE EDIT WITH CARE</span>
+<span class="tok-s1">&#39;use strict&#39;</span><span class="tok-p">;</span>
 
 
-console.log("hello world");
+<span class="tok-nx">console</span><span class="tok-p">.</span><span class="tok-nx">log</span><span class="tok-p">(</span><span class="tok-s2">&quot;hello world&quot;</span><span class="tok-p">);</span>
 
-/*  Not a pure module */ <b class="conum">(1)</b></code></pre>
+<span class="tok-cm">/*  Not a pure module */</span> <b class="conum">(1)</b></code></pre>
 </div>
 </div>
 <div class="colist arabic">
@@ -1162,24 +1223,24 @@ will call <code>fib</code>.</p>
 <div class="listingblock">
 <div class="title">bsconfig.json</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js">{
-    "name" : "helo",
-    "sources" : { "dir" : "src"}
-}</code></pre>
+<pre class="pygments highlight"><code data-lang="js"><span class="tok-p">{</span>
+    <span class="tok-s2">&quot;name&quot;</span> <span class="tok-o">:</span> <span class="tok-s2">&quot;helo&quot;</span><span class="tok-p">,</span>
+    <span class="tok-s2">&quot;sources&quot;</span> <span class="tok-o">:</span> <span class="tok-p">{</span> <span class="tok-s2">&quot;dir&quot;</span> <span class="tok-o">:</span> <span class="tok-s2">&quot;src&quot;</span><span class="tok-p">}</span>
+<span class="tok-p">}</span></code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="title">package.json</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js">{
-    "dependencies": {
-        "bs-platform": "1.7.0"
-    },
-    "scripts" : {
-        "build" : "bsb",
-        "watch" : "bsb -w"
-    }
-}</code></pre>
+<pre class="pygments highlight"><code data-lang="js"><span class="tok-p">{</span>
+    <span class="tok-s2">&quot;dependencies&quot;</span><span class="tok-o">:</span> <span class="tok-p">{</span>
+        <span class="tok-s2">&quot;bs-platform&quot;</span><span class="tok-o">:</span> <span class="tok-s2">&quot;1.7.0&quot;</span>
+    <span class="tok-p">},</span>
+    <span class="tok-s2">&quot;scripts&quot;</span> <span class="tok-o">:</span> <span class="tok-p">{</span>
+        <span class="tok-s2">&quot;build&quot;</span> <span class="tok-o">:</span> <span class="tok-s2">&quot;bsb&quot;</span><span class="tok-p">,</span>
+        <span class="tok-s2">&quot;watch&quot;</span> <span class="tok-o">:</span> <span class="tok-s2">&quot;bsb -w&quot;</span>
+    <span class="tok-p">}</span>
+<span class="tok-p">}</span></code></pre>
 </div>
 </div>
 </li>
@@ -1188,21 +1249,21 @@ will call <code>fib</code>.</p>
 <div class="listingblock">
 <div class="title">src/fib.ml</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml">let fib n =
-  let rec aux n a b =
-    if n = 0 then a
-    else
-      aux (n - 1) b (a+b)
-  in aux n 1 1</code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">fib</span> <span class="tok-n">n</span> <span class="tok-o">=</span>
+  <span class="tok-k">let</span> <span class="tok-k">rec</span> <span class="tok-n">aux</span> <span class="tok-n">n</span> <span class="tok-n">a</span> <span class="tok-n">b</span> <span class="tok-o">=</span>
+    <span class="tok-k">if</span> <span class="tok-n">n</span> <span class="tok-o">=</span> <span class="tok-mi">0</span> <span class="tok-k">then</span> <span class="tok-n">a</span>
+    <span class="tok-k">else</span>
+      <span class="tok-n">aux</span> <span class="tok-o">(</span><span class="tok-n">n</span> <span class="tok-o">-</span> <span class="tok-mi">1</span><span class="tok-o">)</span> <span class="tok-n">b</span> <span class="tok-o">(</span><span class="tok-n">a</span><span class="tok-o">+</span><span class="tok-n">b</span><span class="tok-o">)</span>
+  <span class="tok-k">in</span> <span class="tok-n">aux</span> <span class="tok-n">n</span> <span class="tok-mi">1</span> <span class="tok-mi">1</span></code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="title">src/main_entry.ml</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml">let () =
-  for i = 0 to 10 do
-    Js.log (Fib.fib i) <b class="conum">(1)</b>
-  done</code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-bp">()</span> <span class="tok-o">=</span>
+  <span class="tok-k">for</span> <span class="tok-n">i</span> <span class="tok-o">=</span> <span class="tok-mi">0</span> <span class="tok-k">to</span> <span class="tok-mi">10</span> <span class="tok-k">do</span>
+    <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">log</span> <span class="tok-o">(</span><span class="tok-nn">Fib</span><span class="tok-p">.</span><span class="tok-n">fib</span> <span class="tok-n">i</span><span class="tok-o">)</span> <b class="conum">(1)</b>
+  <span class="tok-k">done</span></code></pre>
 </div>
 </div>
 <div class="colist arabic">
@@ -1285,7 +1346,7 @@ directories, we have a flag</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="sh">bsc.exe -bs-package-name $npm_package_name -bs-package-output modulesystem:path/to/your/js/dir -c a.ml</code></pre>
+<pre class="pygments highlight"><code data-lang="sh">bsc.exe -bs-package-name <span class="tok-nv">$npm_package_name</span> -bs-package-output modulesystem:path/to/your/js/dir -c a.ml</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -1322,7 +1383,7 @@ pretty straightforward:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="sh">bsc.exe -I path/to/ocaml/package1/installed -I path/to/ocaml/package2/installed  -bs-package-name $npm_package_name -bs-package-output commonjs:path/to/lib/js/ -c a.ml</code></pre>
+<pre class="pygments highlight"><code data-lang="sh">bsc.exe -I path/to/ocaml/package1/installed -I path/to/ocaml/package2/installed  -bs-package-name <span class="tok-nv">$npm_package_name</span> -bs-package-output commonjs:path/to/lib/js/ -c a.ml</code></pre>
 </div>
 </div>
 </div>
@@ -1374,9 +1435,9 @@ we recommend users to export it as functions.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml">  type t =
-    | Cons of int * t
-    | Nil</code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">  <span class="tok-k">type</span> <span class="tok-n">t</span> <span class="tok-o">=</span>
+    <span class="tok-o">|</span> <span class="tok-nc">Cons</span> <span class="tok-k">of</span> <span class="tok-kt">int</span> <span class="tok-o">*</span> <span class="tok-n">t</span>
+    <span class="tok-o">|</span> <span class="tok-nc">Nil</span></code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -1385,8 +1446,8 @@ so that it can be constructed from the JS side.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml">let cons x y = Cons (x,y)
-let nil = Nil</code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">cons</span> <span class="tok-n">x</span> <span class="tok-n">y</span> <span class="tok-o">=</span> <span class="tok-nc">Cons</span> <span class="tok-o">(</span><span class="tok-n">x</span><span class="tok-o">,</span><span class="tok-n">y</span><span class="tok-o">)</span>
+<span class="tok-k">let</span> <span class="tok-n">nil</span> <span class="tok-o">=</span> <span class="tok-nc">Nil</span></code></pre>
 </div>
 </div>
 <div class="admonitionblock note">
@@ -1436,7 +1497,7 @@ improve the generated code.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml">Js.log "你好"</code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">log</span> <span class="tok-s2">&quot;你好&quot;</span></code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -1444,7 +1505,7 @@ improve the generated code.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js">console.log("\xe4\xbd\xa0\xe5\xa5\xbd");</code></pre>
+<pre class="pygments highlight"><code data-lang="js"><span class="tok-nx">console</span><span class="tok-p">.</span><span class="tok-nx">log</span><span class="tok-p">(</span><span class="tok-s2">&quot;\xe4\xbd\xa0\xe5\xa5\xbd&quot;</span><span class="tok-p">);</span></code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -1452,14 +1513,14 @@ improve the generated code.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml">Js.log {js|你好，
-世界|js}</code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">log</span> <span class="tok-o">{</span><span class="tok-n">js</span><span class="tok-o">|</span><span class="tok-err">你好，</span>
+<span class="tok-err">世界</span><span class="tok-o">|</span><span class="tok-n">js</span><span class="tok-o">}</span></code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="title">Output</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js">console.log("你好，\n世界");</code></pre>
+<pre class="pygments highlight"><code data-lang="js"><span class="tok-nx">console</span><span class="tok-p">.</span><span class="tok-nx">log</span><span class="tok-p">(</span><span class="tok-s2">&quot;你好，\n世界&quot;</span><span class="tok-p">);</span></code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -1467,13 +1528,13 @@ improve the generated code.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml">Js.log {js|\x3f\u003f\b\t\n\v\f\r\0"'|js}</code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">log</span> <span class="tok-o">{</span><span class="tok-n">js</span><span class="tok-o">|</span><span class="tok-err">\</span><span class="tok-n">x3f</span><span class="tok-err">\</span><span class="tok-n">u003f</span><span class="tok-err">\</span><span class="tok-n">b</span><span class="tok-err">\</span><span class="tok-n">t</span><span class="tok-err">\</span><span class="tok-n">n</span><span class="tok-err">\</span><span class="tok-n">v</span><span class="tok-err">\</span><span class="tok-n">f</span><span class="tok-err">\</span><span class="tok-n">r</span><span class="tok-err">\</span><span class="tok-mi">0</span><span class="tok-s2">&quot;&#39;|js}</span></code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="title">Output</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js">console.log("\x3f\u003f\b\t\n\v\f\r\0\"\'");</code></pre>
+<pre class="pygments highlight"><code data-lang="js"><span class="tok-nx">console</span><span class="tok-p">.</span><span class="tok-nx">log</span><span class="tok-p">(</span><span class="tok-s2">&quot;\x3f\u003f\b\t\n\v\f\r\0\&quot;\&#39;&quot;</span><span class="tok-p">);</span></code></pre>
 </div>
 </div>
 <div class="sect3">
@@ -1486,8 +1547,8 @@ improve the generated code.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml">let world = {j|世界|j}
-let hello_world = {j|你好，$world|j}</code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">world</span> <span class="tok-o">=</span> <span class="tok-o">{</span><span class="tok-n">j</span><span class="tok-o">|</span><span class="tok-err">世界</span><span class="tok-o">|</span><span class="tok-n">j</span><span class="tok-o">}</span>
+<span class="tok-k">let</span> <span class="tok-n">hello_world</span> <span class="tok-o">=</span> <span class="tok-o">{</span><span class="tok-n">j</span><span class="tok-o">|</span><span class="tok-err">你好，</span><span class="tok-o">$</span><span class="tok-n">world</span><span class="tok-o">|</span><span class="tok-n">j</span><span class="tok-o">}</span></code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -1495,7 +1556,7 @@ let hello_world = {j|你好，$world|j}</code></pre>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml">let hello_world = {j|你好，$(world)|j}</code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">hello_world</span> <span class="tok-o">=</span> <span class="tok-o">{</span><span class="tok-n">j</span><span class="tok-o">|</span><span class="tok-err">你好，</span><span class="tok-o">$(</span><span class="tok-n">world</span><span class="tok-o">)|</span><span class="tok-n">j</span><span class="tok-o">}</span></code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -1505,8 +1566,8 @@ Its lexical convention is as below:</p>
 <div class="listingblock">
 <div class="content">
 <pre class="pygments highlight"><code data-lang="bnf">identifier := leading_identifier_char identifier_chars
-leading_identifier_char := 'a' .. 'z' | '_'
-identifier_chars := 'a' .. 'z' | 'A' .. 'Z' | '0' .. '9' | '_' | '\'</code></pre>
+leading_identifier_char := &#39;a&#39; .. &#39;z&#39; | &#39;_&#39;
+identifier_chars := &#39;a&#39; .. &#39;z&#39; | &#39;A&#39; .. &#39;Z&#39; | &#39;0&#39; .. &#39;9&#39; | &#39;_&#39; | &#39;\&#39;</code></pre>
 </div>
 </div>
 </div>
@@ -1552,8 +1613,8 @@ with syntax as described below:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml">external value-name : typexpr = external-declaration attributes
-external-declaration := string-literal</code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">external</span> <span class="tok-k">value</span><span class="tok-o">-</span><span class="tok-n">name</span> <span class="tok-o">:</span> <span class="tok-n">typexpr</span> <span class="tok-o">=</span> <span class="tok-k">external</span><span class="tok-o">-</span><span class="tok-n">declaration</span> <span class="tok-n">attributes</span>
+<span class="tok-k">external</span><span class="tok-o">-</span><span class="tok-n">declaration</span> <span class="tok-o">:=</span> <span class="tok-kt">string</span><span class="tok-o">-</span><span class="tok-n">literal</span></code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -1565,10 +1626,10 @@ and provide customized <code>attributes</code>.</p>
 <h4 id="_binding_to_global_value_bs_val"><a class="anchor" href="#_binding_to_global_value_bs_val"></a>Binding to global value: bs.val</h4>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml">external imul : int -&gt; int -&gt; int = "Math.imul" [@@bs.val]
-type dom
-(* Abstract type for the DOM *)
-external dom : dom = "document" [@@bs.val]</code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">external</span> <span class="tok-n">imul</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;Math.imul&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">val</span><span class="tok-o">]</span>
+<span class="tok-k">type</span> <span class="tok-n">dom</span>
+<span class="tok-c">(* Abstract type for the DOM *)</span>
+<span class="tok-k">external</span> <span class="tok-n">dom</span> <span class="tok-o">:</span> <span class="tok-n">dom</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;document&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">val</span><span class="tok-o">]</span></code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -1589,7 +1650,7 @@ it can be a function or plain value.</p>
 For example:</p>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml">external document : dom = "" [@@bs.val]</code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">external</span> <span class="tok-n">document</span> <span class="tok-o">:</span> <span class="tok-n">dom</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">val</span><span class="tok-o">]</span></code></pre>
 </div>
 </div>
 </li>
@@ -1599,8 +1660,8 @@ JavaScript functions, you can
 give the JavaScript foreign function a different name:</p>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml">external imul : int -&gt; int -&gt; int =
-  "c_imul" [@@bs.val "Math.imul"]</code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">external</span> <span class="tok-n">imul</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">=</span>
+  <span class="tok-s2">&quot;c_imul&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">val</span> <span class="tok-s2">&quot;Math.imul&quot;</span><span class="tok-o">]</span></code></pre>
 </div>
 </div>
 </li>
@@ -1622,22 +1683,22 @@ the user needs needs to type <code>commands</code> properly before typing <code>
 <div class="listingblock">
 <div class="title">Example</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml">type param
-external executeCommands : string -&gt; param array -&gt; unit = ""
-[@@bs.scope "commands"] [@@bs.module "vscode"][@@bs.splice]
+<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">type</span> <span class="tok-n">param</span>
+<span class="tok-k">external</span> <span class="tok-n">executeCommands</span> <span class="tok-o">:</span> <span class="tok-kt">string</span> <span class="tok-o">-&gt;</span> <span class="tok-n">param</span> <span class="tok-kt">array</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">unit</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;&quot;</span>
+<span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">scope</span> <span class="tok-s2">&quot;commands&quot;</span><span class="tok-o">]</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">module</span> <span class="tok-s2">&quot;vscode&quot;</span><span class="tok-o">][@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">splice</span><span class="tok-o">]</span>
 
-let f a b c  =
-  executeCommands "hi"  [|a;b;c|]</code></pre>
+<span class="tok-k">let</span> <span class="tok-n">f</span> <span class="tok-n">a</span> <span class="tok-n">b</span> <span class="tok-n">c</span>  <span class="tok-o">=</span>
+  <span class="tok-n">executeCommands</span> <span class="tok-s2">&quot;hi&quot;</span>  <span class="tok-o">[|</span><span class="tok-n">a</span><span class="tok-o">;</span><span class="tok-n">b</span><span class="tok-o">;</span><span class="tok-n">c</span><span class="tok-o">|]</span></code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="title">Output</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js">var Vscode = require("vscode");
-function f(a, b, c) {
-  Vscode.commands.executeCommands("hi", a, b, c);
-  return process.env;
-}</code></pre>
+<pre class="pygments highlight"><code data-lang="js"><span class="tok-kd">var</span> <span class="tok-nx">Vscode</span> <span class="tok-o">=</span> <span class="tok-nx">require</span><span class="tok-p">(</span><span class="tok-s2">&quot;vscode&quot;</span><span class="tok-p">);</span>
+<span class="tok-kd">function</span> <span class="tok-nx">f</span><span class="tok-p">(</span><span class="tok-nx">a</span><span class="tok-p">,</span> <span class="tok-nx">b</span><span class="tok-p">,</span> <span class="tok-nx">c</span><span class="tok-p">)</span> <span class="tok-p">{</span>
+  <span class="tok-nx">Vscode</span><span class="tok-p">.</span><span class="tok-nx">commands</span><span class="tok-p">.</span><span class="tok-nx">executeCommands</span><span class="tok-p">(</span><span class="tok-s2">&quot;hi&quot;</span><span class="tok-p">,</span> <span class="tok-nx">a</span><span class="tok-p">,</span> <span class="tok-nx">b</span><span class="tok-p">,</span> <span class="tok-nx">c</span><span class="tok-p">);</span>
+  <span class="tok-k">return</span> <span class="tok-nx">process</span><span class="tok-p">.</span><span class="tok-nx">env</span><span class="tok-p">;</span>
+<span class="tok-p">}</span></code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -1646,30 +1707,30 @@ function f(a, b, c) {
 <div class="listingblock">
 <div class="title">Exmaple</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml">external makeBuffer : int -&gt; buffer = "Buffer"
-[@@bs.new] [@@bs.scope "global"]
-external hi : string = ""
-[@@bs.module "z"] [@@bs.scope "a0", "a1", "a2"]
-external ho : string = ""
-[@@bs.val] [@@bs.scope "a0","a1","a2"]
-external imul : int -&gt; int -&gt; int = ""
-[@@bs.val] [@@bs.scope "Math"]
-let f2 ()  =
-  makeBuffer 20 , hi , ho, imul 1 2</code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">external</span> <span class="tok-n">makeBuffer</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-n">buffer</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;Buffer&quot;</span>
+<span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">new</span><span class="tok-o">]</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">scope</span> <span class="tok-s2">&quot;global&quot;</span><span class="tok-o">]</span>
+<span class="tok-k">external</span> <span class="tok-n">hi</span> <span class="tok-o">:</span> <span class="tok-kt">string</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;&quot;</span>
+<span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">module</span> <span class="tok-s2">&quot;z&quot;</span><span class="tok-o">]</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">scope</span> <span class="tok-s2">&quot;a0&quot;</span><span class="tok-o">,</span> <span class="tok-s2">&quot;a1&quot;</span><span class="tok-o">,</span> <span class="tok-s2">&quot;a2&quot;</span><span class="tok-o">]</span>
+<span class="tok-k">external</span> <span class="tok-n">ho</span> <span class="tok-o">:</span> <span class="tok-kt">string</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;&quot;</span>
+<span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">val</span><span class="tok-o">]</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">scope</span> <span class="tok-s2">&quot;a0&quot;</span><span class="tok-o">,</span><span class="tok-s2">&quot;a1&quot;</span><span class="tok-o">,</span><span class="tok-s2">&quot;a2&quot;</span><span class="tok-o">]</span>
+<span class="tok-k">external</span> <span class="tok-n">imul</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;&quot;</span>
+<span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">val</span><span class="tok-o">]</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">scope</span> <span class="tok-s2">&quot;Math&quot;</span><span class="tok-o">]</span>
+<span class="tok-k">let</span> <span class="tok-n">f2</span> <span class="tok-bp">()</span>  <span class="tok-o">=</span>
+  <span class="tok-n">makeBuffer</span> <span class="tok-mi">20</span> <span class="tok-o">,</span> <span class="tok-n">hi</span> <span class="tok-o">,</span> <span class="tok-n">ho</span><span class="tok-o">,</span> <span class="tok-n">imul</span> <span class="tok-mi">1</span> <span class="tok-mi">2</span></code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="title">Output</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js">var Z      = require("z");
-function f2() {
-  return /* tuple */[
-          new (global.Buffer)(20),
-          Z.a0.a1.a2.hi,
-          a0.a1.a2.ho,
-          Math.imul(1, 2)
-        ];
-}</code></pre>
+<pre class="pygments highlight"><code data-lang="js"><span class="tok-kd">var</span> <span class="tok-nx">Z</span>      <span class="tok-o">=</span> <span class="tok-nx">require</span><span class="tok-p">(</span><span class="tok-s2">&quot;z&quot;</span><span class="tok-p">);</span>
+<span class="tok-kd">function</span> <span class="tok-nx">f2</span><span class="tok-p">()</span> <span class="tok-p">{</span>
+  <span class="tok-k">return</span> <span class="tok-cm">/* tuple */</span><span class="tok-p">[</span>
+          <span class="tok-k">new</span> <span class="tok-p">(</span><span class="tok-nx">global</span><span class="tok-p">.</span><span class="tok-nx">Buffer</span><span class="tok-p">)(</span><span class="tok-mi">20</span><span class="tok-p">),</span>
+          <span class="tok-nx">Z</span><span class="tok-p">.</span><span class="tok-nx">a0</span><span class="tok-p">.</span><span class="tok-nx">a1</span><span class="tok-p">.</span><span class="tok-nx">a2</span><span class="tok-p">.</span><span class="tok-nx">hi</span><span class="tok-p">,</span>
+          <span class="tok-nx">a0</span><span class="tok-p">.</span><span class="tok-nx">a1</span><span class="tok-p">.</span><span class="tok-nx">a2</span><span class="tok-p">.</span><span class="tok-nx">ho</span><span class="tok-p">,</span>
+          <span class="tok-nb">Math</span><span class="tok-p">.</span><span class="tok-nx">imul</span><span class="tok-p">(</span><span class="tok-mi">1</span><span class="tok-p">,</span> <span class="tok-mi">2</span><span class="tok-p">)</span>
+        <span class="tok-p">];</span>
+<span class="tok-p">}</span></code></pre>
 </div>
 </div>
 </div>
@@ -1680,14 +1741,14 @@ function f2() {
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml">external create_date : unit -&gt; t = "Date" [@@bs.new]
-let date = create_date ()</code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">external</span> <span class="tok-n">create_date</span> <span class="tok-o">:</span> <span class="tok-kt">unit</span> <span class="tok-o">-&gt;</span> <span class="tok-n">t</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;Date&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">new</span><span class="tok-o">]</span>
+<span class="tok-k">let</span> <span class="tok-n">date</span> <span class="tok-o">=</span> <span class="tok-n">create_date</span> <span class="tok-bp">()</span></code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="title">Output:</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js">var date = new Date();</code></pre>
+<pre class="pygments highlight"><code data-lang="js"><span class="tok-kd">var</span> <span class="tok-nx">date</span> <span class="tok-o">=</span> <span class="tok-k">new</span> <span class="tok-nb">Date</span><span class="tok-p">();</span></code></pre>
 </div>
 </div>
 </div>
@@ -1696,10 +1757,10 @@ let date = create_date ()</code></pre>
 <div class="listingblock">
 <div class="title">Input:</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml">external add : int -&gt; int -&gt; int = "add" [@@bs.module "x"]
-external add2 : int -&gt; int -&gt; int = "add2"[@@bs.module "y", "U"] <b class="conum">(1)</b>
-let f = add 3 4
-let g = add2 3 4</code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">external</span> <span class="tok-n">add</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;add&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">module</span> <span class="tok-s2">&quot;x&quot;</span><span class="tok-o">]</span>
+<span class="tok-k">external</span> <span class="tok-n">add2</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;add2&quot;</span><span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">module</span> <span class="tok-s2">&quot;y&quot;</span><span class="tok-o">,</span> <span class="tok-s2">&quot;U&quot;</span><span class="tok-o">]</span> <b class="conum">(1)</b>
+<span class="tok-k">let</span> <span class="tok-n">f</span> <span class="tok-o">=</span> <span class="tok-n">add</span> <span class="tok-mi">3</span> <span class="tok-mi">4</span>
+<span class="tok-k">let</span> <span class="tok-n">g</span> <span class="tok-o">=</span> <span class="tok-n">add2</span> <span class="tok-mi">3</span> <span class="tok-mi">4</span></code></pre>
 </div>
 </div>
 <div class="colist arabic">
@@ -1712,10 +1773,10 @@ let g = add2 3 4</code></pre>
 <div class="listingblock">
 <div class="title">Output:</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js">var U = require("y");
-var X = require("x");
-var f = X.add(3, 4);
-var g = U.add2(3, 4);</code></pre>
+<pre class="pygments highlight"><code data-lang="js"><span class="tok-kd">var</span> <span class="tok-nx">U</span> <span class="tok-o">=</span> <span class="tok-nx">require</span><span class="tok-p">(</span><span class="tok-s2">&quot;y&quot;</span><span class="tok-p">);</span>
+<span class="tok-kd">var</span> <span class="tok-nx">X</span> <span class="tok-o">=</span> <span class="tok-nx">require</span><span class="tok-p">(</span><span class="tok-s2">&quot;x&quot;</span><span class="tok-p">);</span>
+<span class="tok-kd">var</span> <span class="tok-nx">f</span> <span class="tok-o">=</span> <span class="tok-nx">X</span><span class="tok-p">.</span><span class="tok-nx">add</span><span class="tok-p">(</span><span class="tok-mi">3</span><span class="tok-p">,</span> <span class="tok-mi">4</span><span class="tok-p">);</span>
+<span class="tok-kd">var</span> <span class="tok-nx">g</span> <span class="tok-o">=</span> <span class="tok-nx">U</span><span class="tok-p">.</span><span class="tok-nx">add2</span><span class="tok-p">(</span><span class="tok-mi">3</span><span class="tok-p">,</span> <span class="tok-mi">4</span><span class="tok-p">);</span></code></pre>
 </div>
 </div>
 <div class="admonitionblock note">
@@ -1731,7 +1792,7 @@ var g = U.add2(3, 4);</code></pre>
 <p>if <code>external-declaration</code> is the same as value-name, it can be left empty, for example,</p>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml">external add : int -&gt; int -&gt; int = "" [@@bs.module "x"]</code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">external</span> <span class="tok-n">add</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">module</span> <span class="tok-s2">&quot;x&quot;</span><span class="tok-o">]</span></code></pre>
 </div>
 </div>
 </li>
@@ -1746,8 +1807,8 @@ var g = U.add2(3, 4);</code></pre>
 <h4 id="_binding_the_whole_module_as_a_value_or_function"><a class="anchor" href="#_binding_the_whole_module_as_a_value_or_function"></a>Binding the whole module as a value or function</h4>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml">type http
-external http : http = "http" [@@bs.module] <b class="conum">(1)</b></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">type</span> <span class="tok-n">http</span>
+<span class="tok-k">external</span> <span class="tok-n">http</span> <span class="tok-o">:</span> <span class="tok-n">http</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;http&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">module</span><span class="tok-o">]</span> <b class="conum">(1)</b></code></pre>
 </div>
 </div>
 <div class="colist arabic">
@@ -1770,7 +1831,7 @@ external http : http = "http" [@@bs.module] <b class="conum">(1)</b></code></pre
 <p>if <code>external-declaration</code> is the same as value-name, it can be left empty, for example:</p>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml">external http : http = "" [@@bs.module]</code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">external</span> <span class="tok-n">http</span> <span class="tok-o">:</span> <span class="tok-n">http</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">module</span><span class="tok-o">]</span></code></pre>
 </div>
 </div>
 </li>
@@ -1788,9 +1849,9 @@ external http : http = "http" [@@bs.module] <b class="conum">(1)</b></code></pre
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml">type id (** Abstract type for id object *)
-external get_by_id : dom -&gt; string -&gt; id =
-  "getElementById" [@@bs.send]</code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">type</span> <span class="tok-n">id</span> <span class="tok-c">(** Abstract type for id object *)</span>
+<span class="tok-k">external</span> <span class="tok-n">get_by_id</span> <span class="tok-o">:</span> <span class="tok-n">dom</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">string</span> <span class="tok-o">-&gt;</span> <span class="tok-n">id</span> <span class="tok-o">=</span>
+  <span class="tok-s2">&quot;getElementById&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">send</span><span class="tok-o">]</span></code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -1799,13 +1860,13 @@ external get_by_id : dom -&gt; string -&gt; id =
 <div class="listingblock">
 <div class="title">Input:</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml">get_by_id dom "xx"</code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-n">get_by_id</span> <span class="tok-n">dom</span> <span class="tok-s2">&quot;xx&quot;</span></code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="title">Output:</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js">dom.getElementById("xx")</code></pre>
+<pre class="pygments highlight"><code data-lang="js"><span class="tok-nx">dom</span><span class="tok-p">.</span><span class="tok-nx">getElementById</span><span class="tok-p">(</span><span class="tok-s2">&quot;xx&quot;</span><span class="tok-p">)</span></code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -1814,14 +1875,14 @@ is put in the position of last argument to help user write in a <em>chaining sty
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml">external map : ('a -&gt; 'b [@bs]) -&gt; 'b array =
-  "" [@@bs.send.pipe: 'a array] <b class="conum">(1)</b>
-external forEach: ('a -&gt; unit [@bs]) -&gt; 'a array =
-  "" [@@bs.send.pipe: 'a array]
-let test arr =
-    arr
-    |&gt; map (fun [@bs] x -&gt; x + 1)
-    |&gt; forEach (fun [@bs] x -&gt; Js.log x)</code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">external</span> <span class="tok-n">map</span> <span class="tok-o">:</span> <span class="tok-o">(</span><span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">b</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">])</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">b</span> <span class="tok-kt">array</span> <span class="tok-o">=</span>
+  <span class="tok-s2">&quot;&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">send</span><span class="tok-o">.</span><span class="tok-n">pipe</span><span class="tok-o">:</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-kt">array</span><span class="tok-o">]</span> <b class="conum">(1)</b>
+<span class="tok-k">external</span> <span class="tok-n">forEach</span><span class="tok-o">:</span> <span class="tok-o">(</span><span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">unit</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">])</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-kt">array</span> <span class="tok-o">=</span>
+  <span class="tok-s2">&quot;&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">send</span><span class="tok-o">.</span><span class="tok-n">pipe</span><span class="tok-o">:</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-kt">array</span><span class="tok-o">]</span>
+<span class="tok-k">let</span> <span class="tok-n">test</span> <span class="tok-n">arr</span> <span class="tok-o">=</span>
+    <span class="tok-n">arr</span>
+    <span class="tok-o">|&gt;</span> <span class="tok-n">map</span> <span class="tok-o">(</span><span class="tok-k">fun</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">]</span> <span class="tok-n">x</span> <span class="tok-o">-&gt;</span> <span class="tok-n">x</span> <span class="tok-o">+</span> <span class="tok-mi">1</span><span class="tok-o">)</span>
+    <span class="tok-o">|&gt;</span> <span class="tok-n">forEach</span> <span class="tok-o">(</span><span class="tok-k">fun</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">]</span> <span class="tok-n">x</span> <span class="tok-o">-&gt;</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">log</span> <span class="tok-n">x</span><span class="tok-o">)</span></code></pre>
 </div>
 </div>
 <div class="colist arabic">
@@ -1844,8 +1905,8 @@ let test arr =
 <p>if <code>external-declaration</code> is the same as value-name, it can be left empty, for example:</p>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml">external getElementById : dom -&gt; string -&gt; id =
-  "" [@@bs.send]</code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">external</span> <span class="tok-n">getElementById</span> <span class="tok-o">:</span> <span class="tok-n">dom</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">string</span> <span class="tok-o">-&gt;</span> <span class="tok-n">id</span> <span class="tok-o">=</span>
+  <span class="tok-s2">&quot;&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">send</span><span class="tok-o">]</span></code></pre>
 </div>
 </div>
 </li>
@@ -1863,10 +1924,10 @@ let test arr =
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml">type t
-external create : int -&gt; t = "Int32Array" [@@bs.new]
-external get : t -&gt; int -&gt; int = "" [@@bs.get_index]
-external set : t -&gt; int -&gt; int -&gt; unit = "" [@@bs.set_index]</code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">type</span> <span class="tok-n">t</span>
+<span class="tok-k">external</span> <span class="tok-n">create</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-n">t</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;Int32Array&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">new</span><span class="tok-o">]</span>
+<span class="tok-k">external</span> <span class="tok-n">get</span> <span class="tok-o">:</span> <span class="tok-n">t</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">get_index</span><span class="tok-o">]</span>
+<span class="tok-k">external</span> <span class="tok-n">set</span> <span class="tok-o">:</span> <span class="tok-n">t</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">unit</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">set_index</span><span class="tok-o">]</span></code></pre>
 </div>
 </div>
 </div>
@@ -1877,9 +1938,9 @@ external set : t -&gt; int -&gt; int -&gt; unit = "" [@@bs.set_index]</code></pr
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml">type textarea
-external set_name : textarea -&gt; string -&gt; unit = "name" [@@bs.set]
-external get_name : textarea -&gt; string = "name" [@@bs.get]</code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">type</span> <span class="tok-n">textarea</span>
+<span class="tok-k">external</span> <span class="tok-n">set_name</span> <span class="tok-o">:</span> <span class="tok-n">textarea</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">string</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">unit</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;name&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">set</span><span class="tok-o">]</span>
+<span class="tok-k">external</span> <span class="tok-n">get_name</span> <span class="tok-o">:</span> <span class="tok-n">textarea</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">string</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;name&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">get</span><span class="tok-o">]</span></code></pre>
 </div>
 </div>
 </div>
@@ -1892,15 +1953,15 @@ BuckleScript supports typing homogeneous variadic arguments. For example,</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml">external join : string array -&gt; string = "" [@@bs.module "path"] [@@bs.splice]
-let v = join [| "a"; "b"|]</code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">external</span> <span class="tok-n">join</span> <span class="tok-o">:</span> <span class="tok-kt">string</span> <span class="tok-kt">array</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">string</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">module</span> <span class="tok-s2">&quot;path&quot;</span><span class="tok-o">]</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">splice</span><span class="tok-o">]</span>
+<span class="tok-k">let</span> <span class="tok-n">v</span> <span class="tok-o">=</span> <span class="tok-n">join</span> <span class="tok-o">[|</span> <span class="tok-s2">&quot;a&quot;</span><span class="tok-o">;</span> <span class="tok-s2">&quot;b&quot;</span><span class="tok-o">|]</span></code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="title">Output</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js">var Path = require("path")
-var v = Path.join("a","b")</code></pre>
+<pre class="pygments highlight"><code data-lang="js"><span class="tok-kd">var</span> <span class="tok-nx">Path</span> <span class="tok-o">=</span> <span class="tok-nx">require</span><span class="tok-p">(</span><span class="tok-s2">&quot;path&quot;</span><span class="tok-p">)</span>
+<span class="tok-kd">var</span> <span class="tok-nx">v</span> <span class="tok-o">=</span> <span class="tok-nx">Path</span><span class="tok-p">.</span><span class="tok-nx">join</span><span class="tok-p">(</span><span class="tok-s2">&quot;a&quot;</span><span class="tok-p">,</span><span class="tok-s2">&quot;b&quot;</span><span class="tok-p">)</span></code></pre>
 </div>
 </div>
 <div class="admonitionblock note">
@@ -1930,16 +1991,16 @@ way by using annotated polymorphic variant.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml">external readFileSync :
-  name:string -&gt;
-  ([ `utf8
-   | `my_name [@bs.as "ascii"] <b class="conum">(1)</b>
-   ] [@bs.string]) -&gt;
-  string = ""
-  [@@bs.module "fs"]
+<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">external</span> <span class="tok-n">readFileSync</span> <span class="tok-o">:</span>
+  <span class="tok-n">name</span><span class="tok-o">:</span><span class="tok-kt">string</span> <span class="tok-o">-&gt;</span>
+  <span class="tok-o">([</span> <span class="tok-o">`</span><span class="tok-n">utf8</span>
+   <span class="tok-o">|</span> <span class="tok-o">`</span><span class="tok-n">my_name</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">as</span> <span class="tok-s2">&quot;ascii&quot;</span><span class="tok-o">]</span> <b class="conum">(1)</b>
+   <span class="tok-o">]</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-kt">string</span><span class="tok-o">])</span> <span class="tok-o">-&gt;</span>
+  <span class="tok-kt">string</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;&quot;</span>
+  <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">module</span> <span class="tok-s2">&quot;fs&quot;</span><span class="tok-o">]</span>
 
-let _ =
-  readFileSync ~name:"xx.txt" `my_name</code></pre>
+<span class="tok-k">let</span> <span class="tok-o">_</span> <span class="tok-o">=</span>
+  <span class="tok-n">readFileSync</span> <span class="tok-o">~</span><span class="tok-n">name</span><span class="tok-o">:</span><span class="tok-s2">&quot;xx.txt&quot;</span> <span class="tok-o">`</span><span class="tok-n">my_name</span></code></pre>
 </div>
 </div>
 <div class="colist arabic">
@@ -1954,8 +2015,8 @@ let _ =
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js">var Fs = require("fs");
-Fs.readFileSync("xx.txt", "ascii");</code></pre>
+<pre class="pygments highlight"><code data-lang="js"><span class="tok-kd">var</span> <span class="tok-nx">Fs</span> <span class="tok-o">=</span> <span class="tok-nx">require</span><span class="tok-p">(</span><span class="tok-s2">&quot;fs&quot;</span><span class="tok-p">);</span>
+<span class="tok-nx">Fs</span><span class="tok-p">.</span><span class="tok-nx">readFileSync</span><span class="tok-p">(</span><span class="tok-s2">&quot;xx.txt&quot;</span><span class="tok-p">,</span> <span class="tok-s2">&quot;ascii&quot;</span><span class="tok-p">);</span></code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -1963,13 +2024,13 @@ Fs.readFileSync("xx.txt", "ascii");</code></pre>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml">external test_int_type :
-  ([ `on_closed <b class="conum">(1)</b>
-   | `on_open [@bs.as 3] <b class="conum">(2)</b>
-   | `in_bin <b class="conum">(3)</b>
-   ]
-   [@bs.int]) -&gt; int =
-  "" [@@bs.val]</code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">external</span> <span class="tok-n">test_int_type</span> <span class="tok-o">:</span>
+  <span class="tok-o">([</span> <span class="tok-o">`</span><span class="tok-n">on_closed</span> <b class="conum">(1)</b>
+   <span class="tok-o">|</span> <span class="tok-o">`</span><span class="tok-n">on_open</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">as</span> <span class="tok-mi">3</span><span class="tok-o">]</span> <b class="conum">(2)</b>
+   <span class="tok-o">|</span> <span class="tok-o">`</span><span class="tok-n">in_bin</span> <b class="conum">(3)</b>
+   <span class="tok-o">]</span>
+   <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-kt">int</span><span class="tok-o">])</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">=</span>
+  <span class="tok-s2">&quot;&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">val</span><span class="tok-o">]</span></code></pre>
 </div>
 </div>
 <div class="colist arabic">
@@ -1993,18 +2054,18 @@ Fs.readFileSync("xx.txt", "ascii");</code></pre>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml">type readline
-external on :
-    (
-    [ `close of unit -&gt; unit
-    | `line of string -&gt; unit
-    ] <b class="conum">(1)</b>
-    [@bs.string])
-    -&gt; readline = "" [@@bs.send.pipe: readline]
-let register rl =
-  rl
-  |&gt; on (`close (fun event -&gt; () ))
-  |&gt; on (`line (fun line -&gt; print_endline line))</code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">type</span> <span class="tok-n">readline</span>
+<span class="tok-k">external</span> <span class="tok-n">on</span> <span class="tok-o">:</span>
+    <span class="tok-o">(</span>
+    <span class="tok-o">[</span> <span class="tok-o">`</span><span class="tok-n">close</span> <span class="tok-k">of</span> <span class="tok-kt">unit</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">unit</span>
+    <span class="tok-o">|</span> <span class="tok-o">`</span><span class="tok-n">line</span> <span class="tok-k">of</span> <span class="tok-kt">string</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">unit</span>
+    <span class="tok-o">]</span> <b class="conum">(1)</b>
+    <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-kt">string</span><span class="tok-o">])</span>
+    <span class="tok-o">-&gt;</span> <span class="tok-n">readline</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">send</span><span class="tok-o">.</span><span class="tok-n">pipe</span><span class="tok-o">:</span> <span class="tok-n">readline</span><span class="tok-o">]</span>
+<span class="tok-k">let</span> <span class="tok-n">register</span> <span class="tok-n">rl</span> <span class="tok-o">=</span>
+  <span class="tok-n">rl</span>
+  <span class="tok-o">|&gt;</span> <span class="tok-n">on</span> <span class="tok-o">(`</span><span class="tok-n">close</span> <span class="tok-o">(</span><span class="tok-k">fun</span> <span class="tok-n">event</span> <span class="tok-o">-&gt;</span> <span class="tok-bp">()</span> <span class="tok-o">))</span>
+  <span class="tok-o">|&gt;</span> <span class="tok-n">on</span> <span class="tok-o">(`</span><span class="tok-n">line</span> <span class="tok-o">(</span><span class="tok-k">fun</span> <span class="tok-n">line</span> <span class="tok-o">-&gt;</span> <span class="tok-n">print_endline</span> <span class="tok-n">line</span><span class="tok-o">))</span></code></pre>
 </div>
 </div>
 <div class="colist arabic">
@@ -2017,15 +2078,15 @@ let register rl =
 <div class="listingblock">
 <div class="title">Output:</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js">function register(rl) {
-  return rl.on("close", function () {
-                return /* () */0;
-              })
-           .on("line", function (line) {
-              console.log(line);
-              return /* () */0;
-            });
-}</code></pre>
+<pre class="pygments highlight"><code data-lang="js"><span class="tok-kd">function</span> <span class="tok-nx">register</span><span class="tok-p">(</span><span class="tok-nx">rl</span><span class="tok-p">)</span> <span class="tok-p">{</span>
+  <span class="tok-k">return</span> <span class="tok-nx">rl</span><span class="tok-p">.</span><span class="tok-nx">on</span><span class="tok-p">(</span><span class="tok-s2">&quot;close&quot;</span><span class="tok-p">,</span> <span class="tok-kd">function</span> <span class="tok-p">()</span> <span class="tok-p">{</span>
+                <span class="tok-k">return</span> <span class="tok-cm">/* () */</span><span class="tok-mi">0</span><span class="tok-p">;</span>
+              <span class="tok-p">})</span>
+           <span class="tok-p">.</span><span class="tok-nx">on</span><span class="tok-p">(</span><span class="tok-s2">&quot;line&quot;</span><span class="tok-p">,</span> <span class="tok-kd">function</span> <span class="tok-p">(</span><span class="tok-nx">line</span><span class="tok-p">)</span> <span class="tok-p">{</span>
+              <span class="tok-nx">console</span><span class="tok-p">.</span><span class="tok-nx">log</span><span class="tok-p">(</span><span class="tok-nx">line</span><span class="tok-p">);</span>
+              <span class="tok-k">return</span> <span class="tok-cm">/* () */</span><span class="tok-mi">0</span><span class="tok-p">;</span>
+            <span class="tok-p">});</span>
+<span class="tok-p">}</span></code></pre>
 </div>
 </div>
 <div class="admonitionblock warning">
@@ -2067,9 +2128,9 @@ still be recorded.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml">external add : (int [@bs.ignore]) -&gt; int -&gt; int = ""
-[@@bs.val]
-let v = add 0 1 2 <b class="conum">(1)</b></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">external</span> <span class="tok-n">add</span> <span class="tok-o">:</span> <span class="tok-o">(</span><span class="tok-kt">int</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">ignore</span><span class="tok-o">])</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;&quot;</span>
+<span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">val</span><span class="tok-o">]</span>
+<span class="tok-k">let</span> <span class="tok-n">v</span> <span class="tok-o">=</span> <span class="tok-n">add</span> <span class="tok-mi">0</span> <span class="tok-mi">1</span> <span class="tok-mi">2</span> <b class="conum">(1)</b></code></pre>
 </div>
 </div>
 <div class="colist arabic">
@@ -2082,7 +2143,7 @@ let v = add 0 1 2 <b class="conum">(1)</b></code></pre>
 <div class="listingblock">
 <div class="title">Output:</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="javascript">var v = add (1,2)</code></pre>
+<pre class="pygments highlight"><code data-lang="javascript"><span class="tok-kd">var</span> <span class="tok-nx">v</span> <span class="tok-o">=</span> <span class="tok-nx">add</span> <span class="tok-p">(</span><span class="tok-mi">1</span><span class="tok-p">,</span><span class="tok-mi">2</span><span class="tok-p">)</span></code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -2090,14 +2151,14 @@ let v = add 0 1 2 <b class="conum">(1)</b></code></pre>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml">type _ kind =
-  | Float : float kind
-  | String : string kind
-external add : ('a kind [@bs.ignore]) -&gt; 'a -&gt; 'a -&gt; 'a = "" [@@bs.val]
+<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">type</span> <span class="tok-o">_</span> <span class="tok-n">kind</span> <span class="tok-o">=</span>
+  <span class="tok-o">|</span> <span class="tok-nc">Float</span> <span class="tok-o">:</span> <span class="tok-kt">float</span> <span class="tok-n">kind</span>
+  <span class="tok-o">|</span> <span class="tok-nc">String</span> <span class="tok-o">:</span> <span class="tok-kt">string</span> <span class="tok-n">kind</span>
+<span class="tok-k">external</span> <span class="tok-n">add</span> <span class="tok-o">:</span> <span class="tok-o">(</span><span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-n">kind</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">ignore</span><span class="tok-o">])</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">val</span><span class="tok-o">]</span>
 
-let () =
-  Js.log (add Float 3.0 2.0);
-  Js.log (add String "x" "y");</code></pre>
+<span class="tok-k">let</span> <span class="tok-bp">()</span> <span class="tok-o">=</span>
+  <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">log</span> <span class="tok-o">(</span><span class="tok-n">add</span> <span class="tok-nc">Float</span> <span class="tok-mi">3</span><span class="tok-o">.</span><span class="tok-mi">0</span> <span class="tok-mi">2</span><span class="tok-o">.</span><span class="tok-mi">0</span><span class="tok-o">);</span>
+  <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">log</span> <span class="tok-o">(</span><span class="tok-n">add</span> <span class="tok-nc">String</span> <span class="tok-s2">&quot;x&quot;</span> <span class="tok-s2">&quot;y&quot;</span><span class="tok-o">);</span></code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -2105,16 +2166,16 @@ let () =
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml">let string_of_kind (type t) (kind : t kind) =
-  match kind with
-  | Float -&gt; "float"
-  | String -&gt; "string"
+<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">string_of_kind</span> <span class="tok-o">(</span><span class="tok-k">type</span> <span class="tok-n">t</span><span class="tok-o">)</span> <span class="tok-o">(</span><span class="tok-n">kind</span> <span class="tok-o">:</span> <span class="tok-n">t</span> <span class="tok-n">kind</span><span class="tok-o">)</span> <span class="tok-o">=</span>
+  <span class="tok-k">match</span> <span class="tok-n">kind</span> <span class="tok-k">with</span>
+  <span class="tok-o">|</span> <span class="tok-nc">Float</span> <span class="tok-o">-&gt;</span> <span class="tok-s2">&quot;float&quot;</span>
+  <span class="tok-o">|</span> <span class="tok-nc">String</span> <span class="tok-o">-&gt;</span> <span class="tok-s2">&quot;string&quot;</span>
 
-external add_dyn : ('a kind [@bs.ignore]) -&gt; string -&gt; 'a -&gt; 'a -&gt; 'a = ""
-[@@bs.val]
+<span class="tok-k">external</span> <span class="tok-n">add_dyn</span> <span class="tok-o">:</span> <span class="tok-o">(</span><span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-n">kind</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">ignore</span><span class="tok-o">])</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">string</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;&quot;</span>
+<span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">val</span><span class="tok-o">]</span>
 
-let add2 k x y =
-  add_dyn k (string_of_kind k) x y</code></pre>
+<span class="tok-k">let</span> <span class="tok-n">add2</span> <span class="tok-n">k</span> <span class="tok-n">x</span> <span class="tok-n">y</span> <span class="tok-o">=</span>
+  <span class="tok-n">add_dyn</span> <span class="tok-n">k</span> <span class="tok-o">(</span><span class="tok-n">string_of_kind</span> <span class="tok-n">k</span><span class="tok-o">)</span> <span class="tok-n">x</span> <span class="tok-n">y</span></code></pre>
 </div>
 </div>
 </div>
@@ -2130,21 +2191,21 @@ data.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml">external process_on_exit : (_ [@bs.as "exit"]) -&gt; (int -&gt; unit) -&gt; unit =
-  "process.on" [@@bs.val]
+<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">external</span> <span class="tok-n">process_on_exit</span> <span class="tok-o">:</span> <span class="tok-o">(_</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">as</span> <span class="tok-s2">&quot;exit&quot;</span><span class="tok-o">])</span> <span class="tok-o">-&gt;</span> <span class="tok-o">(</span><span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">unit</span><span class="tok-o">)</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">unit</span> <span class="tok-o">=</span>
+  <span class="tok-s2">&quot;process.on&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">val</span><span class="tok-o">]</span>
 
-let () =
-    process_on_exit (fun exit_code -&gt;
-        Js.log( "error code: " ^ string_of_int exit_code ))</code></pre>
+<span class="tok-k">let</span> <span class="tok-bp">()</span> <span class="tok-o">=</span>
+    <span class="tok-n">process_on_exit</span> <span class="tok-o">(</span><span class="tok-k">fun</span> <span class="tok-n">exit_code</span> <span class="tok-o">-&gt;</span>
+        <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">log</span><span class="tok-o">(</span> <span class="tok-s2">&quot;error code: &quot;</span> <span class="tok-o">^</span> <span class="tok-n">string_of_int</span> <span class="tok-n">exit_code</span> <span class="tok-o">))</span></code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="title">Output</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js">process.on("exit", function (exit_code) {
-      console.log("error code: " + exit_code);
-      return /* () */0;
-    });</code></pre>
+<pre class="pygments highlight"><code data-lang="js"><span class="tok-nx">process</span><span class="tok-p">.</span><span class="tok-nx">on</span><span class="tok-p">(</span><span class="tok-s2">&quot;exit&quot;</span><span class="tok-p">,</span> <span class="tok-kd">function</span> <span class="tok-p">(</span><span class="tok-nx">exit_code</span><span class="tok-p">)</span> <span class="tok-p">{</span>
+      <span class="tok-nx">console</span><span class="tok-p">.</span><span class="tok-nx">log</span><span class="tok-p">(</span><span class="tok-s2">&quot;error code: &quot;</span> <span class="tok-o">+</span> <span class="tok-nx">exit_code</span><span class="tok-p">);</span>
+      <span class="tok-k">return</span> <span class="tok-cm">/* () */</span><span class="tok-mi">0</span><span class="tok-p">;</span>
+    <span class="tok-p">});</span></code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -2152,41 +2213,41 @@ let () =
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml">type process
+<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">type</span> <span class="tok-n">process</span>
 
-external on_exit : (_ [@bs.as "exit"]) -&gt; (int -&gt; unit) -&gt; unit =
-    "on" [@@bs.send.pipe: process]
-let register (p : process) =
-        p |&gt; on_exit (fun i -&gt; Js.log i)</code></pre>
+<span class="tok-k">external</span> <span class="tok-n">on_exit</span> <span class="tok-o">:</span> <span class="tok-o">(_</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">as</span> <span class="tok-s2">&quot;exit&quot;</span><span class="tok-o">])</span> <span class="tok-o">-&gt;</span> <span class="tok-o">(</span><span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">unit</span><span class="tok-o">)</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">unit</span> <span class="tok-o">=</span>
+    <span class="tok-s2">&quot;on&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">send</span><span class="tok-o">.</span><span class="tok-n">pipe</span><span class="tok-o">:</span> <span class="tok-n">process</span><span class="tok-o">]</span>
+<span class="tok-k">let</span> <span class="tok-n">register</span> <span class="tok-o">(</span><span class="tok-n">p</span> <span class="tok-o">:</span> <span class="tok-n">process</span><span class="tok-o">)</span> <span class="tok-o">=</span>
+        <span class="tok-n">p</span> <span class="tok-o">|&gt;</span> <span class="tok-n">on_exit</span> <span class="tok-o">(</span><span class="tok-k">fun</span> <span class="tok-n">i</span> <span class="tok-o">-&gt;</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">log</span> <span class="tok-n">i</span><span class="tok-o">)</span></code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="title">Output</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js">function register(p) {
-  return p.on("exit", function (i) {
-              console.log(i);
-              return /* () */0;
-            });
-}</code></pre>
+<pre class="pygments highlight"><code data-lang="js"><span class="tok-kd">function</span> <span class="tok-nx">register</span><span class="tok-p">(</span><span class="tok-nx">p</span><span class="tok-p">)</span> <span class="tok-p">{</span>
+  <span class="tok-k">return</span> <span class="tok-nx">p</span><span class="tok-p">.</span><span class="tok-nx">on</span><span class="tok-p">(</span><span class="tok-s2">&quot;exit&quot;</span><span class="tok-p">,</span> <span class="tok-kd">function</span> <span class="tok-p">(</span><span class="tok-nx">i</span><span class="tok-p">)</span> <span class="tok-p">{</span>
+              <span class="tok-nx">console</span><span class="tok-p">.</span><span class="tok-nx">log</span><span class="tok-p">(</span><span class="tok-nx">i</span><span class="tok-p">);</span>
+              <span class="tok-k">return</span> <span class="tok-cm">/* () */</span><span class="tok-mi">0</span><span class="tok-p">;</span>
+            <span class="tok-p">});</span>
+<span class="tok-p">}</span></code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="title">Input</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml">external io_config :
-    stdio:(_ [@bs.as "inherit"]) -&gt; cwd:string -&gt; unit -&gt; _ = "" [@@bs.obj]
+<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">external</span> <span class="tok-n">io_config</span> <span class="tok-o">:</span>
+    <span class="tok-n">stdio</span><span class="tok-o">:(_</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">as</span> <span class="tok-s2">&quot;inherit&quot;</span><span class="tok-o">])</span> <span class="tok-o">-&gt;</span> <span class="tok-n">cwd</span><span class="tok-o">:</span><span class="tok-kt">string</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">unit</span> <span class="tok-o">-&gt;</span> <span class="tok-o">_</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">obj</span><span class="tok-o">]</span>
 
-let config = io_config ~cwd:"." ()</code></pre>
+<span class="tok-k">let</span> <span class="tok-n">config</span> <span class="tok-o">=</span> <span class="tok-n">io_config</span> <span class="tok-o">~</span><span class="tok-n">cwd</span><span class="tok-o">:</span><span class="tok-s2">&quot;.&quot;</span> <span class="tok-bp">()</span></code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="title">Output</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js">var config = {
-  stdio: "inherit",
-  cwd: "."
-};</code></pre>
+<pre class="pygments highlight"><code data-lang="js"><span class="tok-kd">var</span> <span class="tok-nx">config</span> <span class="tok-o">=</span> <span class="tok-p">{</span>
+  <span class="tok-nx">stdio</span><span class="tok-o">:</span> <span class="tok-s2">&quot;inherit&quot;</span><span class="tok-p">,</span>
+  <span class="tok-nx">cwd</span><span class="tok-o">:</span> <span class="tok-s2">&quot;.&quot;</span>
+<span class="tok-p">};</span></code></pre>
 </div>
 </div>
 </div>
@@ -2197,31 +2258,31 @@ let config = io_config ~cwd:"." ()</code></pre>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml">external on_exit_slice5 :
-    int
-    -&gt; (_ [@bs.as 3])
-    -&gt; (_ [@bs.as {json|true|json}])
-    -&gt; (_ [@bs.as {json|false|json}])
-    -&gt; (_ [@bs.as {json|"你好"|json}])
-    -&gt; (_ [@bs.as {json| ["你好",1,2,3] |json}])
-    -&gt; (_ [@bs.as {json| [{ "arr" : ["你好",1,2,3], "encoding" : "utf8"}] |json}])
-    -&gt; (_ [@bs.as {json| [{ "arr" : ["你好",1,2,3], "encoding" : "utf8"}] |json}])
-    -&gt; (_ [@bs.as "xxx"])
-    -&gt; ([`a|`b|`c] [@bs.int])
-    -&gt; (_ [@bs.as "yyy"])
-    -&gt; ([`a|`b|`c] [@bs.string])
-    -&gt; int array
-    -&gt; unit
-    =
-    "xx" [@@bs.send.pipe: t] [@@bs.splice]
+<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">external</span> <span class="tok-n">on_exit_slice5</span> <span class="tok-o">:</span>
+    <span class="tok-kt">int</span>
+    <span class="tok-o">-&gt;</span> <span class="tok-o">(_</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">as</span> <span class="tok-mi">3</span><span class="tok-o">])</span>
+    <span class="tok-o">-&gt;</span> <span class="tok-o">(_</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">as</span> <span class="tok-o">{</span><span class="tok-n">json</span><span class="tok-o">|</span><span class="tok-bp">true</span><span class="tok-o">|</span><span class="tok-n">json</span><span class="tok-o">}])</span>
+    <span class="tok-o">-&gt;</span> <span class="tok-o">(_</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">as</span> <span class="tok-o">{</span><span class="tok-n">json</span><span class="tok-o">|</span><span class="tok-bp">false</span><span class="tok-o">|</span><span class="tok-n">json</span><span class="tok-o">}])</span>
+    <span class="tok-o">-&gt;</span> <span class="tok-o">(_</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">as</span> <span class="tok-o">{</span><span class="tok-n">json</span><span class="tok-o">|</span><span class="tok-s2">&quot;你好&quot;</span><span class="tok-o">|</span><span class="tok-n">json</span><span class="tok-o">}])</span>
+    <span class="tok-o">-&gt;</span> <span class="tok-o">(_</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">as</span> <span class="tok-o">{</span><span class="tok-n">json</span><span class="tok-o">|</span> <span class="tok-o">[</span><span class="tok-s2">&quot;你好&quot;</span><span class="tok-o">,</span><span class="tok-mi">1</span><span class="tok-o">,</span><span class="tok-mi">2</span><span class="tok-o">,</span><span class="tok-mi">3</span><span class="tok-o">]</span> <span class="tok-o">|</span><span class="tok-n">json</span><span class="tok-o">}])</span>
+    <span class="tok-o">-&gt;</span> <span class="tok-o">(_</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">as</span> <span class="tok-o">{</span><span class="tok-n">json</span><span class="tok-o">|</span> <span class="tok-o">[{</span> <span class="tok-s2">&quot;arr&quot;</span> <span class="tok-o">:</span> <span class="tok-o">[</span><span class="tok-s2">&quot;你好&quot;</span><span class="tok-o">,</span><span class="tok-mi">1</span><span class="tok-o">,</span><span class="tok-mi">2</span><span class="tok-o">,</span><span class="tok-mi">3</span><span class="tok-o">],</span> <span class="tok-s2">&quot;encoding&quot;</span> <span class="tok-o">:</span> <span class="tok-s2">&quot;utf8&quot;</span><span class="tok-o">}]</span> <span class="tok-o">|</span><span class="tok-n">json</span><span class="tok-o">}])</span>
+    <span class="tok-o">-&gt;</span> <span class="tok-o">(_</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">as</span> <span class="tok-o">{</span><span class="tok-n">json</span><span class="tok-o">|</span> <span class="tok-o">[{</span> <span class="tok-s2">&quot;arr&quot;</span> <span class="tok-o">:</span> <span class="tok-o">[</span><span class="tok-s2">&quot;你好&quot;</span><span class="tok-o">,</span><span class="tok-mi">1</span><span class="tok-o">,</span><span class="tok-mi">2</span><span class="tok-o">,</span><span class="tok-mi">3</span><span class="tok-o">],</span> <span class="tok-s2">&quot;encoding&quot;</span> <span class="tok-o">:</span> <span class="tok-s2">&quot;utf8&quot;</span><span class="tok-o">}]</span> <span class="tok-o">|</span><span class="tok-n">json</span><span class="tok-o">}])</span>
+    <span class="tok-o">-&gt;</span> <span class="tok-o">(_</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">as</span> <span class="tok-s2">&quot;xxx&quot;</span><span class="tok-o">])</span>
+    <span class="tok-o">-&gt;</span> <span class="tok-o">([`</span><span class="tok-n">a</span><span class="tok-o">|`</span><span class="tok-n">b</span><span class="tok-o">|`</span><span class="tok-n">c</span><span class="tok-o">]</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-kt">int</span><span class="tok-o">])</span>
+    <span class="tok-o">-&gt;</span> <span class="tok-o">(_</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">as</span> <span class="tok-s2">&quot;yyy&quot;</span><span class="tok-o">])</span>
+    <span class="tok-o">-&gt;</span> <span class="tok-o">([`</span><span class="tok-n">a</span><span class="tok-o">|`</span><span class="tok-n">b</span><span class="tok-o">|`</span><span class="tok-n">c</span><span class="tok-o">]</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-kt">string</span><span class="tok-o">])</span>
+    <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-kt">array</span>
+    <span class="tok-o">-&gt;</span> <span class="tok-kt">unit</span>
+    <span class="tok-o">=</span>
+    <span class="tok-s2">&quot;xx&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">send</span><span class="tok-o">.</span><span class="tok-n">pipe</span><span class="tok-o">:</span> <span class="tok-n">t</span><span class="tok-o">]</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">splice</span><span class="tok-o">]</span>
 
-let _ = x |&gt; on_exit_slice5 __LINE__ `a `b [|1;2;3;4;5|]</code></pre>
+<span class="tok-k">let</span> <span class="tok-o">_</span> <span class="tok-o">=</span> <span class="tok-n">x</span> <span class="tok-o">|&gt;</span> <span class="tok-n">on_exit_slice5</span> <span class="tok-o">__</span><span class="tok-n">LINE__</span> <span class="tok-o">`</span><span class="tok-n">a</span> <span class="tok-o">`</span><span class="tok-n">b</span> <span class="tok-o">[|</span><span class="tok-mi">1</span><span class="tok-o">;</span><span class="tok-mi">2</span><span class="tok-o">;</span><span class="tok-mi">3</span><span class="tok-o">;</span><span class="tok-mi">4</span><span class="tok-o">;</span><span class="tok-mi">5</span><span class="tok-o">|]</span></code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="title">Output</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js">x.xx(114, 3, true, false, ("你好"), ( ["你好",1,2,3] ), ( [{ "arr" : ["你好",1,2,3], "encoding" : "utf8"}] ), ( [{ "arr" : ["你好",1,2,3], "encoding" : "utf8"}] ), "xxx", 0, "yyy", "b", 1, 2, 3, 4, 5)</code></pre>
+<pre class="pygments highlight"><code data-lang="js"><span class="tok-nx">x</span><span class="tok-p">.</span><span class="tok-nx">xx</span><span class="tok-p">(</span><span class="tok-mi">114</span><span class="tok-p">,</span> <span class="tok-mi">3</span><span class="tok-p">,</span> <span class="tok-kc">true</span><span class="tok-p">,</span> <span class="tok-kc">false</span><span class="tok-p">,</span> <span class="tok-p">(</span><span class="tok-s2">&quot;你好&quot;</span><span class="tok-p">),</span> <span class="tok-p">(</span> <span class="tok-p">[</span><span class="tok-s2">&quot;你好&quot;</span><span class="tok-p">,</span><span class="tok-mi">1</span><span class="tok-p">,</span><span class="tok-mi">2</span><span class="tok-p">,</span><span class="tok-mi">3</span><span class="tok-p">]</span> <span class="tok-p">),</span> <span class="tok-p">(</span> <span class="tok-p">[{</span> <span class="tok-s2">&quot;arr&quot;</span> <span class="tok-o">:</span> <span class="tok-p">[</span><span class="tok-s2">&quot;你好&quot;</span><span class="tok-p">,</span><span class="tok-mi">1</span><span class="tok-p">,</span><span class="tok-mi">2</span><span class="tok-p">,</span><span class="tok-mi">3</span><span class="tok-p">],</span> <span class="tok-s2">&quot;encoding&quot;</span> <span class="tok-o">:</span> <span class="tok-s2">&quot;utf8&quot;</span><span class="tok-p">}]</span> <span class="tok-p">),</span> <span class="tok-p">(</span> <span class="tok-p">[{</span> <span class="tok-s2">&quot;arr&quot;</span> <span class="tok-o">:</span> <span class="tok-p">[</span><span class="tok-s2">&quot;你好&quot;</span><span class="tok-p">,</span><span class="tok-mi">1</span><span class="tok-p">,</span><span class="tok-mi">2</span><span class="tok-p">,</span><span class="tok-mi">3</span><span class="tok-p">],</span> <span class="tok-s2">&quot;encoding&quot;</span> <span class="tok-o">:</span> <span class="tok-s2">&quot;utf8&quot;</span><span class="tok-p">}]</span> <span class="tok-p">),</span> <span class="tok-s2">&quot;xxx&quot;</span><span class="tok-p">,</span> <span class="tok-mi">0</span><span class="tok-p">,</span> <span class="tok-s2">&quot;yyy&quot;</span><span class="tok-p">,</span> <span class="tok-s2">&quot;b&quot;</span><span class="tok-p">,</span> <span class="tok-mi">1</span><span class="tok-p">,</span> <span class="tok-mi">2</span><span class="tok-p">,</span> <span class="tok-mi">3</span><span class="tok-p">,</span> <span class="tok-mi">4</span><span class="tok-p">,</span> <span class="tok-mi">5</span><span class="tok-p">)</span></code></pre>
 </div>
 </div>
 </div>
@@ -2236,10 +2297,10 @@ Their semantics are more like macros instead of functions.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml">let dirname : string option = [%bs.node __dirname]
-let filename : string option = [%bs.node __filename]
-let _module : Node.node_module option = [%bs.node _module]
-let require : Node.node_require option = [%bs.node require]</code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">dirname</span> <span class="tok-o">:</span> <span class="tok-kt">string</span> <span class="tok-n">option</span> <span class="tok-o">=</span> <span class="tok-o">[%</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">node</span> <span class="tok-o">__</span><span class="tok-n">dirname</span><span class="tok-o">]</span>
+<span class="tok-k">let</span> <span class="tok-n">filename</span> <span class="tok-o">:</span> <span class="tok-kt">string</span> <span class="tok-n">option</span> <span class="tok-o">=</span> <span class="tok-o">[%</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">node</span> <span class="tok-o">__</span><span class="tok-n">filename</span><span class="tok-o">]</span>
+<span class="tok-k">let</span> <span class="tok-o">_</span><span class="tok-n">module</span> <span class="tok-o">:</span> <span class="tok-nn">Node</span><span class="tok-p">.</span><span class="tok-n">node_module</span> <span class="tok-n">option</span> <span class="tok-o">=</span> <span class="tok-o">[%</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">node</span> <span class="tok-o">_</span><span class="tok-n">module</span><span class="tok-o">]</span>
+<span class="tok-k">let</span> <span class="tok-n">require</span> <span class="tok-o">:</span> <span class="tok-nn">Node</span><span class="tok-p">.</span><span class="tok-n">node_require</span> <span class="tok-n">option</span> <span class="tok-o">=</span> <span class="tok-o">[%</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">node</span> <span class="tok-n">require</span><span class="tok-o">]</span></code></pre>
 </div>
 </div>
 </div>
@@ -2252,14 +2313,14 @@ JS has a map function as below:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js">function map (a, b, f){
-  var i = Math.min(a.length, b.length);
-  var c = new Array(i);
-  for(var j = 0; j &lt; i; ++j){
-    c[j] = f(a[i],b[i])
-  }
-  return c ;
-}</code></pre>
+<pre class="pygments highlight"><code data-lang="js"><span class="tok-kd">function</span> <span class="tok-nx">map</span> <span class="tok-p">(</span><span class="tok-nx">a</span><span class="tok-p">,</span> <span class="tok-nx">b</span><span class="tok-p">,</span> <span class="tok-nx">f</span><span class="tok-p">){</span>
+  <span class="tok-kd">var</span> <span class="tok-nx">i</span> <span class="tok-o">=</span> <span class="tok-nb">Math</span><span class="tok-p">.</span><span class="tok-nx">min</span><span class="tok-p">(</span><span class="tok-nx">a</span><span class="tok-p">.</span><span class="tok-nx">length</span><span class="tok-p">,</span> <span class="tok-nx">b</span><span class="tok-p">.</span><span class="tok-nx">length</span><span class="tok-p">);</span>
+  <span class="tok-kd">var</span> <span class="tok-nx">c</span> <span class="tok-o">=</span> <span class="tok-k">new</span> <span class="tok-nb">Array</span><span class="tok-p">(</span><span class="tok-nx">i</span><span class="tok-p">);</span>
+  <span class="tok-k">for</span><span class="tok-p">(</span><span class="tok-kd">var</span> <span class="tok-nx">j</span> <span class="tok-o">=</span> <span class="tok-mi">0</span><span class="tok-p">;</span> <span class="tok-nx">j</span> <span class="tok-o">&lt;</span> <span class="tok-nx">i</span><span class="tok-p">;</span> <span class="tok-o">++</span><span class="tok-nx">j</span><span class="tok-p">){</span>
+    <span class="tok-nx">c</span><span class="tok-p">[</span><span class="tok-nx">j</span><span class="tok-p">]</span> <span class="tok-o">=</span> <span class="tok-nx">f</span><span class="tok-p">(</span><span class="tok-nx">a</span><span class="tok-p">[</span><span class="tok-nx">i</span><span class="tok-p">],</span><span class="tok-nx">b</span><span class="tok-p">[</span><span class="tok-nx">i</span><span class="tok-p">])</span>
+  <span class="tok-p">}</span>
+  <span class="tok-k">return</span> <span class="tok-nx">c</span> <span class="tok-p">;</span>
+<span class="tok-p">}</span></code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -2267,7 +2328,7 @@ JS has a map function as below:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml">external map : 'a array -&gt; 'b array -&gt; ('a -&gt; 'b -&gt; 'c) -&gt; 'c array = "" [@@bs.val]</code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">external</span> <span class="tok-n">map</span> <span class="tok-o">:</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-kt">array</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">b</span> <span class="tok-kt">array</span> <span class="tok-o">-&gt;</span> <span class="tok-o">(</span><span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">b</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">c</span><span class="tok-o">)</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">c</span> <span class="tok-kt">array</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">val</span><span class="tok-o">]</span></code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -2276,12 +2337,12 @@ reading the type <code>'a &#8594; 'b &#8594; 'c</code>, it can be in several cas
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml">let f x y = x + y</code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">f</span> <span class="tok-n">x</span> <span class="tok-n">y</span> <span class="tok-o">=</span> <span class="tok-n">x</span> <span class="tok-o">+</span> <span class="tok-n">y</span></code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml">let g x = let z = x + 1 in fun y -&gt; x + z</code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">g</span> <span class="tok-n">x</span> <span class="tok-o">=</span> <span class="tok-k">let</span> <span class="tok-n">z</span> <span class="tok-o">=</span> <span class="tok-n">x</span> <span class="tok-o">+</span> <span class="tok-mi">1</span> <span class="tok-k">in</span> <span class="tok-k">fun</span> <span class="tok-n">y</span> <span class="tok-o">-&gt;</span> <span class="tok-n">x</span> <span class="tok-o">+</span> <span class="tok-n">z</span></code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -2294,22 +2355,22 @@ different arities.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml">let f = fun x -&gt; fun y -&gt; x + y</code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">f</span> <span class="tok-o">=</span> <span class="tok-k">fun</span> <span class="tok-n">x</span> <span class="tok-o">-&gt;</span> <span class="tok-k">fun</span> <span class="tok-n">y</span> <span class="tok-o">-&gt;</span> <span class="tok-n">x</span> <span class="tok-o">+</span> <span class="tok-n">y</span></code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js">function f(x){
-  return function (y){
-    return x + y;
-  }
-}
-function g(x){
-  var z = x + 1 ;
-  return function (y){
-    return x + z ;
-  }
-}</code></pre>
+<pre class="pygments highlight"><code data-lang="js"><span class="tok-kd">function</span> <span class="tok-nx">f</span><span class="tok-p">(</span><span class="tok-nx">x</span><span class="tok-p">){</span>
+  <span class="tok-k">return</span> <span class="tok-kd">function</span> <span class="tok-p">(</span><span class="tok-nx">y</span><span class="tok-p">){</span>
+    <span class="tok-k">return</span> <span class="tok-nx">x</span> <span class="tok-o">+</span> <span class="tok-nx">y</span><span class="tok-p">;</span>
+  <span class="tok-p">}</span>
+<span class="tok-p">}</span>
+<span class="tok-kd">function</span> <span class="tok-nx">g</span><span class="tok-p">(</span><span class="tok-nx">x</span><span class="tok-p">){</span>
+  <span class="tok-kd">var</span> <span class="tok-nx">z</span> <span class="tok-o">=</span> <span class="tok-nx">x</span> <span class="tok-o">+</span> <span class="tok-mi">1</span> <span class="tok-p">;</span>
+  <span class="tok-k">return</span> <span class="tok-kd">function</span> <span class="tok-p">(</span><span class="tok-nx">y</span><span class="tok-p">){</span>
+    <span class="tok-k">return</span> <span class="tok-nx">x</span> <span class="tok-o">+</span> <span class="tok-nx">z</span> <span class="tok-p">;</span>
+  <span class="tok-p">}</span>
+<span class="tok-p">}</span></code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -2321,9 +2382,9 @@ however, we expect <em>its arity to be 2</em>.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js">function f(x,y){
-  return x + y ;
-}</code></pre>
+<pre class="pygments highlight"><code data-lang="js"><span class="tok-kd">function</span> <span class="tok-nx">f</span><span class="tok-p">(</span><span class="tok-nx">x</span><span class="tok-p">,</span><span class="tok-nx">y</span><span class="tok-p">){</span>
+  <span class="tok-k">return</span> <span class="tok-nx">x</span> <span class="tok-o">+</span> <span class="tok-nx">y</span> <span class="tok-p">;</span>
+<span class="tok-p">}</span></code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -2338,8 +2399,8 @@ we support a special attribute <code>[@bs]</code> at the type level.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml">external map : 'a array -&gt; 'b array -&gt; ('a -&gt; 'b -&gt; 'c [@bs]) -&gt; 'c array
-= "map" [@@bs.val]</code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">external</span> <span class="tok-n">map</span> <span class="tok-o">:</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-kt">array</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">b</span> <span class="tok-kt">array</span> <span class="tok-o">-&gt;</span> <span class="tok-o">(</span><span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">b</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">c</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">])</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">c</span> <span class="tok-kt">array</span>
+<span class="tok-o">=</span> <span class="tok-s2">&quot;map&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">val</span><span class="tok-o">]</span></code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -2355,9 +2416,9 @@ unknown.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml">let f : 'a0 -&gt; 'a1 -&gt; .. 'b0 [@bs] =
-  fun [@bs] a0 a1 .. aN -&gt; b0
-let b : 'b0 = f a0 a1 a2 .. aN [@bs]</code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">f</span> <span class="tok-o">:</span> <span class="tok-k">&#39;</span><span class="tok-n">a0</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">a1</span> <span class="tok-o">-&gt;</span> <span class="tok-o">..</span> <span class="tok-k">&#39;</span><span class="tok-n">b0</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">]</span> <span class="tok-o">=</span>
+  <span class="tok-k">fun</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">]</span> <span class="tok-n">a0</span> <span class="tok-n">a1</span> <span class="tok-o">..</span> <span class="tok-n">aN</span> <span class="tok-o">-&gt;</span> <span class="tok-n">b0</span>
+<span class="tok-k">let</span> <span class="tok-n">b</span> <span class="tok-o">:</span> <span class="tok-k">&#39;</span><span class="tok-n">b0</span> <span class="tok-o">=</span> <span class="tok-n">f</span> <span class="tok-n">a0</span> <span class="tok-n">a1</span> <span class="tok-n">a2</span> <span class="tok-o">..</span> <span class="tok-n">aN</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">]</span></code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -2365,8 +2426,8 @@ let b : 'b0 = f a0 a1 a2 .. aN [@bs]</code></pre>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml">let f : unit -&gt; 'b0 [@bs] = fun [@bs] () -&gt; b0
-let b : 'b0 = f () [@bs]</code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">f</span> <span class="tok-o">:</span> <span class="tok-kt">unit</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">b0</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">]</span> <span class="tok-o">=</span> <span class="tok-k">fun</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">]</span> <span class="tok-bp">()</span> <span class="tok-o">-&gt;</span> <span class="tok-n">b0</span>
+<span class="tok-k">let</span> <span class="tok-n">b</span> <span class="tok-o">:</span> <span class="tok-k">&#39;</span><span class="tok-n">b0</span> <span class="tok-o">=</span> <span class="tok-n">f</span> <span class="tok-bp">()</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">]</span></code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -2380,10 +2441,10 @@ will complain.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml">type 'a return = int -&gt; 'a [@bs]
-type 'a u0 = int -&gt; string -&gt; 'a return [@bs] <b class="conum">(1)</b>
-type 'a u1 = int -&gt; string -&gt; int -&gt; 'a [@bs] <b class="conum">(2)</b>
-type 'a u2 = int -&gt; string -&gt; (int -&gt; 'a [@bs]) [@bs] <b class="conum">(3)</b></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">type</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-n">return</span> <span class="tok-o">=</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">]</span>
+<span class="tok-k">type</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-n">u0</span> <span class="tok-o">=</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">string</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-n">return</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">]</span> <b class="conum">(1)</b>
+<span class="tok-k">type</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-n">u1</span> <span class="tok-o">=</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">string</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">]</span> <b class="conum">(2)</b>
+<span class="tok-k">type</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-n">u2</span> <span class="tok-o">=</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">string</span> <span class="tok-o">-&gt;</span> <span class="tok-o">(</span><span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">])</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">]</span> <b class="conum">(3)</b></code></pre>
 </div>
 </div>
 <div class="colist arabic">
@@ -2412,8 +2473,8 @@ that it requires users to write <code>[@bs]</code> both in definition site and c
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml">external map : 'a array -&gt; ('a -&gt; 'b[@bs]) -&gt; 'b array = "" [@@bs.send] <b class="conum">(1)</b>
-map [|1;2;3|] (fun [@bs] x -&gt; x + 1) <b class="conum">(2)</b></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">external</span> <span class="tok-n">map</span> <span class="tok-o">:</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-kt">array</span> <span class="tok-o">-&gt;</span> <span class="tok-o">(</span><span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">b</span><span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">])</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">b</span> <span class="tok-kt">array</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">send</span><span class="tok-o">]</span> <b class="conum">(1)</b>
+<span class="tok-n">map</span> <span class="tok-o">[|</span><span class="tok-mi">1</span><span class="tok-o">;</span><span class="tok-mi">2</span><span class="tok-o">;</span><span class="tok-mi">3</span><span class="tok-o">|]</span> <span class="tok-o">(</span><span class="tok-k">fun</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">]</span> <span class="tok-n">x</span> <span class="tok-o">-&gt;</span> <span class="tok-n">x</span> <span class="tok-o">+</span> <span class="tok-mi">1</span><span class="tok-o">)</span> <b class="conum">(2)</b></code></pre>
 </div>
 </div>
 <div class="colist arabic">
@@ -2432,8 +2493,8 @@ only once.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml">external map : 'a array -&gt; ('a -&gt; 'b [@bs.uncurry]) -&gt; 'b array = "" [@@bs.send] <b class="conum">(1)</b>
-map [|1;2;3|] (fun x -&gt; x+ 1) <b class="conum">(2)</b></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">external</span> <span class="tok-n">map</span> <span class="tok-o">:</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-kt">array</span> <span class="tok-o">-&gt;</span> <span class="tok-o">(</span><span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">b</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">uncurry</span><span class="tok-o">])</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">b</span> <span class="tok-kt">array</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">send</span><span class="tok-o">]</span> <b class="conum">(1)</b>
+<span class="tok-n">map</span> <span class="tok-o">[|</span><span class="tok-mi">1</span><span class="tok-o">;</span><span class="tok-mi">2</span><span class="tok-o">;</span><span class="tok-mi">3</span><span class="tok-o">|]</span> <span class="tok-o">(</span><span class="tok-k">fun</span> <span class="tok-n">x</span> <span class="tok-o">-&gt;</span> <span class="tok-n">x</span><span class="tok-o">+</span> <span class="tok-mi">1</span><span class="tok-o">)</span> <b class="conum">(2)</b></code></pre>
 </div>
 </div>
 <div class="colist arabic">
@@ -2478,9 +2539,9 @@ the native compilation is very slow and expensive for all functions.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml">let f x y z = x + y + z
-let a = f 1 2 3
-let b = f 1 2</code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">f</span> <span class="tok-n">x</span> <span class="tok-n">y</span> <span class="tok-n">z</span> <span class="tok-o">=</span> <span class="tok-n">x</span> <span class="tok-o">+</span> <span class="tok-n">y</span> <span class="tok-o">+</span> <span class="tok-n">z</span>
+<span class="tok-k">let</span> <span class="tok-n">a</span> <span class="tok-o">=</span> <span class="tok-n">f</span> <span class="tok-mi">1</span> <span class="tok-mi">2</span> <span class="tok-mi">3</span>
+<span class="tok-k">let</span> <span class="tok-n">b</span> <span class="tok-o">=</span> <span class="tok-n">f</span> <span class="tok-mi">1</span> <span class="tok-mi">2</span></code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -2488,15 +2549,15 @@ let b = f 1 2</code></pre>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js">function f(x){
-  return function (y){
-    return function (z){
-      return x + y + z
-    }
-  }
-}
-var a = f (1) (2) (3)
-var b = f (1) (2)</code></pre>
+<pre class="pygments highlight"><code data-lang="js"><span class="tok-kd">function</span> <span class="tok-nx">f</span><span class="tok-p">(</span><span class="tok-nx">x</span><span class="tok-p">){</span>
+  <span class="tok-k">return</span> <span class="tok-kd">function</span> <span class="tok-p">(</span><span class="tok-nx">y</span><span class="tok-p">){</span>
+    <span class="tok-k">return</span> <span class="tok-kd">function</span> <span class="tok-p">(</span><span class="tok-nx">z</span><span class="tok-p">){</span>
+      <span class="tok-k">return</span> <span class="tok-nx">x</span> <span class="tok-o">+</span> <span class="tok-nx">y</span> <span class="tok-o">+</span> <span class="tok-nx">z</span>
+    <span class="tok-p">}</span>
+  <span class="tok-p">}</span>
+<span class="tok-p">}</span>
+<span class="tok-kd">var</span> <span class="tok-nx">a</span> <span class="tok-o">=</span> <span class="tok-nx">f</span> <span class="tok-p">(</span><span class="tok-mi">1</span><span class="tok-p">)</span> <span class="tok-p">(</span><span class="tok-mi">2</span><span class="tok-p">)</span> <span class="tok-p">(</span><span class="tok-mi">3</span><span class="tok-p">)</span>
+<span class="tok-kd">var</span> <span class="tok-nx">b</span> <span class="tok-o">=</span> <span class="tok-nx">f</span> <span class="tok-p">(</span><span class="tok-mi">1</span><span class="tok-p">)</span> <span class="tok-p">(</span><span class="tok-mi">2</span><span class="tok-p">)</span></code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -2505,9 +2566,9 @@ already <em>saw the source definition</em> of <code>f</code>, it can be optimize
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js">function f(x,y,z) {return x + y + z}
-var a = f(1,2,3)
-var b = function(z){return f(1,2,z)}</code></pre>
+<pre class="pygments highlight"><code data-lang="js"><span class="tok-kd">function</span> <span class="tok-nx">f</span><span class="tok-p">(</span><span class="tok-nx">x</span><span class="tok-p">,</span><span class="tok-nx">y</span><span class="tok-p">,</span><span class="tok-nx">z</span><span class="tok-p">)</span> <span class="tok-p">{</span><span class="tok-k">return</span> <span class="tok-nx">x</span> <span class="tok-o">+</span> <span class="tok-nx">y</span> <span class="tok-o">+</span> <span class="tok-nx">z</span><span class="tok-p">}</span>
+<span class="tok-kd">var</span> <span class="tok-nx">a</span> <span class="tok-o">=</span> <span class="tok-nx">f</span><span class="tok-p">(</span><span class="tok-mi">1</span><span class="tok-p">,</span><span class="tok-mi">2</span><span class="tok-p">,</span><span class="tok-mi">3</span><span class="tok-p">)</span>
+<span class="tok-kd">var</span> <span class="tok-nx">b</span> <span class="tok-o">=</span> <span class="tok-kd">function</span><span class="tok-p">(</span><span class="tok-nx">z</span><span class="tok-p">){</span><span class="tok-k">return</span> <span class="tok-nx">f</span><span class="tok-p">(</span><span class="tok-mi">1</span><span class="tok-p">,</span><span class="tok-mi">2</span><span class="tok-p">,</span><span class="tok-nx">z</span><span class="tok-p">)}</span></code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -2525,7 +2586,7 @@ i.e, callbacks.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml">let app f x = f x</code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">app</span> <span class="tok-n">f</span> <span class="tok-n">x</span> <span class="tok-o">=</span> <span class="tok-n">f</span> <span class="tok-n">x</span></code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -2535,9 +2596,9 @@ have to generate code as below:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js">function app(f,x){
-  return Curry._1(f,x);
-}</code></pre>
+<pre class="pygments highlight"><code data-lang="js"><span class="tok-kd">function</span> <span class="tok-nx">app</span><span class="tok-p">(</span><span class="tok-nx">f</span><span class="tok-p">,</span><span class="tok-nx">x</span><span class="tok-p">){</span>
+  <span class="tok-k">return</span> <span class="tok-nx">Curry</span><span class="tok-p">.</span><span class="tok-nx">_1</span><span class="tok-p">(</span><span class="tok-nx">f</span><span class="tok-p">,</span><span class="tok-nx">x</span><span class="tok-p">);</span>
+<span class="tok-p">}</span></code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -2550,7 +2611,7 @@ as below</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml">let app f x = f x [@bs]</code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">app</span> <span class="tok-n">f</span> <span class="tok-n">x</span> <span class="tok-o">=</span> <span class="tok-n">f</span> <span class="tok-n">x</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">]</span></code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -2559,9 +2620,9 @@ as below</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js">function app(f,x){
-  return f(x)
-}</code></pre>
+<pre class="pygments highlight"><code data-lang="js"><span class="tok-kd">function</span> <span class="tok-nx">app</span><span class="tok-p">(</span><span class="tok-nx">f</span><span class="tok-p">,</span><span class="tok-nx">x</span><span class="tok-p">){</span>
+  <span class="tok-k">return</span> <span class="tok-nx">f</span><span class="tok-p">(</span><span class="tok-nx">x</span><span class="tok-p">)</span>
+<span class="tok-p">}</span></code></pre>
 </div>
 </div>
 <div class="admonitionblock note">
@@ -2591,9 +2652,9 @@ example:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js">x.onload = function(v){
-  console.log(this.response + v )
-}</code></pre>
+<pre class="pygments highlight"><code data-lang="js"><span class="tok-nx">x</span><span class="tok-p">.</span><span class="tok-nx">onload</span> <span class="tok-o">=</span> <span class="tok-kd">function</span><span class="tok-p">(</span><span class="tok-nx">v</span><span class="tok-p">){</span>
+  <span class="tok-nx">console</span><span class="tok-p">.</span><span class="tok-nx">log</span><span class="tok-p">(</span><span class="tok-k">this</span><span class="tok-p">.</span><span class="tok-nx">response</span> <span class="tok-o">+</span> <span class="tok-nx">v</span> <span class="tok-p">)</span>
+<span class="tok-p">}</span></code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -2605,21 +2666,21 @@ Instead, we introduced a special attribute
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml">type x
-external set_onload : x -&gt; (x -&gt; int -&gt; unit [@bs.this]) -&gt; unit = "onload" [@@bs.set]
-external resp : x -&gt; int = "response" [@@bs.get]
-set_onload x begin fun [@bs.this] o v -&gt;
-  Js.log(resp o + v )
-end</code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">type</span> <span class="tok-n">x</span>
+<span class="tok-k">external</span> <span class="tok-n">set_onload</span> <span class="tok-o">:</span> <span class="tok-n">x</span> <span class="tok-o">-&gt;</span> <span class="tok-o">(</span><span class="tok-n">x</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">unit</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">this</span><span class="tok-o">])</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">unit</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;onload&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">set</span><span class="tok-o">]</span>
+<span class="tok-k">external</span> <span class="tok-n">resp</span> <span class="tok-o">:</span> <span class="tok-n">x</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;response&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">get</span><span class="tok-o">]</span>
+<span class="tok-n">set_onload</span> <span class="tok-n">x</span> <span class="tok-k">begin</span> <span class="tok-k">fun</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">this</span><span class="tok-o">]</span> <span class="tok-n">o</span> <span class="tok-n">v</span> <span class="tok-o">-&gt;</span>
+  <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">log</span><span class="tok-o">(</span><span class="tok-n">resp</span> <span class="tok-n">o</span> <span class="tok-o">+</span> <span class="tok-n">v</span> <span class="tok-o">)</span>
+<span class="tok-k">end</span></code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="title">Output:</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js">x.onload = function(v){
-  var o = this ; <b class="conum">(1)</b>
-  console.log(o.response + v);
-}</code></pre>
+<pre class="pygments highlight"><code data-lang="js"><span class="tok-nx">x</span><span class="tok-p">.</span><span class="tok-nx">onload</span> <span class="tok-o">=</span> <span class="tok-kd">function</span><span class="tok-p">(</span><span class="tok-nx">v</span><span class="tok-p">){</span>
+  <span class="tok-kd">var</span> <span class="tok-nx">o</span> <span class="tok-o">=</span> <span class="tok-k">this</span> <span class="tok-p">;</span> <b class="conum">(1)</b>
+  <span class="tok-nx">console</span><span class="tok-p">.</span><span class="tok-nx">log</span><span class="tok-p">(</span><span class="tok-nx">o</span><span class="tok-p">.</span><span class="tok-nx">response</span> <span class="tok-o">+</span> <span class="tok-nx">v</span><span class="tok-p">);</span>
+<span class="tok-p">}</span></code></pre>
 </div>
 </div>
 <div class="colist arabic">
@@ -2635,10 +2696,10 @@ reserved for <code>this</code> and for arity of 0, there is no need for a redund
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml">let f : 'obj -&gt; 'b [@bs.this] =
-  fun [@bs.this] obj -&gt; ....
-let f1 : 'obj -&gt; 'a0 -&gt; 'b [@bs.this] =
-  fun [@bs.this] obj a -&gt; ...</code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">f</span> <span class="tok-o">:</span> <span class="tok-k">&#39;</span><span class="tok-n">obj</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">b</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">this</span><span class="tok-o">]</span> <span class="tok-o">=</span>
+  <span class="tok-k">fun</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">this</span><span class="tok-o">]</span> <span class="tok-n">obj</span> <span class="tok-o">-&gt;</span> <span class="tok-o">....</span>
+<span class="tok-k">let</span> <span class="tok-n">f1</span> <span class="tok-o">:</span> <span class="tok-k">&#39;</span><span class="tok-n">obj</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">a0</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">b</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">this</span><span class="tok-o">]</span> <span class="tok-o">=</span>
+  <span class="tok-k">fun</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">this</span><span class="tok-o">]</span> <span class="tok-n">obj</span> <span class="tok-n">a</span> <span class="tok-o">-&gt;</span> <span class="tok-o">...</span></code></pre>
 </div>
 </div>
 <div class="admonitionblock note">
@@ -2693,8 +2754,8 @@ which exports two properties: <code>height</code> and <code>width</code>:</p>
 <div class="listingblock">
 <div class="title">demo.js</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js">exports.height = 3
-exports.width  = 3</code></pre>
+<pre class="pygments highlight"><code data-lang="js"><span class="tok-nx">exports</span><span class="tok-p">.</span><span class="tok-nx">height</span> <span class="tok-o">=</span> <span class="tok-mi">3</span>
+<span class="tok-nx">exports</span><span class="tok-p">.</span><span class="tok-nx">width</span>  <span class="tok-o">=</span> <span class="tok-mi">3</span></code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -2703,7 +2764,7 @@ here we use OCaml objects to model module <code>demo</code></p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml">external demo : &lt; height : int ; width : int &gt; Js.t = "" [@@bs.module]</code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">external</span> <span class="tok-n">demo</span> <span class="tok-o">:</span> <span class="tok-o">&lt;</span> <span class="tok-n">height</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">;</span> <span class="tok-n">width</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">&gt;</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">t</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">module</span><span class="tok-o">]</span></code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -2715,10 +2776,10 @@ here we use OCaml objects to model module <code>demo</code></p>
 <p>normal type</p>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml">&lt; label : int &gt;
-&lt; label : int -&gt; int &gt;
-&lt; label : int -&gt; int [@bs]&gt;
-&lt; label : int -&gt; int [@bs.this]&gt;</code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-o">&lt;</span> <span class="tok-n">label</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">&gt;</span>
+<span class="tok-o">&lt;</span> <span class="tok-n">label</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">&gt;</span>
+<span class="tok-o">&lt;</span> <span class="tok-n">label</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">]&gt;</span>
+<span class="tok-o">&lt;</span> <span class="tok-n">label</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">this</span><span class="tok-o">]&gt;</span></code></pre>
 </div>
 </div>
 </li>
@@ -2726,7 +2787,7 @@ here we use OCaml objects to model module <code>demo</code></p>
 <p>method</p>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml">&lt; label : int -&gt; int [@bs.meth] &gt;</code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-o">&lt;</span> <span class="tok-n">label</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">meth</span><span class="tok-o">]</span> <span class="tok-o">&gt;</span></code></pre>
 </div>
 </div>
 </li>
@@ -2741,14 +2802,14 @@ its arguments all at the same time, since its semantics depends on <code>this</c
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml">let test f =
-  f##hi 1 <b class="conum">(1)</b>
-let test2 f =
-  let u = f##hi in
-  u 1
-let test3 f =
-  let u = f##hi in
-  u 1 [@bs]</code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">test</span> <span class="tok-n">f</span> <span class="tok-o">=</span>
+  <span class="tok-n">f</span><span class="tok-o">##</span><span class="tok-n">hi</span> <span class="tok-mi">1</span> <b class="conum">(1)</b>
+<span class="tok-k">let</span> <span class="tok-n">test2</span> <span class="tok-n">f</span> <span class="tok-o">=</span>
+  <span class="tok-k">let</span> <span class="tok-n">u</span> <span class="tok-o">=</span> <span class="tok-n">f</span><span class="tok-o">##</span><span class="tok-n">hi</span> <span class="tok-k">in</span>
+  <span class="tok-n">u</span> <span class="tok-mi">1</span>
+<span class="tok-k">let</span> <span class="tok-n">test3</span> <span class="tok-n">f</span> <span class="tok-o">=</span>
+  <span class="tok-k">let</span> <span class="tok-n">u</span> <span class="tok-o">=</span> <span class="tok-n">f</span><span class="tok-o">##</span><span class="tok-n">hi</span> <span class="tok-k">in</span>
+  <span class="tok-n">u</span> <span class="tok-mi">1</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">]</span></code></pre>
 </div>
 </div>
 <div class="colist arabic">
@@ -2763,9 +2824,9 @@ let test3 f =
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml">val test : &lt; hi : int -&gt; 'a [@bs.meth]; .. &gt; -&gt; 'a <b class="conum">(1)</b>
-val test2 : &lt; hi : int -&gt; 'a ; .. &gt; -&gt; 'a
-val test3 : &lt; hi : int -&gt; 'a [@bs]; .. &gt;</code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">val</span> <span class="tok-n">test</span> <span class="tok-o">:</span> <span class="tok-o">&lt;</span> <span class="tok-n">hi</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">meth</span><span class="tok-o">];</span> <span class="tok-o">..</span> <span class="tok-o">&gt;</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <b class="conum">(1)</b>
+<span class="tok-k">val</span> <span class="tok-n">test2</span> <span class="tok-o">:</span> <span class="tok-o">&lt;</span> <span class="tok-n">hi</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-o">;</span> <span class="tok-o">..</span> <span class="tok-o">&gt;</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span>
+<span class="tok-k">val</span> <span class="tok-n">test3</span> <span class="tok-o">:</span> <span class="tok-o">&lt;</span> <span class="tok-n">hi</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">];</span> <span class="tok-o">..</span> <span class="tok-o">&gt;</span></code></pre>
 </div>
 </div>
 <div class="colist arabic">
@@ -2783,12 +2844,12 @@ val test3 : &lt; hi : int -&gt; 'a [@bs]; .. &gt;</code></pre>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml">class type _rect = object
-  method height : int
-  method width : int
-  method draw : unit -&gt; unit
-end [@bs] <b class="conum">(1)</b>
-type rect = _rect Js.t</code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">class</span> <span class="tok-k">type</span> <span class="tok-o">_</span><span class="tok-n">rect</span> <span class="tok-o">=</span> <span class="tok-k">object</span>
+  <span class="tok-k">method</span> <span class="tok-n">height</span> <span class="tok-o">:</span> <span class="tok-kt">int</span>
+  <span class="tok-k">method</span> <span class="tok-n">width</span> <span class="tok-o">:</span> <span class="tok-kt">int</span>
+  <span class="tok-k">method</span> <span class="tok-n">draw</span> <span class="tok-o">:</span> <span class="tok-kt">unit</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">unit</span>
+<span class="tok-k">end</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">]</span> <b class="conum">(1)</b>
+<span class="tok-k">type</span> <span class="tok-n">rect</span> <span class="tok-o">=</span> <span class="tok-o">_</span><span class="tok-n">rect</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">t</span></code></pre>
 </div>
 </div>
 <div class="colist arabic">
@@ -2810,7 +2871,7 @@ are treated as properties.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml">type rect = &lt; height : int ; wdith : int ; draw : unit -&gt; unit [@bs.meth] &gt; Js.t</code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">type</span> <span class="tok-n">rect</span> <span class="tok-o">=</span> <span class="tok-o">&lt;</span> <span class="tok-n">height</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">;</span> <span class="tok-n">wdith</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">;</span> <span class="tok-n">draw</span> <span class="tok-o">:</span> <span class="tok-kt">unit</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">unit</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">meth</span><span class="tok-o">]</span> <span class="tok-o">&gt;</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">t</span></code></pre>
 </div>
 </div>
 </div>
@@ -2821,9 +2882,9 @@ are treated as properties.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml">f##property <b class="conum">(1)</b>
-f##property #= v
-f##js_method args0 args1 args2 <b class="conum">(2)</b></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-n">f</span><span class="tok-o">##</span><span class="tok-n">property</span> <b class="conum">(1)</b>
+<span class="tok-n">f</span><span class="tok-o">##</span><span class="tok-n">property</span> <span class="tok-o">#=</span> <span class="tok-n">v</span>
+<span class="tok-n">f</span><span class="tok-o">##</span><span class="tok-n">js_method</span> <span class="tok-n">args0</span> <span class="tok-n">args1</span> <span class="tok-n">args2</span> <b class="conum">(2)</b></code></pre>
 </div>
 </div>
 <div class="colist arabic">
@@ -2849,9 +2910,9 @@ be guaranteed by OCaml&#8217;s type checker, a classic example shown below:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js">console.log('fine')
-var log = console.log;
-log('fine') <b class="conum">(1)</b></code></pre>
+<pre class="pygments highlight"><code data-lang="js"><span class="tok-nx">console</span><span class="tok-p">.</span><span class="tok-nx">log</span><span class="tok-p">(</span><span class="tok-s1">&#39;fine&#39;</span><span class="tok-p">)</span>
+<span class="tok-kd">var</span> <span class="tok-nx">log</span> <span class="tok-o">=</span> <span class="tok-nx">console</span><span class="tok-p">.</span><span class="tok-nx">log</span><span class="tok-p">;</span>
+<span class="tok-nx">log</span><span class="tok-p">(</span><span class="tok-s1">&#39;fine&#39;</span><span class="tok-p">)</span> <b class="conum">(1)</b></code></pre>
 </div>
 </div>
 <div class="colist arabic">
@@ -2870,9 +2931,9 @@ log('fine') <b class="conum">(1)</b></code></pre>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml">let fn = f0##f in
-let a = fn 1 2
-(* f##field a b would think `field` as a method *)</code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">fn</span> <span class="tok-o">=</span> <span class="tok-n">f0</span><span class="tok-o">##</span><span class="tok-n">f</span> <span class="tok-k">in</span>
+<span class="tok-k">let</span> <span class="tok-n">a</span> <span class="tok-o">=</span> <span class="tok-n">fn</span> <span class="tok-mi">1</span> <span class="tok-mi">2</span>
+<span class="tok-c">(* f##field a b would think `field` as a method *)</span></code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -2880,7 +2941,7 @@ let a = fn 1 2
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml">let b = f1##f 1 2</code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">b</span> <span class="tok-o">=</span> <span class="tok-n">f1</span><span class="tok-o">##</span><span class="tok-n">f</span> <span class="tok-mi">1</span> <span class="tok-mi">2</span></code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -2888,8 +2949,8 @@ let a = fn 1 2
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml">val f0 : &lt; f : int -&gt; int -&gt; int &gt; Js.t
-val f1 : &lt; f : int -&gt; int -&gt; int [@bs.meth] &gt; Js.t</code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">val</span> <span class="tok-n">f0</span> <span class="tok-o">:</span> <span class="tok-o">&lt;</span> <span class="tok-n">f</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">&gt;</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">t</span>
+<span class="tok-k">val</span> <span class="tok-n">f1</span> <span class="tok-o">:</span> <span class="tok-o">&lt;</span> <span class="tok-n">f</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">meth</span><span class="tok-o">]</span> <span class="tok-o">&gt;</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">t</span></code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -2897,9 +2958,9 @@ val f1 : &lt; f : int -&gt; int -&gt; int [@bs.meth] &gt; Js.t</code></pre>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml">console##log "fine"
-let u = console##log
-let () = u "fine" <b class="conum">(1)</b></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-n">console</span><span class="tok-o">##</span><span class="tok-n">log</span> <span class="tok-s2">&quot;fine&quot;</span>
+<span class="tok-k">let</span> <span class="tok-n">u</span> <span class="tok-o">=</span> <span class="tok-n">console</span><span class="tok-o">##</span><span class="tok-n">log</span>
+<span class="tok-k">let</span> <span class="tok-bp">()</span> <span class="tok-o">=</span> <span class="tok-n">u</span> <span class="tok-s2">&quot;fine&quot;</span> <b class="conum">(1)</b></code></pre>
 </div>
 </div>
 <div class="colist arabic">
@@ -2934,21 +2995,21 @@ them as property getters/setters.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml">type y = &lt;
-  height : int [@bs.set {no_get}] <b class="conum">(1)</b>
-&gt; Js.t
-type y0 = &lt;
-  height : int [@bs.set] [@bs.get {null}] <b class="conum">(2)</b>
-&gt; Js.t
-type y1 = &lt;
-  height : int [@bs.set] [@bs.get {undefined}] <b class="conum">(3)</b>
-&gt; Js.t
-type y2 = &lt;
-  height : int [@bs.set] [@bs.get {undefined; null}] <b class="conum">(4)</b>
-&gt; Js.t
-type y3 = &lt;
-  height : int [@bs.get {undefined ; null}] <b class="conum">(5)</b>
-&gt; Js.t</code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">type</span> <span class="tok-n">y</span> <span class="tok-o">=</span> <span class="tok-o">&lt;</span>
+  <span class="tok-n">height</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">set</span> <span class="tok-o">{</span><span class="tok-n">no_get</span><span class="tok-o">}]</span> <b class="conum">(1)</b>
+<span class="tok-o">&gt;</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">t</span>
+<span class="tok-k">type</span> <span class="tok-n">y0</span> <span class="tok-o">=</span> <span class="tok-o">&lt;</span>
+  <span class="tok-n">height</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">set</span><span class="tok-o">]</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">get</span> <span class="tok-o">{</span><span class="tok-n">null</span><span class="tok-o">}]</span> <b class="conum">(2)</b>
+<span class="tok-o">&gt;</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">t</span>
+<span class="tok-k">type</span> <span class="tok-n">y1</span> <span class="tok-o">=</span> <span class="tok-o">&lt;</span>
+  <span class="tok-n">height</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">set</span><span class="tok-o">]</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">get</span> <span class="tok-o">{</span><span class="tok-n">undefined</span><span class="tok-o">}]</span> <b class="conum">(3)</b>
+<span class="tok-o">&gt;</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">t</span>
+<span class="tok-k">type</span> <span class="tok-n">y2</span> <span class="tok-o">=</span> <span class="tok-o">&lt;</span>
+  <span class="tok-n">height</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">set</span><span class="tok-o">]</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">get</span> <span class="tok-o">{</span><span class="tok-n">undefined</span><span class="tok-o">;</span> <span class="tok-n">null</span><span class="tok-o">}]</span> <b class="conum">(4)</b>
+<span class="tok-o">&gt;</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">t</span>
+<span class="tok-k">type</span> <span class="tok-n">y3</span> <span class="tok-o">=</span> <span class="tok-o">&lt;</span>
+  <span class="tok-n">height</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">get</span> <span class="tok-o">{</span><span class="tok-n">undefined</span> <span class="tok-o">;</span> <span class="tok-n">null</span><span class="tok-o">}]</span> <b class="conum">(5)</b>
+<span class="tok-o">&gt;</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">t</span></code></pre>
 </div>
 </div>
 <div class="colist arabic">
@@ -2992,7 +3053,7 @@ create JS objects in a type safe way on the OCaml side:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml">let u = [%bs.obj { x = { y = { z = 3}}} ] <b class="conum">(1)</b></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">u</span> <span class="tok-o">=</span> <span class="tok-o">[%</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">obj</span> <span class="tok-o">{</span> <span class="tok-n">x</span> <span class="tok-o">=</span> <span class="tok-o">{</span> <span class="tok-n">y</span> <span class="tok-o">=</span> <span class="tok-o">{</span> <span class="tok-n">z</span> <span class="tok-o">=</span> <span class="tok-mi">3</span><span class="tok-o">}}}</span> <span class="tok-o">]</span> <b class="conum">(1)</b></code></pre>
 </div>
 </div>
 <div class="colist arabic">
@@ -3005,7 +3066,7 @@ create JS objects in a type safe way on the OCaml side:</p>
 <div class="listingblock">
 <div class="title">Output:</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js">var u = { x : { y : { z : 3 }}}}</code></pre>
+<pre class="pygments highlight"><code data-lang="js"><span class="tok-kd">var</span> <span class="tok-nx">u</span> <span class="tok-o">=</span> <span class="tok-p">{</span> <span class="tok-nx">x</span> <span class="tok-o">:</span> <span class="tok-p">{</span> <span class="tok-nx">y</span> <span class="tok-o">:</span> <span class="tok-p">{</span> <span class="tok-nx">z</span> <span class="tok-o">:</span> <span class="tok-mi">3</span> <span class="tok-p">}}}}</span></code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -3013,7 +3074,7 @@ create JS objects in a type safe way on the OCaml side:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml">val u : &lt; x : &lt; y : &lt; z : int &gt; Js.t &gt; Js.t &gt; Js.t</code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">val</span> <span class="tok-n">u</span> <span class="tok-o">:</span> <span class="tok-o">&lt;</span> <span class="tok-n">x</span> <span class="tok-o">:</span> <span class="tok-o">&lt;</span> <span class="tok-n">y</span> <span class="tok-o">:</span> <span class="tok-o">&lt;</span> <span class="tok-n">z</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">&gt;</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">t</span> <span class="tok-o">&gt;</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">t</span> <span class="tok-o">&gt;</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">t</span></code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -3022,7 +3083,7 @@ into the type level, so you can write:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml">val u : [%bs.obj: &lt; x : &lt; y : &lt; z : int &gt; &gt; &gt; ]</code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">val</span> <span class="tok-n">u</span> <span class="tok-o">:</span> <span class="tok-o">[%</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">obj</span><span class="tok-o">:</span> <span class="tok-o">&lt;</span> <span class="tok-n">x</span> <span class="tok-o">:</span> <span class="tok-o">&lt;</span> <span class="tok-n">y</span> <span class="tok-o">:</span> <span class="tok-o">&lt;</span> <span class="tok-n">z</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">&gt;</span> <span class="tok-o">&gt;</span> <span class="tok-o">&gt;</span> <span class="tok-o">]</span></code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -3030,7 +3091,7 @@ into the type level, so you can write:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml">let u = [%bs.obj ( { x = { y = { z = 3 }}} : &lt; x : &lt; y : &lt; z : int &gt; &gt; &gt; ]</code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">u</span> <span class="tok-o">=</span> <span class="tok-o">[%</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">obj</span> <span class="tok-o">(</span> <span class="tok-o">{</span> <span class="tok-n">x</span> <span class="tok-o">=</span> <span class="tok-o">{</span> <span class="tok-n">y</span> <span class="tok-o">=</span> <span class="tok-o">{</span> <span class="tok-n">z</span> <span class="tok-o">=</span> <span class="tok-mi">3</span> <span class="tok-o">}}}</span> <span class="tok-o">:</span> <span class="tok-o">&lt;</span> <span class="tok-n">x</span> <span class="tok-o">:</span> <span class="tok-o">&lt;</span> <span class="tok-n">y</span> <span class="tok-o">:</span> <span class="tok-o">&lt;</span> <span class="tok-n">z</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">&gt;</span> <span class="tok-o">&gt;</span> <span class="tok-o">&gt;</span> <span class="tok-o">]</span></code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -3038,15 +3099,15 @@ into the type level, so you can write:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml">let xs = [%bs.obj [| { x = 3 } ; { x = 3 } |] : &lt; x : int &gt; array ]
-let ys = [%bs.obj [| { x = 3 } ; { x = 4 } |] ]</code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">xs</span> <span class="tok-o">=</span> <span class="tok-o">[%</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">obj</span> <span class="tok-o">[|</span> <span class="tok-o">{</span> <span class="tok-n">x</span> <span class="tok-o">=</span> <span class="tok-mi">3</span> <span class="tok-o">}</span> <span class="tok-o">;</span> <span class="tok-o">{</span> <span class="tok-n">x</span> <span class="tok-o">=</span> <span class="tok-mi">3</span> <span class="tok-o">}</span> <span class="tok-o">|]</span> <span class="tok-o">:</span> <span class="tok-o">&lt;</span> <span class="tok-n">x</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">&gt;</span> <span class="tok-kt">array</span> <span class="tok-o">]</span>
+<span class="tok-k">let</span> <span class="tok-n">ys</span> <span class="tok-o">=</span> <span class="tok-o">[%</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">obj</span> <span class="tok-o">[|</span> <span class="tok-o">{</span> <span class="tok-n">x</span> <span class="tok-o">=</span> <span class="tok-mi">3</span> <span class="tok-o">}</span> <span class="tok-o">;</span> <span class="tok-o">{</span> <span class="tok-n">x</span> <span class="tok-o">=</span> <span class="tok-mi">4</span> <span class="tok-o">}</span> <span class="tok-o">|]</span> <span class="tok-o">]</span></code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="title">Output:</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js">var xs = [ { x : 3 } , { x : 3 } ]
-var ys = [ { x : 3 } , { x : 4 } ]</code></pre>
+<pre class="pygments highlight"><code data-lang="js"><span class="tok-kd">var</span> <span class="tok-nx">xs</span> <span class="tok-o">=</span> <span class="tok-p">[</span> <span class="tok-p">{</span> <span class="tok-nx">x</span> <span class="tok-o">:</span> <span class="tok-mi">3</span> <span class="tok-p">}</span> <span class="tok-p">,</span> <span class="tok-p">{</span> <span class="tok-nx">x</span> <span class="tok-o">:</span> <span class="tok-mi">3</span> <span class="tok-p">}</span> <span class="tok-p">]</span>
+<span class="tok-kd">var</span> <span class="tok-nx">ys</span> <span class="tok-o">=</span> <span class="tok-p">[</span> <span class="tok-p">{</span> <span class="tok-nx">x</span> <span class="tok-o">:</span> <span class="tok-mi">3</span> <span class="tok-p">}</span> <span class="tok-p">,</span> <span class="tok-p">{</span> <span class="tok-nx">x</span> <span class="tok-o">:</span> <span class="tok-mi">4</span> <span class="tok-p">}</span> <span class="tok-p">]</span></code></pre>
 </div>
 </div>
 </div>
@@ -3057,14 +3118,14 @@ var ys = [ { x : 3 } , { x : 4 } ]</code></pre>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml">external make_config : hi:int -&gt; lo:int -&gt; unit -&gt; t = "" [@@bs.obj]
-let v = make_config ~hi:2 ~lo:3</code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">external</span> <span class="tok-n">make_config</span> <span class="tok-o">:</span> <span class="tok-n">hi</span><span class="tok-o">:</span><span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-n">lo</span><span class="tok-o">:</span><span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">unit</span> <span class="tok-o">-&gt;</span> <span class="tok-n">t</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">obj</span><span class="tok-o">]</span>
+<span class="tok-k">let</span> <span class="tok-n">v</span> <span class="tok-o">=</span> <span class="tok-n">make_config</span> <span class="tok-o">~</span><span class="tok-n">hi</span><span class="tok-o">:</span><span class="tok-mi">2</span> <span class="tok-o">~</span><span class="tok-n">lo</span><span class="tok-o">:</span><span class="tok-mi">3</span></code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="title">Output:</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js">var v = { hi : 2 , lo : 3 }</code></pre>
+<pre class="pygments highlight"><code data-lang="js"><span class="tok-kd">var</span> <span class="tok-nx">v</span> <span class="tok-o">=</span> <span class="tok-p">{</span> <span class="tok-nx">hi</span> <span class="tok-o">:</span> <span class="tok-mi">2</span> <span class="tok-p">,</span> <span class="tok-nx">lo</span> <span class="tok-o">:</span> <span class="tok-mi">3</span> <span class="tok-p">}</span></code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -3072,9 +3133,9 @@ let v = make_config ~hi:2 ~lo:3</code></pre>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml">external make_config : hi:int -&gt; ?lo:int -&gt; unit -&gt; t = "" [@@bs.obj] <b class="conum">(1)</b>
-let u = make_config ~hi:3 ()
-let v = make_config ~lo:2 ~hi:3 ()</code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">external</span> <span class="tok-n">make_config</span> <span class="tok-o">:</span> <span class="tok-n">hi</span><span class="tok-o">:</span><span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-o">?</span><span class="tok-n">lo</span><span class="tok-o">:</span><span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">unit</span> <span class="tok-o">-&gt;</span> <span class="tok-n">t</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">obj</span><span class="tok-o">]</span> <b class="conum">(1)</b>
+<span class="tok-k">let</span> <span class="tok-n">u</span> <span class="tok-o">=</span> <span class="tok-n">make_config</span> <span class="tok-o">~</span><span class="tok-n">hi</span><span class="tok-o">:</span><span class="tok-mi">3</span> <span class="tok-bp">()</span>
+<span class="tok-k">let</span> <span class="tok-n">v</span> <span class="tok-o">=</span> <span class="tok-n">make_config</span> <span class="tok-o">~</span><span class="tok-n">lo</span><span class="tok-o">:</span><span class="tok-mi">2</span> <span class="tok-o">~</span><span class="tok-n">hi</span><span class="tok-o">:</span><span class="tok-mi">3</span> <span class="tok-bp">()</span></code></pre>
 </div>
 </div>
 <div class="colist arabic">
@@ -3089,8 +3150,8 @@ are fulfilled (including optional arguments), it is common to have a <code>unit<
 <div class="listingblock">
 <div class="title">Output:</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js">var u = {hi : 3}
-var v = {hi : 3 , lo: 2}</code></pre>
+<pre class="pygments highlight"><code data-lang="js"><span class="tok-kd">var</span> <span class="tok-nx">u</span> <span class="tok-o">=</span> <span class="tok-p">{</span><span class="tok-nx">hi</span> <span class="tok-o">:</span> <span class="tok-mi">3</span><span class="tok-p">}</span>
+<span class="tok-kd">var</span> <span class="tok-nx">v</span> <span class="tok-o">=</span> <span class="tok-p">{</span><span class="tok-nx">hi</span> <span class="tok-o">:</span> <span class="tok-mi">3</span> <span class="tok-p">,</span> <span class="tok-nx">lo</span><span class="tok-o">:</span> <span class="tok-mi">2</span><span class="tok-p">}</span></code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -3098,13 +3159,13 @@ var v = {hi : 3 , lo: 2}</code></pre>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml">let u = [%bs.obj {
-  x = { y = { z = 3 } };
-  fn = fun [@bs] u v -&gt; u + v <b class="conum">(1)</b>
-  } ]
-let h = u##x##y##z
-let a = u##fn
-let b = a 1 2 [@bs]</code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">u</span> <span class="tok-o">=</span> <span class="tok-o">[%</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">obj</span> <span class="tok-o">{</span>
+  <span class="tok-n">x</span> <span class="tok-o">=</span> <span class="tok-o">{</span> <span class="tok-n">y</span> <span class="tok-o">=</span> <span class="tok-o">{</span> <span class="tok-n">z</span> <span class="tok-o">=</span> <span class="tok-mi">3</span> <span class="tok-o">}</span> <span class="tok-o">};</span>
+  <span class="tok-n">fn</span> <span class="tok-o">=</span> <span class="tok-k">fun</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">]</span> <span class="tok-n">u</span> <span class="tok-n">v</span> <span class="tok-o">-&gt;</span> <span class="tok-n">u</span> <span class="tok-o">+</span> <span class="tok-n">v</span> <b class="conum">(1)</b>
+  <span class="tok-o">}</span> <span class="tok-o">]</span>
+<span class="tok-k">let</span> <span class="tok-n">h</span> <span class="tok-o">=</span> <span class="tok-n">u</span><span class="tok-o">##</span><span class="tok-n">x</span><span class="tok-o">##</span><span class="tok-n">y</span><span class="tok-o">##</span><span class="tok-n">z</span>
+<span class="tok-k">let</span> <span class="tok-n">a</span> <span class="tok-o">=</span> <span class="tok-n">u</span><span class="tok-o">##</span><span class="tok-n">fn</span>
+<span class="tok-k">let</span> <span class="tok-n">b</span> <span class="tok-o">=</span> <span class="tok-n">a</span> <span class="tok-mi">1</span> <span class="tok-mi">2</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">]</span></code></pre>
 </div>
 </div>
 <div class="colist arabic">
@@ -3118,10 +3179,10 @@ We will show how to create JS method in OCaml later.</p>
 <div class="listingblock">
 <div class="title">Output:</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js">var u = { x : { y : { z : 3 } }, fn : function (u, v) {return u + v}}
-var h = u.x.y.z
-var a = u.fn
-var b = a(1,2)</code></pre>
+<pre class="pygments highlight"><code data-lang="js"><span class="tok-kd">var</span> <span class="tok-nx">u</span> <span class="tok-o">=</span> <span class="tok-p">{</span> <span class="tok-nx">x</span> <span class="tok-o">:</span> <span class="tok-p">{</span> <span class="tok-nx">y</span> <span class="tok-o">:</span> <span class="tok-p">{</span> <span class="tok-nx">z</span> <span class="tok-o">:</span> <span class="tok-mi">3</span> <span class="tok-p">}</span> <span class="tok-p">},</span> <span class="tok-nx">fn</span> <span class="tok-o">:</span> <span class="tok-kd">function</span> <span class="tok-p">(</span><span class="tok-nx">u</span><span class="tok-p">,</span> <span class="tok-nx">v</span><span class="tok-p">)</span> <span class="tok-p">{</span><span class="tok-k">return</span> <span class="tok-nx">u</span> <span class="tok-o">+</span> <span class="tok-nx">v</span><span class="tok-p">}}</span>
+<span class="tok-kd">var</span> <span class="tok-nx">h</span> <span class="tok-o">=</span> <span class="tok-nx">u</span><span class="tok-p">.</span><span class="tok-nx">x</span><span class="tok-p">.</span><span class="tok-nx">y</span><span class="tok-p">.</span><span class="tok-nx">z</span>
+<span class="tok-kd">var</span> <span class="tok-nx">a</span> <span class="tok-o">=</span> <span class="tok-nx">u</span><span class="tok-p">.</span><span class="tok-nx">fn</span>
+<span class="tok-kd">var</span> <span class="tok-nx">b</span> <span class="tok-o">=</span> <span class="tok-nx">a</span><span class="tok-p">(</span><span class="tok-mi">1</span><span class="tok-p">,</span><span class="tok-mi">2</span><span class="tok-p">)</span></code></pre>
 </div>
 </div>
 <div class="admonitionblock note">
@@ -3137,14 +3198,14 @@ is available:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml">let b x y h = h#@fn x y</code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">b</span> <span class="tok-n">x</span> <span class="tok-n">y</span> <span class="tok-n">h</span> <span class="tok-o">=</span> <span class="tok-n">h</span><span class="tok-o">#@</span><span class="tok-n">fn</span> <span class="tok-n">x</span> <span class="tok-n">y</span></code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js">function b (x,y,h){
-  return h.fn(x,y)
-}</code></pre>
+<pre class="pygments highlight"><code data-lang="js"><span class="tok-kd">function</span> <span class="tok-nx">b</span> <span class="tok-p">(</span><span class="tok-nx">x</span><span class="tok-p">,</span><span class="tok-nx">y</span><span class="tok-p">,</span><span class="tok-nx">h</span><span class="tok-p">){</span>
+  <span class="tok-k">return</span> <span class="tok-nx">h</span><span class="tok-p">.</span><span class="tok-nx">fn</span><span class="tok-p">(</span><span class="tok-nx">x</span><span class="tok-p">,</span><span class="tok-nx">y</span><span class="tok-p">)</span>
+<span class="tok-p">}</span></code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -3152,7 +3213,7 @@ is available:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml">val b : 'a -&gt; 'b -&gt; &lt; fn : 'a -&gt; 'b -&gt; 'c [@bs] &gt; Js.t -&gt; 'c</code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">val</span> <span class="tok-n">b</span> <span class="tok-o">:</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">b</span> <span class="tok-o">-&gt;</span> <span class="tok-o">&lt;</span> <span class="tok-n">fn</span> <span class="tok-o">:</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">b</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">c</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">]</span> <span class="tok-o">&gt;</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">t</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">c</span></code></pre>
 </div>
 </div>
 </td>
@@ -3168,13 +3229,13 @@ BuckleScript too.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml">let v2 =
-  let x = 3. in
-  object (self) <b class="conum">(1)</b>
-    method hi x y = self##say x +. y
-    method say x = x *. self##x ()
-    method x () = x
-  end [@bs] <b class="conum">(2)</b></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">v2</span> <span class="tok-o">=</span>
+  <span class="tok-k">let</span> <span class="tok-n">x</span> <span class="tok-o">=</span> <span class="tok-mi">3</span><span class="tok-o">.</span> <span class="tok-k">in</span>
+  <span class="tok-k">object</span> <span class="tok-o">(</span><span class="tok-n">self</span><span class="tok-o">)</span> <b class="conum">(1)</b>
+    <span class="tok-k">method</span> <span class="tok-n">hi</span> <span class="tok-n">x</span> <span class="tok-n">y</span> <span class="tok-o">=</span> <span class="tok-n">self</span><span class="tok-o">##</span><span class="tok-n">say</span> <span class="tok-n">x</span> <span class="tok-o">+.</span> <span class="tok-n">y</span>
+    <span class="tok-k">method</span> <span class="tok-n">say</span> <span class="tok-n">x</span> <span class="tok-o">=</span> <span class="tok-n">x</span> <span class="tok-o">*.</span> <span class="tok-n">self</span><span class="tok-o">##</span><span class="tok-n">x</span> <span class="tok-bp">()</span>
+    <span class="tok-k">method</span> <span class="tok-n">x</span> <span class="tok-bp">()</span> <span class="tok-o">=</span> <span class="tok-n">x</span>
+  <span class="tok-k">end</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">]</span> <b class="conum">(2)</b></code></pre>
 </div>
 </div>
 <div class="colist arabic">
@@ -3190,19 +3251,19 @@ BuckleScript too.</p>
 <div class="listingblock">
 <div class="title">Output:</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js">var v2 = {
-  hi: function (x, y) {
-    var self = this ;
-    return self.say(x) + y;
-  },
-  say: function (x) {
-    var self = this ;
-    return x * self.x();
-  },
-  x: function () {
-    return 3;
-  }
-};</code></pre>
+<pre class="pygments highlight"><code data-lang="js"><span class="tok-kd">var</span> <span class="tok-nx">v2</span> <span class="tok-o">=</span> <span class="tok-p">{</span>
+  <span class="tok-nx">hi</span><span class="tok-o">:</span> <span class="tok-kd">function</span> <span class="tok-p">(</span><span class="tok-nx">x</span><span class="tok-p">,</span> <span class="tok-nx">y</span><span class="tok-p">)</span> <span class="tok-p">{</span>
+    <span class="tok-kd">var</span> <span class="tok-nx">self</span> <span class="tok-o">=</span> <span class="tok-k">this</span> <span class="tok-p">;</span>
+    <span class="tok-k">return</span> <span class="tok-nx">self</span><span class="tok-p">.</span><span class="tok-nx">say</span><span class="tok-p">(</span><span class="tok-nx">x</span><span class="tok-p">)</span> <span class="tok-o">+</span> <span class="tok-nx">y</span><span class="tok-p">;</span>
+  <span class="tok-p">},</span>
+  <span class="tok-nx">say</span><span class="tok-o">:</span> <span class="tok-kd">function</span> <span class="tok-p">(</span><span class="tok-nx">x</span><span class="tok-p">)</span> <span class="tok-p">{</span>
+    <span class="tok-kd">var</span> <span class="tok-nx">self</span> <span class="tok-o">=</span> <span class="tok-k">this</span> <span class="tok-p">;</span>
+    <span class="tok-k">return</span> <span class="tok-nx">x</span> <span class="tok-o">*</span> <span class="tok-nx">self</span><span class="tok-p">.</span><span class="tok-nx">x</span><span class="tok-p">();</span>
+  <span class="tok-p">},</span>
+  <span class="tok-nx">x</span><span class="tok-o">:</span> <span class="tok-kd">function</span> <span class="tok-p">()</span> <span class="tok-p">{</span>
+    <span class="tok-k">return</span> <span class="tok-mi">3</span><span class="tok-p">;</span>
+  <span class="tok-p">}</span>
+<span class="tok-p">};</span></code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -3210,11 +3271,11 @@ BuckleScript too.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml">val v2 : &lt;
-  hi : float -&gt; float -&gt; float [@bs.meth];
-  say : float -&gt; float [@bs.meth];
-  x : unit -&gt; float [@bs.meth]
-&gt; [@bs]</code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">val</span> <span class="tok-n">v2</span> <span class="tok-o">:</span> <span class="tok-o">&lt;</span>
+  <span class="tok-n">hi</span> <span class="tok-o">:</span> <span class="tok-kt">float</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">float</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">float</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">meth</span><span class="tok-o">];</span>
+  <span class="tok-n">say</span> <span class="tok-o">:</span> <span class="tok-kt">float</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">float</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">meth</span><span class="tok-o">];</span>
+  <span class="tok-n">x</span> <span class="tok-o">:</span> <span class="tok-kt">unit</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">float</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">meth</span><span class="tok-o">]</span>
+<span class="tok-o">&gt;</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">]</span></code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -3222,37 +3283,37 @@ BuckleScript too.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml">let f (u : rect) =
-  (* the type annotation is un-necessary,
-     but it gives better error message
-  *)
-   Js.log u##height;
-   Js.log u##width;
-   u##width #= 30;
-   u##height #= 30;
-   u##draw ()</code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">f</span> <span class="tok-o">(</span><span class="tok-n">u</span> <span class="tok-o">:</span> <span class="tok-n">rect</span><span class="tok-o">)</span> <span class="tok-o">=</span>
+  <span class="tok-c">(* the type annotation is un-necessary,</span>
+<span class="tok-c">     but it gives better error message</span>
+<span class="tok-c">  *)</span>
+   <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">log</span> <span class="tok-n">u</span><span class="tok-o">##</span><span class="tok-n">height</span><span class="tok-o">;</span>
+   <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">log</span> <span class="tok-n">u</span><span class="tok-o">##</span><span class="tok-n">width</span><span class="tok-o">;</span>
+   <span class="tok-n">u</span><span class="tok-o">##</span><span class="tok-n">width</span> <span class="tok-o">#=</span> <span class="tok-mi">30</span><span class="tok-o">;</span>
+   <span class="tok-n">u</span><span class="tok-o">##</span><span class="tok-n">height</span> <span class="tok-o">#=</span> <span class="tok-mi">30</span><span class="tok-o">;</span>
+   <span class="tok-n">u</span><span class="tok-o">##</span><span class="tok-n">draw</span> <span class="tok-bp">()</span></code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="title">Output:</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js">function f(u){
-  console.log(u.height);
-  console.log(u.width);
-  u.width = 30;
-  u.height = 30;
-  return u.draw()
-}</code></pre>
+<pre class="pygments highlight"><code data-lang="js"><span class="tok-kd">function</span> <span class="tok-nx">f</span><span class="tok-p">(</span><span class="tok-nx">u</span><span class="tok-p">){</span>
+  <span class="tok-nx">console</span><span class="tok-p">.</span><span class="tok-nx">log</span><span class="tok-p">(</span><span class="tok-nx">u</span><span class="tok-p">.</span><span class="tok-nx">height</span><span class="tok-p">);</span>
+  <span class="tok-nx">console</span><span class="tok-p">.</span><span class="tok-nx">log</span><span class="tok-p">(</span><span class="tok-nx">u</span><span class="tok-p">.</span><span class="tok-nx">width</span><span class="tok-p">);</span>
+  <span class="tok-nx">u</span><span class="tok-p">.</span><span class="tok-nx">width</span> <span class="tok-o">=</span> <span class="tok-mi">30</span><span class="tok-p">;</span>
+  <span class="tok-nx">u</span><span class="tok-p">.</span><span class="tok-nx">height</span> <span class="tok-o">=</span> <span class="tok-mi">30</span><span class="tok-p">;</span>
+  <span class="tok-k">return</span> <span class="tok-nx">u</span><span class="tok-p">.</span><span class="tok-nx">draw</span><span class="tok-p">()</span>
+<span class="tok-p">}</span></code></pre>
 </div>
 </div>
 <div class="sect4">
 <h5 id="_method_chaining"><a class="anchor" href="#_method_chaining"></a>Method chaining</h5>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml">f
-##(meth0 ())
-##(meth1 a)
-##(meth2 a b)</code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-n">f</span>
+<span class="tok-o">##(</span><span class="tok-n">meth0</span> <span class="tok-bp">()</span><span class="tok-o">)</span>
+<span class="tok-o">##(</span><span class="tok-n">meth1</span> <span class="tok-n">a</span><span class="tok-o">)</span>
+<span class="tok-o">##(</span><span class="tok-n">meth2</span> <span class="tok-n">a</span> <span class="tok-n">b</span><span class="tok-o">)</span></code></pre>
 </div>
 </div>
 </div>
@@ -3269,15 +3330,15 @@ error.</p>
 <div class="listingblock">
 <div class="title">Key-word method:</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml">f##_open
-f##_MAX_LENGTH</code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-n">f</span><span class="tok-o">##_</span><span class="tok-n">open</span>
+<span class="tok-n">f</span><span class="tok-o">##_</span><span class="tok-n">MAX_LENGTH</span></code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="title">OUTPUT:</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js">f.open
-f.MAX_LENGTH</code></pre>
+<pre class="pygments highlight"><code data-lang="js"><span class="tok-nx">f</span><span class="tok-p">.</span><span class="tok-nx">open</span>
+<span class="tok-nx">f</span><span class="tok-p">.</span><span class="tok-nx">MAX_LENGTH</span></code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -3288,15 +3349,15 @@ object labels, which is <em>occasionally</em> useful as below</p>
 <div class="listingblock">
 <div class="title">Ad-hoc polymorphism</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml">f##draw__cat (x,y)
-f##draw__dog (x,y)</code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-n">f</span><span class="tok-o">##</span><span class="tok-n">draw__cat</span> <span class="tok-o">(</span><span class="tok-n">x</span><span class="tok-o">,</span><span class="tok-n">y</span><span class="tok-o">)</span>
+<span class="tok-n">f</span><span class="tok-o">##</span><span class="tok-n">draw__dog</span> <span class="tok-o">(</span><span class="tok-n">x</span><span class="tok-o">,</span><span class="tok-n">y</span><span class="tok-o">)</span></code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="title">OUTPUT:</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js">f.draw(x,y) // f.draw in JS can accept different types
-f.draw(x,y)</code></pre>
+<pre class="pygments highlight"><code data-lang="js"><span class="tok-nx">f</span><span class="tok-p">.</span><span class="tok-nx">draw</span><span class="tok-p">(</span><span class="tok-nx">x</span><span class="tok-p">,</span><span class="tok-nx">y</span><span class="tok-p">)</span> <span class="tok-c1">// f.draw in JS can accept different types</span>
+<span class="tok-nx">f</span><span class="tok-p">.</span><span class="tok-nx">draw</span><span class="tok-p">(</span><span class="tok-nx">x</span><span class="tok-p">,</span><span class="tok-nx">y</span><span class="tok-p">)</span></code></pre>
 </div>
 </div>
 <div class="admonitionblock note">
@@ -3372,16 +3433,16 @@ drop the first '_'</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml">type element
-type dom
-external getElementById : string -&gt; element option = ""
-[@@bs.send.pipe:dom] [@@bs.return null_to_opt] <b class="conum">(1)</b>
+<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">type</span> <span class="tok-n">element</span>
+<span class="tok-k">type</span> <span class="tok-n">dom</span>
+<span class="tok-k">external</span> <span class="tok-n">getElementById</span> <span class="tok-o">:</span> <span class="tok-kt">string</span> <span class="tok-o">-&gt;</span> <span class="tok-n">element</span> <span class="tok-n">option</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;&quot;</span>
+<span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">send</span><span class="tok-o">.</span><span class="tok-n">pipe</span><span class="tok-o">:</span><span class="tok-n">dom</span><span class="tok-o">]</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">return</span> <span class="tok-n">null_to_opt</span><span class="tok-o">]</span> <b class="conum">(1)</b>
 
-let test dom =
-    let elem = dom |&gt; getElementById "haha" in
-    match elem with
-    | None -&gt; 1
-    | Some ui -&gt; Js.log ui ; 2</code></pre>
+<span class="tok-k">let</span> <span class="tok-n">test</span> <span class="tok-n">dom</span> <span class="tok-o">=</span>
+    <span class="tok-k">let</span> <span class="tok-n">elem</span> <span class="tok-o">=</span> <span class="tok-n">dom</span> <span class="tok-o">|&gt;</span> <span class="tok-n">getElementById</span> <span class="tok-s2">&quot;haha&quot;</span> <span class="tok-k">in</span>
+    <span class="tok-k">match</span> <span class="tok-n">elem</span> <span class="tok-k">with</span>
+    <span class="tok-o">|</span> <span class="tok-nc">None</span> <span class="tok-o">-&gt;</span> <span class="tok-mi">1</span>
+    <span class="tok-o">|</span> <span class="tok-nc">Some</span> <span class="tok-n">ui</span> <span class="tok-o">-&gt;</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">log</span> <span class="tok-n">ui</span> <span class="tok-o">;</span> <span class="tok-mi">2</span></code></pre>
 </div>
 </div>
 <div class="colist arabic">
@@ -3394,16 +3455,16 @@ let test dom =
 <div class="listingblock">
 <div class="title">Output</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js">function test(dom) {
-  var elem = dom.getElementById("haha");
-  if (elem !== null) { <b class="conum">(1)</b>
-    console.log(elem);
-    return 2;
-  }
-  else {
-    return 1;
-  }
-}</code></pre>
+<pre class="pygments highlight"><code data-lang="js"><span class="tok-kd">function</span> <span class="tok-nx">test</span><span class="tok-p">(</span><span class="tok-nx">dom</span><span class="tok-p">)</span> <span class="tok-p">{</span>
+  <span class="tok-kd">var</span> <span class="tok-nx">elem</span> <span class="tok-o">=</span> <span class="tok-nx">dom</span><span class="tok-p">.</span><span class="tok-nx">getElementById</span><span class="tok-p">(</span><span class="tok-s2">&quot;haha&quot;</span><span class="tok-p">);</span>
+  <span class="tok-k">if</span> <span class="tok-p">(</span><span class="tok-nx">elem</span> <span class="tok-o">!==</span> <span class="tok-kc">null</span><span class="tok-p">)</span> <span class="tok-p">{</span> <b class="conum">(1)</b>
+    <span class="tok-nx">console</span><span class="tok-p">.</span><span class="tok-nx">log</span><span class="tok-p">(</span><span class="tok-nx">elem</span><span class="tok-p">);</span>
+    <span class="tok-k">return</span> <span class="tok-mi">2</span><span class="tok-p">;</span>
+  <span class="tok-p">}</span>
+  <span class="tok-k">else</span> <span class="tok-p">{</span>
+    <span class="tok-k">return</span> <span class="tok-mi">1</span><span class="tok-p">;</span>
+  <span class="tok-p">}</span>
+<span class="tok-p">}</span></code></pre>
 </div>
 </div>
 <div class="colist arabic">
@@ -3482,50 +3543,50 @@ get the job done.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml">let test () =
-  match [%external __DEV__] with
-  | Some _ -&gt; Js.log "dev mode"
-  | None -&gt; Js.log "producton mode"</code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">test</span> <span class="tok-bp">()</span> <span class="tok-o">=</span>
+  <span class="tok-k">match</span> <span class="tok-o">[%</span><span class="tok-k">external</span> <span class="tok-o">__</span><span class="tok-n">DEV__</span><span class="tok-o">]</span> <span class="tok-k">with</span>
+  <span class="tok-o">|</span> <span class="tok-nc">Some</span> <span class="tok-o">_</span> <span class="tok-o">-&gt;</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">log</span> <span class="tok-s2">&quot;dev mode&quot;</span>
+  <span class="tok-o">|</span> <span class="tok-nc">None</span> <span class="tok-o">-&gt;</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">log</span> <span class="tok-s2">&quot;producton mode&quot;</span></code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="title">Output</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js">function test() {
-  var match = typeof (__DEV__) === "undefined" ? undefined : (__DEV__);
-  if (match !== undefined) {
-    console.log("dev mode");
-    return /* () */0;
-  }
-  else {
-    console.log("producton mode");
-    return /* () */0;
-  }
-}</code></pre>
+<pre class="pygments highlight"><code data-lang="js"><span class="tok-kd">function</span> <span class="tok-nx">test</span><span class="tok-p">()</span> <span class="tok-p">{</span>
+  <span class="tok-kd">var</span> <span class="tok-nx">match</span> <span class="tok-o">=</span> <span class="tok-k">typeof</span> <span class="tok-p">(</span><span class="tok-nx">__DEV__</span><span class="tok-p">)</span> <span class="tok-o">===</span> <span class="tok-s2">&quot;undefined&quot;</span> <span class="tok-o">?</span> <span class="tok-kc">undefined</span> <span class="tok-o">:</span> <span class="tok-p">(</span><span class="tok-nx">__DEV__</span><span class="tok-p">);</span>
+  <span class="tok-k">if</span> <span class="tok-p">(</span><span class="tok-nx">match</span> <span class="tok-o">!==</span> <span class="tok-kc">undefined</span><span class="tok-p">)</span> <span class="tok-p">{</span>
+    <span class="tok-nx">console</span><span class="tok-p">.</span><span class="tok-nx">log</span><span class="tok-p">(</span><span class="tok-s2">&quot;dev mode&quot;</span><span class="tok-p">);</span>
+    <span class="tok-k">return</span> <span class="tok-cm">/* () */</span><span class="tok-mi">0</span><span class="tok-p">;</span>
+  <span class="tok-p">}</span>
+  <span class="tok-k">else</span> <span class="tok-p">{</span>
+    <span class="tok-nx">console</span><span class="tok-p">.</span><span class="tok-nx">log</span><span class="tok-p">(</span><span class="tok-s2">&quot;producton mode&quot;</span><span class="tok-p">);</span>
+    <span class="tok-k">return</span> <span class="tok-cm">/* () */</span><span class="tok-mi">0</span><span class="tok-p">;</span>
+  <span class="tok-p">}</span>
+<span class="tok-p">}</span></code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml">let test2 () =
-  match [%external __filename] with
-  | Some f -&gt; Js.log f
-  | None -&gt; Js.log "non node environment"</code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">test2</span> <span class="tok-bp">()</span> <span class="tok-o">=</span>
+  <span class="tok-k">match</span> <span class="tok-o">[%</span><span class="tok-k">external</span> <span class="tok-o">__</span><span class="tok-n">filename</span><span class="tok-o">]</span> <span class="tok-k">with</span>
+  <span class="tok-o">|</span> <span class="tok-nc">Some</span> <span class="tok-n">f</span> <span class="tok-o">-&gt;</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">log</span> <span class="tok-n">f</span>
+  <span class="tok-o">|</span> <span class="tok-nc">None</span> <span class="tok-o">-&gt;</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">log</span> <span class="tok-s2">&quot;non node environment&quot;</span></code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="title">Output</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js">function test2() {
-  var match = typeof (__filename) === "undefined" ? undefined : (__filename);
-  if (match !== undefined) {
-    console.log(match);
-    return /* () */0;
-  }
-  else {
-    console.log("non node environment");
-    return /* () */0;
-  }
-}</code></pre>
+<pre class="pygments highlight"><code data-lang="js"><span class="tok-kd">function</span> <span class="tok-nx">test2</span><span class="tok-p">()</span> <span class="tok-p">{</span>
+  <span class="tok-kd">var</span> <span class="tok-nx">match</span> <span class="tok-o">=</span> <span class="tok-k">typeof</span> <span class="tok-p">(</span><span class="tok-nx">__filename</span><span class="tok-p">)</span> <span class="tok-o">===</span> <span class="tok-s2">&quot;undefined&quot;</span> <span class="tok-o">?</span> <span class="tok-kc">undefined</span> <span class="tok-o">:</span> <span class="tok-p">(</span><span class="tok-nx">__filename</span><span class="tok-p">);</span>
+  <span class="tok-k">if</span> <span class="tok-p">(</span><span class="tok-nx">match</span> <span class="tok-o">!==</span> <span class="tok-kc">undefined</span><span class="tok-p">)</span> <span class="tok-p">{</span>
+    <span class="tok-nx">console</span><span class="tok-p">.</span><span class="tok-nx">log</span><span class="tok-p">(</span><span class="tok-nx">match</span><span class="tok-p">);</span>
+    <span class="tok-k">return</span> <span class="tok-cm">/* () */</span><span class="tok-mi">0</span><span class="tok-p">;</span>
+  <span class="tok-p">}</span>
+  <span class="tok-k">else</span> <span class="tok-p">{</span>
+    <span class="tok-nx">console</span><span class="tok-p">.</span><span class="tok-nx">log</span><span class="tok-p">(</span><span class="tok-s2">&quot;non node environment&quot;</span><span class="tok-p">);</span>
+    <span class="tok-k">return</span> <span class="tok-cm">/* () */</span><span class="tok-mi">0</span><span class="tok-p">;</span>
+  <span class="tok-p">}</span>
+<span class="tok-p">}</span></code></pre>
 </div>
 </div>
 </div>
@@ -3533,8 +3594,8 @@ get the job done.</p>
 <h4 id="_embedding_arbitrary_js_code_as_an_expression"><a class="anchor" href="#_embedding_arbitrary_js_code_as_an_expression"></a>Embedding arbitrary JS code as an expression</h4>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml">let keys : t -&gt; string array [@bs] = [%bs.raw "Object.keys" ]
-let unsafe_lt : 'a -&gt; 'a -&gt; Js.boolean [@bs] = [%bs.raw{|function(x,y){return x &lt; y}|}]</code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">keys</span> <span class="tok-o">:</span> <span class="tok-n">t</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">string</span> <span class="tok-kt">array</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">]</span> <span class="tok-o">=</span> <span class="tok-o">[%</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">raw</span> <span class="tok-s2">&quot;Object.keys&quot;</span> <span class="tok-o">]</span>
+<span class="tok-k">let</span> <span class="tok-n">unsafe_lt</span> <span class="tok-o">:</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-o">-&gt;</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">boolean</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">]</span> <span class="tok-o">=</span> <span class="tok-o">[%</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">raw</span><span class="tok-o">{|</span><span class="tok-k">function</span><span class="tok-o">(</span><span class="tok-n">x</span><span class="tok-o">,</span><span class="tok-n">y</span><span class="tok-o">){</span><span class="tok-n">return</span> <span class="tok-n">x</span> <span class="tok-o">&lt;</span> <span class="tok-n">y</span><span class="tok-o">}|}]</span></code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -3547,9 +3608,9 @@ refer to external OCaml symbols in raw JS code.</p>
 <h4 id="_embedding_raw_js_code_as_statements"><a class="anchor" href="#_embedding_raw_js_code_as_statements"></a>Embedding raw JS code as statements</h4>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js">[%%bs.raw{|
-  console.log ("hey");
-|}]</code></pre>
+<pre class="pygments highlight"><code data-lang="js"><span class="tok-p">[</span><span class="tok-o">%%</span><span class="tok-nx">bs</span><span class="tok-p">.</span><span class="tok-nx">raw</span><span class="tok-p">{</span><span class="tok-o">|</span>
+  <span class="tok-nx">console</span><span class="tok-p">.</span><span class="tok-nx">log</span> <span class="tok-p">(</span><span class="tok-s2">&quot;hey&quot;</span><span class="tok-p">);</span>
+<span class="tok-o">|</span><span class="tok-p">}]</span></code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -3557,7 +3618,7 @@ refer to external OCaml symbols in raw JS code.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml">let x : string = [%bs.raw{|"\x01\x02"|}]</code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">x</span> <span class="tok-o">:</span> <span class="tok-kt">string</span> <span class="tok-o">=</span> <span class="tok-o">[%</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">raw</span><span class="tok-o">{|</span><span class="tok-s2">&quot;</span><span class="tok-se">\x01\x02</span><span class="tok-s2">&quot;</span><span class="tok-o">|}]</span></code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -3565,7 +3626,7 @@ refer to external OCaml symbols in raw JS code.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js">var x = "\x01\x02"</code></pre>
+<pre class="pygments highlight"><code data-lang="js"><span class="tok-kd">var</span> <span class="tok-nx">x</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;\x01\x02&quot;</span></code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -3573,12 +3634,12 @@ refer to external OCaml symbols in raw JS code.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml">   [%%bs.raw{|
-   // Math.imul polyfill
-   if (!Math.imul){
-       Math.imul = function (..) {..}
-    }
-   |}]</code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">   <span class="tok-o">[%%</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">raw</span><span class="tok-o">{|</span>
+   <span class="tok-o">//</span> <span class="tok-nn">Math</span><span class="tok-p">.</span><span class="tok-n">imul</span> <span class="tok-n">polyfill</span>
+   <span class="tok-k">if</span> <span class="tok-o">(!</span><span class="tok-nn">Math</span><span class="tok-p">.</span><span class="tok-n">imul</span><span class="tok-o">){</span>
+       <span class="tok-nn">Math</span><span class="tok-p">.</span><span class="tok-n">imul</span> <span class="tok-o">=</span> <span class="tok-k">function</span> <span class="tok-o">(..)</span> <span class="tok-o">{..}</span>
+    <span class="tok-o">}</span>
+   <span class="tok-o">|}]</span></code></pre>
 </div>
 </div>
 <div class="admonitionblock warning">
@@ -3613,9 +3674,9 @@ that the order is correct.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml">  let f x y =
-    [%bs.debugger];
-    x + y</code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml">  <span class="tok-k">let</span> <span class="tok-n">f</span> <span class="tok-n">x</span> <span class="tok-n">y</span> <span class="tok-o">=</span>
+    <span class="tok-o">[%</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">debugger</span><span class="tok-o">];</span>
+    <span class="tok-n">x</span> <span class="tok-o">+</span> <span class="tok-n">y</span></code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -3623,10 +3684,10 @@ that the order is correct.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js">  function f (x,y) {
-     debugger; // JavaScript developer tools will set an breakpoint and stop here
-     x + y;
-  }</code></pre>
+<pre class="pygments highlight"><code data-lang="js">  <span class="tok-kd">function</span> <span class="tok-nx">f</span> <span class="tok-p">(</span><span class="tok-nx">x</span><span class="tok-p">,</span><span class="tok-nx">y</span><span class="tok-p">)</span> <span class="tok-p">{</span>
+     <span class="tok-kr">debugger</span><span class="tok-p">;</span> <span class="tok-c1">// JavaScript developer tools will set an breakpoint and stop here</span>
+     <span class="tok-nx">x</span> <span class="tok-o">+</span> <span class="tok-nx">y</span><span class="tok-p">;</span>
+  <span class="tok-p">}</span></code></pre>
 </div>
 </div>
 </div>
@@ -3637,7 +3698,7 @@ that the order is correct.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml">let f = [%bs.re "/b/g"]</code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">f</span> <span class="tok-o">=</span> <span class="tok-o">[%</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">re</span> <span class="tok-s2">&quot;/b/g&quot;</span><span class="tok-o">]</span></code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -3677,8 +3738,8 @@ more examples, please visit
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml">external describe : string -&gt; (unit -&gt; unit [@bs]) -&gt; unit = "" [@@bs.val]
-external it : string -&gt; (unit -&gt; unit [@bs]) -&gt; unit = "" [@@bs.val]</code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">external</span> <span class="tok-n">describe</span> <span class="tok-o">:</span> <span class="tok-kt">string</span> <span class="tok-o">-&gt;</span> <span class="tok-o">(</span><span class="tok-kt">unit</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">unit</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">])</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">unit</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">val</span><span class="tok-o">]</span>
+<span class="tok-k">external</span> <span class="tok-n">it</span> <span class="tok-o">:</span> <span class="tok-kt">string</span> <span class="tok-o">-&gt;</span> <span class="tok-o">(</span><span class="tok-kt">unit</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">unit</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">])</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">unit</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">val</span><span class="tok-o">]</span></code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -3688,7 +3749,7 @@ external it : string -&gt; (unit -&gt; unit [@bs]) -&gt; unit = "" [@@bs.val]</c
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml">external eq : 'a -&gt; 'a -&gt; unit = "deepEqual" [@@bs.module "assert"]</code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">external</span> <span class="tok-n">eq</span> <span class="tok-o">:</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">unit</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;deepEqual&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">module</span> <span class="tok-s2">&quot;assert&quot;</span><span class="tok-o">]</span></code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -3696,11 +3757,11 @@ external it : string -&gt; (unit -&gt; unit [@bs]) -&gt; unit = "" [@@bs.val]</c
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml">let assert_equal = eq
-let from_suites name suite =
-    describe name (fun [@bs] () -&gt;
-         List.iter (fun (name, code) -&gt; it name code) suite
-         )</code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">assert_equal</span> <span class="tok-o">=</span> <span class="tok-n">eq</span>
+<span class="tok-k">let</span> <span class="tok-n">from_suites</span> <span class="tok-n">name</span> <span class="tok-n">suite</span> <span class="tok-o">=</span>
+    <span class="tok-n">describe</span> <span class="tok-n">name</span> <span class="tok-o">(</span><span class="tok-k">fun</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">]</span> <span class="tok-bp">()</span> <span class="tok-o">-&gt;</span>
+         <span class="tok-nn">List</span><span class="tok-p">.</span><span class="tok-n">iter</span> <span class="tok-o">(</span><span class="tok-k">fun</span> <span class="tok-o">(</span><span class="tok-n">name</span><span class="tok-o">,</span> <span class="tok-n">code</span><span class="tok-o">)</span> <span class="tok-o">-&gt;</span> <span class="tok-n">it</span> <span class="tok-n">name</span> <span class="tok-n">code</span><span class="tok-o">)</span> <span class="tok-n">suite</span>
+         <span class="tok-o">)</span></code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -3708,20 +3769,20 @@ let from_suites name suite =
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js"> var Assert = require("assert");
- var List = require("bs-platform/lib/js/list");
+<pre class="pygments highlight"><code data-lang="js"> <span class="tok-kd">var</span> <span class="tok-nx">Assert</span> <span class="tok-o">=</span> <span class="tok-nx">require</span><span class="tok-p">(</span><span class="tok-s2">&quot;assert&quot;</span><span class="tok-p">);</span>
+ <span class="tok-kd">var</span> <span class="tok-nx">List</span> <span class="tok-o">=</span> <span class="tok-nx">require</span><span class="tok-p">(</span><span class="tok-s2">&quot;bs-platform/lib/js/list&quot;</span><span class="tok-p">);</span>
 
-function assert_equal(prim, prim$1) {
- return Assert.deepEqual(prim, prim$1);
- }
+<span class="tok-kd">function</span> <span class="tok-nx">assert_equal</span><span class="tok-p">(</span><span class="tok-nx">prim</span><span class="tok-p">,</span> <span class="tok-nx">prim$1</span><span class="tok-p">)</span> <span class="tok-p">{</span>
+ <span class="tok-k">return</span> <span class="tok-nx">Assert</span><span class="tok-p">.</span><span class="tok-nx">deepEqual</span><span class="tok-p">(</span><span class="tok-nx">prim</span><span class="tok-p">,</span> <span class="tok-nx">prim$1</span><span class="tok-p">);</span>
+ <span class="tok-p">}</span>
 
-function from_suites(name, suite) {
- return describe(name, function () {
-   return List.iter(function (param) {
-    return it(param[0], param[1]);
-      }, suite);
-  });
- }</code></pre>
+<span class="tok-kd">function</span> <span class="tok-nx">from_suites</span><span class="tok-p">(</span><span class="tok-nx">name</span><span class="tok-p">,</span> <span class="tok-nx">suite</span><span class="tok-p">)</span> <span class="tok-p">{</span>
+ <span class="tok-k">return</span> <span class="tok-nx">describe</span><span class="tok-p">(</span><span class="tok-nx">name</span><span class="tok-p">,</span> <span class="tok-kd">function</span> <span class="tok-p">()</span> <span class="tok-p">{</span>
+   <span class="tok-k">return</span> <span class="tok-nx">List</span><span class="tok-p">.</span><span class="tok-nx">iter</span><span class="tok-p">(</span><span class="tok-kd">function</span> <span class="tok-p">(</span><span class="tok-nx">param</span><span class="tok-p">)</span> <span class="tok-p">{</span>
+    <span class="tok-k">return</span> <span class="tok-nx">it</span><span class="tok-p">(</span><span class="tok-nx">param</span><span class="tok-p">[</span><span class="tok-mi">0</span><span class="tok-p">],</span> <span class="tok-nx">param</span><span class="tok-p">[</span><span class="tok-mi">1</span><span class="tok-p">]);</span>
+      <span class="tok-p">},</span> <span class="tok-nx">suite</span><span class="tok-p">);</span>
+  <span class="tok-p">});</span>
+ <span class="tok-p">}</span></code></pre>
 </div>
 </div>
 </div>
@@ -3741,16 +3802,16 @@ function from_suites(name, suite) {
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml">let example1 () =
-    match Js.Json.exnParse {| {"x" }|} with
-    | exception Js.Exn.Error err -&gt;
-        Js.log @@ Js.Exn.stack err;
-        None
-    | v -&gt; Some v
+<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">example1</span> <span class="tok-bp">()</span> <span class="tok-o">=</span>
+    <span class="tok-k">match</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-nn">Json</span><span class="tok-p">.</span><span class="tok-n">exnParse</span> <span class="tok-o">{|</span> <span class="tok-o">{</span><span class="tok-s2">&quot;x&quot;</span> <span class="tok-o">}|}</span> <span class="tok-k">with</span>
+    <span class="tok-o">|</span> <span class="tok-k">exception</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-nn">Exn</span><span class="tok-p">.</span><span class="tok-nc">Error</span> <span class="tok-n">err</span> <span class="tok-o">-&gt;</span>
+        <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">log</span> <span class="tok-o">@@</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-nn">Exn</span><span class="tok-p">.</span><span class="tok-n">stack</span> <span class="tok-n">err</span><span class="tok-o">;</span>
+        <span class="tok-nc">None</span>
+    <span class="tok-o">|</span> <span class="tok-n">v</span> <span class="tok-o">-&gt;</span> <span class="tok-nc">Some</span> <span class="tok-n">v</span>
 
-let example2 () =
-    try Some (Js.Json.exnParse {| {"x"}|}) with
-    Js.Exn.Error _ -&gt; None</code></pre>
+<span class="tok-k">let</span> <span class="tok-n">example2</span> <span class="tok-bp">()</span> <span class="tok-o">=</span>
+    <span class="tok-k">try</span> <span class="tok-nc">Some</span> <span class="tok-o">(</span><span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-nn">Json</span><span class="tok-p">.</span><span class="tok-n">exnParse</span> <span class="tok-o">{|</span> <span class="tok-o">{</span><span class="tok-s2">&quot;x&quot;</span><span class="tok-o">}|})</span> <span class="tok-k">with</span>
+    <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-nn">Exn</span><span class="tok-p">.</span><span class="tok-nc">Error</span> <span class="tok-o">_</span> <span class="tok-o">-&gt;</span> <span class="tok-nc">None</span></code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -3758,14 +3819,14 @@ let example2 () =
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml">type t =
-  &lt; stack : string Js.undefined ;
-    message : string Js.undefined ;
-    name : string Js.undefined;
-    fileName : string Js.undefined
-  &gt; Js.t
+<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">type</span> <span class="tok-n">t</span> <span class="tok-o">=</span>
+  <span class="tok-o">&lt;</span> <span class="tok-n">stack</span> <span class="tok-o">:</span> <span class="tok-kt">string</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">undefined</span> <span class="tok-o">;</span>
+    <span class="tok-n">message</span> <span class="tok-o">:</span> <span class="tok-kt">string</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">undefined</span> <span class="tok-o">;</span>
+    <span class="tok-n">name</span> <span class="tok-o">:</span> <span class="tok-kt">string</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">undefined</span><span class="tok-o">;</span>
+    <span class="tok-n">fileName</span> <span class="tok-o">:</span> <span class="tok-kt">string</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">undefined</span>
+  <span class="tok-o">&gt;</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">t</span>
 
-exception Error of t</code></pre>
+<span class="tok-k">exception</span> <span class="tok-nc">Error</span> <span class="tok-k">of</span> <span class="tok-n">t</span></code></pre>
 </div>
 </div>
 </div>
@@ -3776,14 +3837,14 @@ exception Error of t</code></pre>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml">(** Raise Js exception Error object with stacktrace *)
-val error : string -&gt; 'a
-val evalError : string -&gt; 'a
-val rangeError : string -&gt; 'a
-val referenceError : string -&gt; 'a
-val syntaxError : string -&gt; 'a
-val typeError : string -&gt; 'a
-val uriError : string -&gt; 'a</code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-c">(** Raise Js exception Error object with stacktrace *)</span>
+<span class="tok-k">val</span> <span class="tok-n">error</span> <span class="tok-o">:</span> <span class="tok-kt">string</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span>
+<span class="tok-k">val</span> <span class="tok-n">evalError</span> <span class="tok-o">:</span> <span class="tok-kt">string</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span>
+<span class="tok-k">val</span> <span class="tok-n">rangeError</span> <span class="tok-o">:</span> <span class="tok-kt">string</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span>
+<span class="tok-k">val</span> <span class="tok-n">referenceError</span> <span class="tok-o">:</span> <span class="tok-kt">string</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span>
+<span class="tok-k">val</span> <span class="tok-n">syntaxError</span> <span class="tok-o">:</span> <span class="tok-kt">string</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span>
+<span class="tok-k">val</span> <span class="tok-n">typeError</span> <span class="tok-o">:</span> <span class="tok-kt">string</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span>
+<span class="tok-k">val</span> <span class="tok-n">uriError</span> <span class="tok-o">:</span> <span class="tok-kt">string</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span></code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -3809,12 +3870,12 @@ it preserves the type safety while allow uesrs to deal with mixed source.</p>
 <div class="listingblock">
 <div class="title">Example</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml">let handleData = function [@bs.open]
-   | Invalid_argument _ -&gt; 0
-   | Not_found -&gt; 1
-   | Sys_error _ -&gt; 2
+<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">handleData</span> <span class="tok-o">=</span> <span class="tok-k">function</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">open</span><span class="tok-o">]</span>
+   <span class="tok-o">|</span> <span class="tok-nc">Invalid_argument</span> <span class="tok-o">_</span> <span class="tok-o">-&gt;</span> <span class="tok-mi">0</span>
+   <span class="tok-o">|</span> <span class="tok-nc">Not_found</span> <span class="tok-o">-&gt;</span> <span class="tok-mi">1</span>
+   <span class="tok-o">|</span> <span class="tok-nc">Sys_error</span> <span class="tok-o">_</span> <span class="tok-o">-&gt;</span> <span class="tok-mi">2</span>
 
-val handleData : 'a -&gt; int option <b class="conum">(1)</b></code></pre>
+<span class="tok-k">val</span> <span class="tok-n">handleData</span> <span class="tok-o">:</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-n">option</span> <b class="conum">(1)</b></code></pre>
 </div>
 </div>
 <div class="colist arabic">
@@ -3831,17 +3892,17 @@ val handleData : 'a -&gt; int option <b class="conum">(1)</b></code></pre>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml">let v = Promise.reject Not_found
-let handlePromiseFaiure = function [@bs.open]
-   | Not_found -&gt; Js.log "Not found"; (Promise.resolve ())
+<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">v</span> <span class="tok-o">=</span> <span class="tok-nn">Promise</span><span class="tok-p">.</span><span class="tok-n">reject</span> <span class="tok-nc">Not_found</span>
+<span class="tok-k">let</span> <span class="tok-n">handlePromiseFaiure</span> <span class="tok-o">=</span> <span class="tok-k">function</span> <span class="tok-o">[@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">open</span><span class="tok-o">]</span>
+   <span class="tok-o">|</span> <span class="tok-nc">Not_found</span> <span class="tok-o">-&gt;</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">log</span> <span class="tok-s2">&quot;Not found&quot;</span><span class="tok-o">;</span> <span class="tok-o">(</span><span class="tok-nn">Promise</span><span class="tok-p">.</span><span class="tok-n">resolve</span> <span class="tok-bp">()</span><span class="tok-o">)</span>
 
-let () =
-   v
-   |&gt; Promise.catch (fun error -&gt;
-        match handlePromiseFaiure error with
-        | Some x -&gt; x
-        | None -&gt; raise UnhandledPromise
-    )</code></pre>
+<span class="tok-k">let</span> <span class="tok-bp">()</span> <span class="tok-o">=</span>
+   <span class="tok-n">v</span>
+   <span class="tok-o">|&gt;</span> <span class="tok-nn">Promise</span><span class="tok-p">.</span><span class="tok-n">catch</span> <span class="tok-o">(</span><span class="tok-k">fun</span> <span class="tok-n">error</span> <span class="tok-o">-&gt;</span>
+        <span class="tok-k">match</span> <span class="tok-n">handlePromiseFaiure</span> <span class="tok-n">error</span> <span class="tok-k">with</span>
+        <span class="tok-o">|</span> <span class="tok-nc">Some</span> <span class="tok-n">x</span> <span class="tok-o">-&gt;</span> <span class="tok-n">x</span>
+        <span class="tok-o">|</span> <span class="tok-nc">None</span> <span class="tok-o">-&gt;</span> <span class="tok-k">raise</span> <span class="tok-nc">UnhandledPromise</span>
+    <span class="tok-o">)</span></code></pre>
 </div>
 </div>
 </div>
@@ -3874,15 +3935,15 @@ want to use them with. For this purpose BuckleScript defines the type <code>'a J
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml">external get_prop_name_maybe : unit -&gt; string Js.null = "" [@@bs.val]
-external set_or_unset_prop : string -&gt; int Js.null -&gt; unit = "" [@@bs.val]
+<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">external</span> <span class="tok-n">get_prop_name_maybe</span> <span class="tok-o">:</span> <span class="tok-kt">unit</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">string</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">null</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">val</span><span class="tok-o">]</span>
+<span class="tok-k">external</span> <span class="tok-n">set_or_unset_prop</span> <span class="tok-o">:</span> <span class="tok-kt">string</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">null</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">unit</span> <span class="tok-o">=</span> <span class="tok-s2">&quot;&quot;</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-k">val</span><span class="tok-o">]</span>
 
-(* unset property if fond *)
-let s = get_prop_name_maybe ()
-let _ = Js.Null.iter s (function name -&gt; set_or_unset_prop name Js.Null.empty)
+<span class="tok-c">(* unset property if fond *)</span>
+<span class="tok-k">let</span> <span class="tok-n">s</span> <span class="tok-o">=</span> <span class="tok-n">get_prop_name_maybe</span> <span class="tok-bp">()</span>
+<span class="tok-k">let</span> <span class="tok-o">_</span> <span class="tok-o">=</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-nn">Null</span><span class="tok-p">.</span><span class="tok-n">iter</span> <span class="tok-n">s</span> <span class="tok-o">(</span><span class="tok-k">function</span> <span class="tok-n">name</span> <span class="tok-o">-&gt;</span> <span class="tok-n">set_or_unset_prop</span> <span class="tok-n">name</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-nn">Null</span><span class="tok-p">.</span><span class="tok-n">empty</span><span class="tok-o">)</span>
 
-(* set some other property *)
-let _ = set_or_unset_prop "some_other_property" (Js.Null.return "")</code></pre>
+<span class="tok-c">(* set some other property *)</span>
+<span class="tok-k">let</span> <span class="tok-o">_</span> <span class="tok-o">=</span> <span class="tok-n">set_or_unset_prop</span> <span class="tok-s2">&quot;some_other_property&quot;</span> <span class="tok-o">(</span><span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-nn">Null</span><span class="tok-p">.</span><span class="tok-n">return</span> <span class="tok-s2">&quot;&quot;</span><span class="tok-o">)</span></code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -3892,10 +3953,10 @@ to maintain:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml">external try_some_thing : string Js.null -&gt; int Js.null = ...
+<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">external</span> <span class="tok-n">try_some_thing</span> <span class="tok-o">:</span> <span class="tok-kt">string</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">null</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-n">null</span> <span class="tok-o">=</span> <span class="tok-o">...</span>
 
-let try_some_thing_maybe ( v : string option) : int option =
-  Js.Null.to_opt (try_some_thing (Js.Null.from_opt v))</code></pre>
+<span class="tok-k">let</span> <span class="tok-n">try_some_thing_maybe</span> <span class="tok-o">(</span> <span class="tok-n">v</span> <span class="tok-o">:</span> <span class="tok-kt">string</span> <span class="tok-n">option</span><span class="tok-o">)</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-n">option</span> <span class="tok-o">=</span>
+  <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-nn">Null</span><span class="tok-p">.</span><span class="tok-n">to_opt</span> <span class="tok-o">(</span><span class="tok-n">try_some_thing</span> <span class="tok-o">(</span><span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-nn">Null</span><span class="tok-p">.</span><span class="tok-n">from_opt</span> <span class="tok-n">v</span><span class="tok-o">))</span></code></pre>
 </div>
 </div>
 </div>
@@ -4164,33 +4225,33 @@ TypeScript. This is still experimental.</p>
 <div class="listingblock">
 <div class="title">Example</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="sh">bsc.exe -dparsetree -drawlambda -bs-eval 'Js.log "hello"'</code></pre>
+<pre class="pygments highlight"><code data-lang="sh">bsc.exe -dparsetree -drawlambda -bs-eval <span class="tok-s1">&#39;Js.log &quot;hello&quot;&#39;</span></code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml">[ <b class="conum">(1)</b>
-  structure_item (//toplevel//[1,0+0]..[1,0+14])
-    Pstr_eval
-    expression (//toplevel//[1,0+0]..[1,0+14])
-      Pexp_apply
-      expression (//toplevel//[1,0+0]..[1,0+6])
-        Pexp_ident "Js.log" (//toplevel//[1,0+0]..[1,0+6])
-      [
-        &lt;label&gt; ""
-          expression (//toplevel//[1,0+7]..[1,0+14])
-            Pexp_constant Const_string("hello",None)
-      ]
-]
+<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-o">[</span> <b class="conum">(1)</b>
+  <span class="tok-n">structure_item</span> <span class="tok-o">(//</span><span class="tok-n">toplevel</span><span class="tok-o">//[</span><span class="tok-mi">1</span><span class="tok-o">,</span><span class="tok-mi">0</span><span class="tok-o">+</span><span class="tok-mi">0</span><span class="tok-o">]..[</span><span class="tok-mi">1</span><span class="tok-o">,</span><span class="tok-mi">0</span><span class="tok-o">+</span><span class="tok-mi">14</span><span class="tok-o">])</span>
+    <span class="tok-nc">Pstr_eval</span>
+    <span class="tok-n">expression</span> <span class="tok-o">(//</span><span class="tok-n">toplevel</span><span class="tok-o">//[</span><span class="tok-mi">1</span><span class="tok-o">,</span><span class="tok-mi">0</span><span class="tok-o">+</span><span class="tok-mi">0</span><span class="tok-o">]..[</span><span class="tok-mi">1</span><span class="tok-o">,</span><span class="tok-mi">0</span><span class="tok-o">+</span><span class="tok-mi">14</span><span class="tok-o">])</span>
+      <span class="tok-nc">Pexp_apply</span>
+      <span class="tok-n">expression</span> <span class="tok-o">(//</span><span class="tok-n">toplevel</span><span class="tok-o">//[</span><span class="tok-mi">1</span><span class="tok-o">,</span><span class="tok-mi">0</span><span class="tok-o">+</span><span class="tok-mi">0</span><span class="tok-o">]..[</span><span class="tok-mi">1</span><span class="tok-o">,</span><span class="tok-mi">0</span><span class="tok-o">+</span><span class="tok-mi">6</span><span class="tok-o">])</span>
+        <span class="tok-nc">Pexp_ident</span> <span class="tok-s2">&quot;Js.log&quot;</span> <span class="tok-o">(//</span><span class="tok-n">toplevel</span><span class="tok-o">//[</span><span class="tok-mi">1</span><span class="tok-o">,</span><span class="tok-mi">0</span><span class="tok-o">+</span><span class="tok-mi">0</span><span class="tok-o">]..[</span><span class="tok-mi">1</span><span class="tok-o">,</span><span class="tok-mi">0</span><span class="tok-o">+</span><span class="tok-mi">6</span><span class="tok-o">])</span>
+      <span class="tok-o">[</span>
+        <span class="tok-o">&lt;</span><span class="tok-n">label</span><span class="tok-o">&gt;</span> <span class="tok-s2">&quot;&quot;</span>
+          <span class="tok-n">expression</span> <span class="tok-o">(//</span><span class="tok-n">toplevel</span><span class="tok-o">//[</span><span class="tok-mi">1</span><span class="tok-o">,</span><span class="tok-mi">0</span><span class="tok-o">+</span><span class="tok-mi">7</span><span class="tok-o">]..[</span><span class="tok-mi">1</span><span class="tok-o">,</span><span class="tok-mi">0</span><span class="tok-o">+</span><span class="tok-mi">14</span><span class="tok-o">])</span>
+            <span class="tok-nc">Pexp_constant</span> <span class="tok-nc">Const_string</span><span class="tok-o">(</span><span class="tok-s2">&quot;hello&quot;</span><span class="tok-o">,</span><span class="tok-nc">None</span><span class="tok-o">)</span>
+      <span class="tok-o">]</span>
+<span class="tok-o">]</span>
 <b class="conum">(2)</b>
-(setglobal Bs_internal_eval! (seq (js_dump "hello") (makeblock 0)))
-// Generated by BUCKLESCRIPT VERSION 1.0.2 , PLEASE EDIT WITH CARE
-'use strict';
+<span class="tok-o">(</span><span class="tok-n">setglobal</span> <span class="tok-nc">Bs_internal_eval</span><span class="tok-o">!</span> <span class="tok-o">(</span><span class="tok-n">seq</span> <span class="tok-o">(</span><span class="tok-n">js_dump</span> <span class="tok-s2">&quot;hello&quot;</span><span class="tok-o">)</span> <span class="tok-o">(</span><span class="tok-n">makeblock</span> <span class="tok-mi">0</span><span class="tok-o">)))</span>
+<span class="tok-o">//</span> <span class="tok-nc">Generated</span> <span class="tok-n">by</span> <span class="tok-nc">BUCKLESCRIPT</span> <span class="tok-nc">VERSION</span> <span class="tok-mi">1</span><span class="tok-o">.</span><span class="tok-mi">0</span><span class="tok-o">.</span><span class="tok-mi">2</span> <span class="tok-o">,</span> <span class="tok-nc">PLEASE</span> <span class="tok-nc">EDIT</span> <span class="tok-nc">WITH</span> <span class="tok-nc">CARE</span>
+<span class="tok-k">&#39;</span><span class="tok-n">use</span> <span class="tok-n">strict&#39;</span><span class="tok-o">;</span>
 
 
-console.log("hello");
+<span class="tok-n">console</span><span class="tok-o">.</span><span class="tok-n">log</span><span class="tok-o">(</span><span class="tok-s2">&quot;hello&quot;</span><span class="tok-o">);</span>
 
-/*  Not a pure module */</code></pre>
+<span class="tok-o">/*</span>  <span class="tok-nc">Not</span> <span class="tok-n">a</span> <span class="tok-n">pure</span> <span class="tok-k">module</span> <span class="tok-o">*/</span></code></pre>
 </div>
 </div>
 <div class="colist arabic">
@@ -4216,7 +4277,7 @@ Another use case is that users can use <code>-ppx</code> explicitly as below:</p
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml">bsc.exe -c -ppx bsppx.exe -bs-no-builtin-ppx-ml c.ml</code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-n">bsc</span><span class="tok-o">.</span><span class="tok-n">exe</span> <span class="tok-o">-</span><span class="tok-n">c</span> <span class="tok-o">-</span><span class="tok-n">ppx</span> <span class="tok-n">bsppx</span><span class="tok-o">.</span><span class="tok-n">exe</span> <span class="tok-o">-</span><span class="tok-n">bs</span><span class="tok-o">-</span><span class="tok-n">no</span><span class="tok-o">-</span><span class="tok-n">builtin</span><span class="tok-o">-</span><span class="tok-n">ppx</span><span class="tok-o">-</span><span class="tok-n">ml</span> <span class="tok-n">c</span><span class="tok-o">.</span><span class="tok-n">ml</span></code></pre>
 </div>
 </div>
 </div>
@@ -4438,13 +4499,13 @@ it would be string</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml">semver Location.none "1.2.3" "~1.3.0" = false;;
-semver Location.none "1.2.3" "^1.3.0" = true ;;
-semver Location.none "1.2.3" "&gt;1.3.0" = false ;;
-semver Location.none "1.2.3" "&gt;=1.3.0" = false ;;
-semver Location.none "1.2.3" "&lt;1.3.0" = true ;;
-semver Location.none "1.2.3" "&lt;=1.3.0" = true ;;
-semver Location.none "1.2.3" "1.2.3" = true;;</code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-n">semver</span> <span class="tok-nn">Location</span><span class="tok-p">.</span><span class="tok-n">none</span> <span class="tok-s2">&quot;1.2.3&quot;</span> <span class="tok-s2">&quot;~1.3.0&quot;</span> <span class="tok-o">=</span> <span class="tok-bp">false</span><span class="tok-o">;;</span>
+<span class="tok-n">semver</span> <span class="tok-nn">Location</span><span class="tok-p">.</span><span class="tok-n">none</span> <span class="tok-s2">&quot;1.2.3&quot;</span> <span class="tok-s2">&quot;^1.3.0&quot;</span> <span class="tok-o">=</span> <span class="tok-bp">true</span> <span class="tok-o">;;</span>
+<span class="tok-n">semver</span> <span class="tok-nn">Location</span><span class="tok-p">.</span><span class="tok-n">none</span> <span class="tok-s2">&quot;1.2.3&quot;</span> <span class="tok-s2">&quot;&gt;1.3.0&quot;</span> <span class="tok-o">=</span> <span class="tok-bp">false</span> <span class="tok-o">;;</span>
+<span class="tok-n">semver</span> <span class="tok-nn">Location</span><span class="tok-p">.</span><span class="tok-n">none</span> <span class="tok-s2">&quot;1.2.3&quot;</span> <span class="tok-s2">&quot;&gt;=1.3.0&quot;</span> <span class="tok-o">=</span> <span class="tok-bp">false</span> <span class="tok-o">;;</span>
+<span class="tok-n">semver</span> <span class="tok-nn">Location</span><span class="tok-p">.</span><span class="tok-n">none</span> <span class="tok-s2">&quot;1.2.3&quot;</span> <span class="tok-s2">&quot;&lt;1.3.0&quot;</span> <span class="tok-o">=</span> <span class="tok-bp">true</span> <span class="tok-o">;;</span>
+<span class="tok-n">semver</span> <span class="tok-nn">Location</span><span class="tok-p">.</span><span class="tok-n">none</span> <span class="tok-s2">&quot;1.2.3&quot;</span> <span class="tok-s2">&quot;&lt;=1.3.0&quot;</span> <span class="tok-o">=</span> <span class="tok-bp">true</span> <span class="tok-o">;;</span>
+<span class="tok-n">semver</span> <span class="tok-nn">Location</span><span class="tok-p">.</span><span class="tok-n">none</span> <span class="tok-s2">&quot;1.2.3&quot;</span> <span class="tok-s2">&quot;1.2.3&quot;</span> <span class="tok-o">=</span> <span class="tok-bp">true</span><span class="tok-o">;;</span></code></pre>
 </div>
 </div>
 </div>
@@ -4453,26 +4514,26 @@ semver Location.none "1.2.3" "1.2.3" = true;;</code></pre>
 <div class="listingblock">
 <div class="title">lwt_unix.mli</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml">type open_flag =
-    Unix.open_flag =
-  | O_RDONLY
-  | O_WRONLY
-  | O_RDWR
-  | O_NONBLOCK
-  | O_APPEND
-  | O_CREAT
-  | O_TRUNC
-  | O_EXCL
-  | O_NOCTTY
-  | O_DSYNC
-  | O_SYNC
-  | O_RSYNC
-#if OCAML_VERSION =~ "&gt;=3.13" then
-  | O_SHARE_DELETE
-#end
-#if OCAML_VERSION =~ "&gt;=4.01" then
-  | O_CLOEXEC
-#end</code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">type</span> <span class="tok-n">open_flag</span> <span class="tok-o">=</span>
+    <span class="tok-nn">Unix</span><span class="tok-p">.</span><span class="tok-n">open_flag</span> <span class="tok-o">=</span>
+  <span class="tok-o">|</span> <span class="tok-nc">O_RDONLY</span>
+  <span class="tok-o">|</span> <span class="tok-nc">O_WRONLY</span>
+  <span class="tok-o">|</span> <span class="tok-nc">O_RDWR</span>
+  <span class="tok-o">|</span> <span class="tok-nc">O_NONBLOCK</span>
+  <span class="tok-o">|</span> <span class="tok-nc">O_APPEND</span>
+  <span class="tok-o">|</span> <span class="tok-nc">O_CREAT</span>
+  <span class="tok-o">|</span> <span class="tok-nc">O_TRUNC</span>
+  <span class="tok-o">|</span> <span class="tok-nc">O_EXCL</span>
+  <span class="tok-o">|</span> <span class="tok-nc">O_NOCTTY</span>
+  <span class="tok-o">|</span> <span class="tok-nc">O_DSYNC</span>
+  <span class="tok-o">|</span> <span class="tok-nc">O_SYNC</span>
+  <span class="tok-o">|</span> <span class="tok-nc">O_RSYNC</span>
+<span class="tok-o">#</span><span class="tok-k">if</span> <span class="tok-nc">OCAML_VERSION</span> <span class="tok-o">=~</span> <span class="tok-s2">&quot;&gt;=3.13&quot;</span> <span class="tok-k">then</span>
+  <span class="tok-o">|</span> <span class="tok-nc">O_SHARE_DELETE</span>
+<span class="tok-o">#</span><span class="tok-k">end</span>
+<span class="tok-o">#</span><span class="tok-k">if</span> <span class="tok-nc">OCAML_VERSION</span> <span class="tok-o">=~</span> <span class="tok-s2">&quot;&gt;=4.01&quot;</span> <span class="tok-k">then</span>
+  <span class="tok-o">|</span> <span class="tok-nc">O_CLOEXEC</span>
+<span class="tok-o">#</span><span class="tok-k">end</span></code></pre>
 </div>
 </div>
 </div>
@@ -4480,15 +4541,15 @@ semver Location.none "1.2.3" "1.2.3" = true;;</code></pre>
 <h3 id="_built_in_variables_and_custom_variables"><a class="anchor" href="#_built_in_variables_and_custom_variables"></a>Built in variables and custom variables</h3>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="sh">ocamlscript&gt;bsc.exe -bs-D CUSTOM_A="ghsigh" -bs-list-conditionals
-OCAML_PATCH "BS"
-BS_VERSION "1.2.1"
-OS_TYPE "Unix"
-BS true
-CUSTOM_A "ghsigh"
+<pre class="pygments highlight"><code data-lang="sh">ocamlscript&gt;bsc.exe -bs-D <span class="tok-nv">CUSTOM_A</span><span class="tok-o">=</span><span class="tok-s2">&quot;ghsigh&quot;</span> -bs-list-conditionals
+OCAML_PATCH <span class="tok-s2">&quot;BS&quot;</span>
+BS_VERSION <span class="tok-s2">&quot;1.2.1&quot;</span>
+OS_TYPE <span class="tok-s2">&quot;Unix&quot;</span>
+BS <span class="tok-nb">true</span>
+CUSTOM_A <span class="tok-s2">&quot;ghsigh&quot;</span>
 WORD_SIZE 64
-OCAML_VERSION "4.02.3+BS"
-BIG_ENDIAN false</code></pre>
+OCAML_VERSION <span class="tok-s2">&quot;4.02.3+BS&quot;</span>
+BIG_ENDIAN <span class="tok-nb">false</span></code></pre>
 </div>
 </div>
 </div>
@@ -4505,8 +4566,8 @@ so that it even works without compilation.</p>
 <div class="title">Example</div>
 <div class="content">
 <pre class="pygments highlight"><code data-lang="sh">bsc.exe -c lwt_unix.mli
-ocamlc -pp 'bspp.exe' -c lwt_unix.mli
-ocamlc -pp 'ocaml -w -a bspp.ml' -c lwt_unix.mli</code></pre>
+ocamlc -pp <span class="tok-s1">&#39;bspp.exe&#39;</span> -c lwt_unix.mli
+ocamlc -pp <span class="tok-s1">&#39;ocaml -w -a bspp.ml&#39;</span> -c lwt_unix.mli</code></pre>
 </div>
 </div>
 <div class="admonitionblock warning">
@@ -4521,9 +4582,9 @@ ocamlc -pp 'ocaml -w -a bspp.ml' -c lwt_unix.mli</code></pre>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml">let f x =
-  x
-#elif <b class="conum">(1)</b></code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">f</span> <span class="tok-n">x</span> <span class="tok-o">=</span>
+  <span class="tok-n">x</span>
+<span class="tok-o">#</span><span class="tok-n">elif</span> <b class="conum">(1)</b></code></pre>
 </div>
 </div>
 <div class="colist arabic">
@@ -4582,17 +4643,17 @@ below is a configuration to help you get auto-completion and validation for free
 <div class="listingblock">
 <div class="title">settings.json</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js">{
-    "json.schemas": [
-        {
-            "fileMatch": [
-                "bsconfig.json"
-            ],
-            "url" : "file:///path/to/bucklescript/docs/docson/build-schema.json" <b class="conum">(1)</b>
-        }
-    ],
-    // ....
-}</code></pre>
+<pre class="pygments highlight"><code data-lang="js"><span class="tok-p">{</span>
+    <span class="tok-s2">&quot;json.schemas&quot;</span><span class="tok-o">:</span> <span class="tok-p">[</span>
+        <span class="tok-p">{</span>
+            <span class="tok-s2">&quot;fileMatch&quot;</span><span class="tok-o">:</span> <span class="tok-p">[</span>
+                <span class="tok-s2">&quot;bsconfig.json&quot;</span>
+            <span class="tok-p">],</span>
+            <span class="tok-s2">&quot;url&quot;</span> <span class="tok-o">:</span> <span class="tok-s2">&quot;file:///path/to/bucklescript/docs/docson/build-schema.json&quot;</span> <b class="conum">(1)</b>
+        <span class="tok-p">}</span>
+    <span class="tok-p">],</span>
+    <span class="tok-c1">// ....</span>
+<span class="tok-p">}</span></code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -4606,10 +4667,10 @@ either <code>bsb</code> (slightly higher latency but symlinked into <code>.bin</
 <div class="listingblock">
 <div class="title">bsconfig.json</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js">{
-  "name": "test", // package name, required <b class="conum">(1)</b>
-  "sources": "src" <b class="conum">(2)</b>
-}</code></pre>
+<pre class="pygments highlight"><code data-lang="js"><span class="tok-p">{</span>
+  <span class="tok-s2">&quot;name&quot;</span><span class="tok-o">:</span> <span class="tok-s2">&quot;test&quot;</span><span class="tok-p">,</span> <span class="tok-c1">// package name, required </span><b class="conum">(1)</b>
+  <span class="tok-s2">&quot;sources&quot;</span><span class="tok-o">:</span> <span class="tok-s2">&quot;src&quot;</span> <b class="conum">(2)</b>
+<span class="tok-p">}</span></code></pre>
 </div>
 </div>
 <div class="colist arabic">
@@ -4691,17 +4752,17 @@ bsb -w <b class="conum">(2)</b></code></pre>
 <div class="listingblock">
 <div class="title">bsconfig.json</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js">{
-    "name": "bs-string",
-    "version": "0.1.3",
-    "bs-dependencies": [
-        "bs-mocha" <b class="conum">(1)</b>
-    ],
-    "sources": [
-       .. .
-    ],
-    "generate-merlin" : false <b class="conum">(2)</b>
-}</code></pre>
+<pre class="pygments highlight"><code data-lang="js"><span class="tok-p">{</span>
+    <span class="tok-s2">&quot;name&quot;</span><span class="tok-o">:</span> <span class="tok-s2">&quot;bs-string&quot;</span><span class="tok-p">,</span>
+    <span class="tok-s2">&quot;version&quot;</span><span class="tok-o">:</span> <span class="tok-s2">&quot;0.1.3&quot;</span><span class="tok-p">,</span>
+    <span class="tok-s2">&quot;bs-dependencies&quot;</span><span class="tok-o">:</span> <span class="tok-p">[</span>
+        <span class="tok-s2">&quot;bs-mocha&quot;</span> <b class="conum">(1)</b>
+    <span class="tok-p">],</span>
+    <span class="tok-s2">&quot;sources&quot;</span><span class="tok-o">:</span> <span class="tok-p">[</span>
+       <span class="tok-p">..</span> <span class="tok-p">.</span>
+    <span class="tok-p">],</span>
+    <span class="tok-s2">&quot;generate-merlin&quot;</span> <span class="tok-o">:</span> <span class="tok-kc">false</span> <b class="conum">(2)</b>
+<span class="tok-p">}</span></code></pre>
 </div>
 </div>
 <div class="colist arabic">
@@ -4717,12 +4778,12 @@ bsb -w <b class="conum">(2)</b></code></pre>
 <div class="listingblock">
 <div class="title">package.json</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js">{
- "dependencies": {
-    "bs-mocha": "0.1.5"
-    },
-  ...
-}</code></pre>
+<pre class="pygments highlight"><code data-lang="js"><span class="tok-p">{</span>
+ <span class="tok-s2">&quot;dependencies&quot;</span><span class="tok-o">:</span> <span class="tok-p">{</span>
+    <span class="tok-s2">&quot;bs-mocha&quot;</span><span class="tok-o">:</span> <span class="tok-s2">&quot;0.1.5&quot;</span>
+    <span class="tok-p">},</span>
+  <span class="tok-p">...</span>
+<span class="tok-p">}</span></code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -4766,12 +4827,12 @@ to build. In that case you can mark it as dev only:</p>
 <div class="listingblock">
 <div class="title">bsconfig.json</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js">{
-        "sources" : {
-                "dir" : "test",
-                "type" : "dev" <b class="conum">(1)</b>
-        }
-}</code></pre>
+<pre class="pygments highlight"><code data-lang="js"><span class="tok-p">{</span>
+        <span class="tok-s2">&quot;sources&quot;</span> <span class="tok-o">:</span> <span class="tok-p">{</span>
+                <span class="tok-s2">&quot;dir&quot;</span> <span class="tok-o">:</span> <span class="tok-s2">&quot;test&quot;</span><span class="tok-p">,</span>
+                <span class="tok-s2">&quot;type&quot;</span> <span class="tok-o">:</span> <span class="tok-s2">&quot;dev&quot;</span> <b class="conum">(1)</b>
+        <span class="tok-p">}</span>
+<span class="tok-p">}</span></code></pre>
 </div>
 </div>
 <div class="colist arabic">
@@ -4791,17 +4852,17 @@ to build. In that case you can mark it as dev only:</p>
 <div class="listingblock">
 <div class="title">bsconfig.json</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js">{
-  "name": "bucklescript-tea",
-  "version": "0.1.3",
-  "sources": [
-   "src", <b class="conum">(1)</b>
-    {
-      "dir": "test",
-      "type": "dev" <b class="conum">(2)</b>
-    }
-  ]
-}</code></pre>
+<pre class="pygments highlight"><code data-lang="js"><span class="tok-p">{</span>
+  <span class="tok-s2">&quot;name&quot;</span><span class="tok-o">:</span> <span class="tok-s2">&quot;bucklescript-tea&quot;</span><span class="tok-p">,</span>
+  <span class="tok-s2">&quot;version&quot;</span><span class="tok-o">:</span> <span class="tok-s2">&quot;0.1.3&quot;</span><span class="tok-p">,</span>
+  <span class="tok-s2">&quot;sources&quot;</span><span class="tok-o">:</span> <span class="tok-p">[</span>
+   <span class="tok-s2">&quot;src&quot;</span><span class="tok-p">,</span> <b class="conum">(1)</b>
+    <span class="tok-p">{</span>
+      <span class="tok-s2">&quot;dir&quot;</span><span class="tok-o">:</span> <span class="tok-s2">&quot;test&quot;</span><span class="tok-p">,</span>
+      <span class="tok-s2">&quot;type&quot;</span><span class="tok-o">:</span> <span class="tok-s2">&quot;dev&quot;</span> <b class="conum">(2)</b>
+    <span class="tok-p">}</span>
+  <span class="tok-p">]</span>
+<span class="tok-p">}</span></code></pre>
 </div>
 </div>
 <div class="colist arabic">
@@ -4817,19 +4878,19 @@ to build. In that case you can mark it as dev only:</p>
 <div class="listingblock">
 <div class="title">package.json</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js">{
-  "name": "bucklescript-tea",
-  "version": "0.1.3",
-  "description": "TEA for Bucklescript",
-  "scripts": {
-    "build": "bsb",
-    "watch": "bsb -w",
-    "test": "echo \"Error: no test specified\" &amp;&amp; exit 1"
-  },
-  "peerDependencies": {
-    "bs-platform": "^1.7.0" <b class="conum">(1)</b>
-  }
-}</code></pre>
+<pre class="pygments highlight"><code data-lang="js"><span class="tok-p">{</span>
+  <span class="tok-s2">&quot;name&quot;</span><span class="tok-o">:</span> <span class="tok-s2">&quot;bucklescript-tea&quot;</span><span class="tok-p">,</span>
+  <span class="tok-s2">&quot;version&quot;</span><span class="tok-o">:</span> <span class="tok-s2">&quot;0.1.3&quot;</span><span class="tok-p">,</span>
+  <span class="tok-s2">&quot;description&quot;</span><span class="tok-o">:</span> <span class="tok-s2">&quot;TEA for Bucklescript&quot;</span><span class="tok-p">,</span>
+  <span class="tok-s2">&quot;scripts&quot;</span><span class="tok-o">:</span> <span class="tok-p">{</span>
+    <span class="tok-s2">&quot;build&quot;</span><span class="tok-o">:</span> <span class="tok-s2">&quot;bsb&quot;</span><span class="tok-p">,</span>
+    <span class="tok-s2">&quot;watch&quot;</span><span class="tok-o">:</span> <span class="tok-s2">&quot;bsb -w&quot;</span><span class="tok-p">,</span>
+    <span class="tok-s2">&quot;test&quot;</span><span class="tok-o">:</span> <span class="tok-s2">&quot;echo \&quot;Error: no test specified\&quot; &amp;&amp; exit 1&quot;</span>
+  <span class="tok-p">},</span>
+  <span class="tok-s2">&quot;peerDependencies&quot;</span><span class="tok-o">:</span> <span class="tok-p">{</span>
+    <span class="tok-s2">&quot;bs-platform&quot;</span><span class="tok-o">:</span> <span class="tok-s2">&quot;^1.7.0&quot;</span> <b class="conum">(1)</b>
+  <span class="tok-p">}</span>
+<span class="tok-p">}</span></code></pre>
 </div>
 </div>
 <div class="colist arabic">
@@ -4845,24 +4906,24 @@ to build. In that case you can mark it as dev only:</p>
 <div class="listingblock">
 <div class="title">bsconfig.json</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js">{
-    "name" : "bucklescript-have-tea",
-    "sources" : "src",
-    "bs-dependencies": [
-      "bucklescript-tea"
-    ]
-}</code></pre>
+<pre class="pygments highlight"><code data-lang="js"><span class="tok-p">{</span>
+    <span class="tok-s2">&quot;name&quot;</span> <span class="tok-o">:</span> <span class="tok-s2">&quot;bucklescript-have-tea&quot;</span><span class="tok-p">,</span>
+    <span class="tok-s2">&quot;sources&quot;</span> <span class="tok-o">:</span> <span class="tok-s2">&quot;src&quot;</span><span class="tok-p">,</span>
+    <span class="tok-s2">&quot;bs-dependencies&quot;</span><span class="tok-o">:</span> <span class="tok-p">[</span>
+      <span class="tok-s2">&quot;bucklescript-tea&quot;</span>
+    <span class="tok-p">]</span>
+<span class="tok-p">}</span></code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="title">package.json</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js">{
-    "name" : "bucklescript-have-tea",
-    "version" : "0.1.0",
-    "dependencies" : { "bucklescript-tea" : "^0.1.2" }, <b class="conum">(1)</b>
-    "peerDependencies" : { "bs-platform" : "^1.7.0" } <b class="conum">(2)</b>
-}</code></pre>
+<pre class="pygments highlight"><code data-lang="js"><span class="tok-p">{</span>
+    <span class="tok-s2">&quot;name&quot;</span> <span class="tok-o">:</span> <span class="tok-s2">&quot;bucklescript-have-tea&quot;</span><span class="tok-p">,</span>
+    <span class="tok-s2">&quot;version&quot;</span> <span class="tok-o">:</span> <span class="tok-s2">&quot;0.1.0&quot;</span><span class="tok-p">,</span>
+    <span class="tok-s2">&quot;dependencies&quot;</span> <span class="tok-o">:</span> <span class="tok-p">{</span> <span class="tok-s2">&quot;bucklescript-tea&quot;</span> <span class="tok-o">:</span> <span class="tok-s2">&quot;^0.1.2&quot;</span> <span class="tok-p">},</span> <b class="conum">(1)</b>
+    <span class="tok-s2">&quot;peerDependencies&quot;</span> <span class="tok-o">:</span> <span class="tok-p">{</span> <span class="tok-s2">&quot;bs-platform&quot;</span> <span class="tok-o">:</span> <span class="tok-s2">&quot;^1.7.0&quot;</span> <span class="tok-p">}</span> <b class="conum">(2)</b>
+<span class="tok-p">}</span></code></pre>
 </div>
 </div>
 <div class="colist arabic">
@@ -4903,11 +4964,11 @@ npm install bs-platform <b class="conum">(2)</b>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js">{
-  ... ,
-  "package-specs" : ["amdjs", "commonjs"],
-  ...
-}</code></pre>
+<pre class="pygments highlight"><code data-lang="js"><span class="tok-p">{</span>
+  <span class="tok-p">...</span> <span class="tok-p">,</span>
+  <span class="tok-s2">&quot;package-specs&quot;</span> <span class="tok-o">:</span> <span class="tok-p">[</span><span class="tok-s2">&quot;amdjs&quot;</span><span class="tok-p">,</span> <span class="tok-s2">&quot;commonjs&quot;</span><span class="tok-p">],</span>
+  <span class="tok-p">...</span>
+<span class="tok-p">}</span></code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -4948,21 +5009,21 @@ are <em>curious</em> about how the build works.</p>
 <div class="listingblock">
 <div class="title">Makefile</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="make">OCAMLC=bsc.exe <b class="conum">(1)</b>
-OCAMLDEP=bsdep.exe <b class="conum">(2)</b>
-SOURCE_LIST := src_a src_b
-SOURCE_MLI = $(addsuffix .mli, $(SOURCE_LIST))
-SOURCE_ML  = $(addsuffix .ml, $(SOURCE_LIST))
-TARGETS := $(addsuffix .cmj, $(SOURCE_LIST))
-INCLUDES=
-all: $(TARGETS)
-.mli:.cmi
-        $(OCAMLC) $(INCLUDES) $(COMPFLAGS) -c $&lt;
-.ml:.cmj:
-        $(OCAMLC) $(INCLUDES) $(COMPFLAGS) -c $&lt;
--include .depend
-depend:
-        $(OCAMLDEP) $(INCLUDES) $(SOURCE_ML) $(SOURCE_MLI) &gt; .depend</code></pre>
+<pre class="pygments highlight"><code data-lang="make"><span class="tok-nv">OCAMLC</span><span class="tok-o">=</span>bsc.exe <b class="conum">(1)</b>
+<span class="tok-nv">OCAMLDEP</span><span class="tok-o">=</span>bsdep.exe <b class="conum">(2)</b>
+<span class="tok-nv">SOURCE_LIST</span> <span class="tok-o">:=</span> src_a src_b
+<span class="tok-nv">SOURCE_MLI</span> <span class="tok-o">=</span> <span class="tok-k">$(</span>addsuffix .mli, <span class="tok-k">$(</span>SOURCE_LIST<span class="tok-k">))</span>
+<span class="tok-nv">SOURCE_ML</span>  <span class="tok-o">=</span> <span class="tok-k">$(</span>addsuffix .ml, <span class="tok-k">$(</span>SOURCE_LIST<span class="tok-k">))</span>
+<span class="tok-nv">TARGETS</span> <span class="tok-o">:=</span> <span class="tok-k">$(</span>addsuffix .cmj, <span class="tok-k">$(</span>SOURCE_LIST<span class="tok-k">))</span>
+<span class="tok-nv">INCLUDES</span><span class="tok-o">=</span>
+<span class="tok-nf">all</span><span class="tok-o">:</span> <span class="tok-k">$(</span><span class="tok-nv">TARGETS</span><span class="tok-k">)</span>
+<span class="tok-nf">.mli</span><span class="tok-o">:</span>.<span class="tok-n">cmi</span>
+        <span class="tok-k">$(</span>OCAMLC<span class="tok-k">)</span> <span class="tok-k">$(</span>INCLUDES<span class="tok-k">)</span> <span class="tok-k">$(</span>COMPFLAGS<span class="tok-k">)</span> -c <span class="tok-nv">$&lt;</span>
+<span class="tok-nf">.ml</span><span class="tok-o">:</span>.<span class="tok-n">cmj</span>:
+        <span class="tok-k">$(</span>OCAMLC<span class="tok-k">)</span> <span class="tok-k">$(</span>INCLUDES<span class="tok-k">)</span> <span class="tok-k">$(</span>COMPFLAGS<span class="tok-k">)</span> -c <span class="tok-nv">$&lt;</span>
+<span class="tok-cp">-include .depend</span>
+<span class="tok-nf">depend</span><span class="tok-o">:</span>
+        <span class="tok-k">$(</span>OCAMLDEP<span class="tok-k">)</span> <span class="tok-k">$(</span>INCLUDES<span class="tok-k">)</span> <span class="tok-k">$(</span>SOURCE_ML<span class="tok-k">)</span> <span class="tok-k">$(</span>SOURCE_MLI<span class="tok-k">)</span> &gt; .depend</code></pre>
 </div>
 </div>
 <div class="colist arabic">
@@ -4986,14 +5047,14 @@ such as <a href="https://facebook.github.io/watchman/">watchman</a> for example,
 <div class="listingblock">
 <div class="title">build.json</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="json">[
-    "trigger", ".", {
-        "name": "build",
-        "expression": ["pcre", "(\\.(ml|mll|mly|mli|sh|sh)$|Makefile)"], <b class="conum">(1)</b>
-        "command": ["./build.sh"],
-        "append_files" : true
-    }
-]</code></pre>
+<pre class="pygments highlight"><code data-lang="json"><span class="tok-p">[</span>
+    <span class="tok-s2">&quot;trigger&quot;</span><span class="tok-p">,</span> <span class="tok-s2">&quot;.&quot;</span><span class="tok-p">,</span> <span class="tok-p">{</span>
+        <span class="tok-nt">&quot;name&quot;</span><span class="tok-p">:</span> <span class="tok-s2">&quot;build&quot;</span><span class="tok-p">,</span>
+        <span class="tok-nt">&quot;expression&quot;</span><span class="tok-p">:</span> <span class="tok-p">[</span><span class="tok-s2">&quot;pcre&quot;</span><span class="tok-p">,</span> <span class="tok-s2">&quot;(\\.(ml|mll|mly|mli|sh|sh)$|Makefile)&quot;</span><span class="tok-p">],</span> <b class="conum">(1)</b>
+        <span class="tok-nt">&quot;command&quot;</span><span class="tok-p">:</span> <span class="tok-p">[</span><span class="tok-s2">&quot;./build.sh&quot;</span><span class="tok-p">],</span>
+        <span class="tok-nt">&quot;append_files&quot;</span> <span class="tok-p">:</span> <span class="tok-kc">true</span>
+    <span class="tok-p">}</span>
+<span class="tok-p">]</span></code></pre>
 </div>
 </div>
 <div class="colist arabic">
@@ -5381,8 +5442,8 @@ We might encode it as buffer in NodeJS.
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml">type t = { x : int; y : int }
-let v = {x = 1; y = 2}</code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">type</span> <span class="tok-n">t</span> <span class="tok-o">=</span> <span class="tok-o">{</span> <span class="tok-n">x</span> <span class="tok-o">:</span> <span class="tok-kt">int</span><span class="tok-o">;</span> <span class="tok-n">y</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">}</span>
+<span class="tok-k">let</span> <span class="tok-n">v</span> <span class="tok-o">=</span> <span class="tok-o">{</span><span class="tok-n">x</span> <span class="tok-o">=</span> <span class="tok-mi">1</span><span class="tok-o">;</span> <span class="tok-n">y</span> <span class="tok-o">=</span> <span class="tok-mi">2</span><span class="tok-o">}</span></code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -5390,7 +5451,7 @@ let v = {x = 1; y = 2}</code></pre>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="js">var v = [1,2]</code></pre>
+<pre class="pygments highlight"><code data-lang="js"><span class="tok-kd">var</span> <span class="tok-nx">v</span> <span class="tok-o">=</span> <span class="tok-p">[</span><span class="tok-mi">1</span><span class="tok-p">,</span><span class="tok-mi">2</span><span class="tok-p">]</span></code></pre>
 </div>
 </div></div></td>
 </tr>
@@ -5461,11 +5522,11 @@ let v = {x = 1; y = 2}</code></pre>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml">type tree =
-  | Leaf
-  | Node of int * tree * tree
-(* Leaf --&gt; 0 *)
-(* Node(a,b,c) --&gt; [a,b,c]*)</code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">type</span> <span class="tok-n">tree</span> <span class="tok-o">=</span>
+  <span class="tok-o">|</span> <span class="tok-nc">Leaf</span>
+  <span class="tok-o">|</span> <span class="tok-nc">Node</span> <span class="tok-k">of</span> <span class="tok-kt">int</span> <span class="tok-o">*</span> <span class="tok-n">tree</span> <span class="tok-o">*</span> <span class="tok-n">tree</span>
+<span class="tok-c">(* Leaf --&gt; 0 *)</span>
+<span class="tok-c">(* Node(a,b,c) --&gt; [a,b,c]*)</span></code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -5473,11 +5534,11 @@ let v = {x = 1; y = 2}</code></pre>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml">type u =
-     | A of string
-     | B of int
-(* A a --&gt; [a].tag=0 -- tag 0 assignment is optional *)
-(* B b --&gt; [b].tag=1 *)</code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">type</span> <span class="tok-n">u</span> <span class="tok-o">=</span>
+     <span class="tok-o">|</span> <span class="tok-nc">A</span> <span class="tok-k">of</span> <span class="tok-kt">string</span>
+     <span class="tok-o">|</span> <span class="tok-nc">B</span> <span class="tok-k">of</span> <span class="tok-kt">int</span>
+<span class="tok-c">(* A a --&gt; [a].tag=0 -- tag 0 assignment is optional *)</span>
+<span class="tok-c">(* B b --&gt; [b].tag=1 *)</span></code></pre>
 </div>
 </div></div></td>
 </tr>
@@ -5488,8 +5549,8 @@ let v = {x = 1; y = 2}</code></pre>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml">`a (* 97 *)
-`a 1 2 (* [97, [1,2] ]*)</code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-o">`</span><span class="tok-n">a</span> <span class="tok-c">(* 97 *)</span>
+<span class="tok-o">`</span><span class="tok-n">a</span> <span class="tok-mi">1</span> <span class="tok-mi">2</span> <span class="tok-c">(* [97, [1,2] ]*)</span></code></pre>
 </div>
 </div></div></td>
 </tr>
@@ -5526,8 +5587,8 @@ let v = {x = 1; y = 2}</code></pre>
 <div class="listingblock">
 <div class="title">Js module</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml">type boolean
-val to_bool: boolean -&gt; bool</code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">type</span> <span class="tok-n">boolean</span>
+<span class="tok-k">val</span> <span class="tok-n">to_bool</span><span class="tok-o">:</span> <span class="tok-n">boolean</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">bool</span></code></pre>
 </div>
 </div>
 <div class="listingblock">
@@ -5545,10 +5606,10 @@ val to_bool: boolean -&gt; bool</code></pre>
 <div class="listingblock">
 <div class="title">Js.Null module</div>
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml">val to_opt : 'a t -&gt; 'a option
-val from_opt : 'a option -&gt; 'a t
-val return : 'a -&gt; 'a t
-val test : 'a t -&gt; bool</code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">val</span> <span class="tok-n">to_opt</span> <span class="tok-o">:</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-n">t</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-n">option</span>
+<span class="tok-k">val</span> <span class="tok-n">from_opt</span> <span class="tok-o">:</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-n">option</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-n">t</span>
+<span class="tok-k">val</span> <span class="tok-n">return</span> <span class="tok-o">:</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-o">-&gt;</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-n">t</span>
+<span class="tok-k">val</span> <span class="tok-n">test</span> <span class="tok-o">:</span> <span class="tok-k">&#39;</span><span class="tok-n">a</span> <span class="tok-n">t</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">bool</span></code></pre>
 </div>
 </div></div></td>
 </tr>
@@ -5609,11 +5670,11 @@ We are working to provide a ppx extension as below:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml">type t =
-  | A
-  | B of int * int
-  | C of int * int
-  | D [@@bs.deriving{export}]</code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">type</span> <span class="tok-n">t</span> <span class="tok-o">=</span>
+  <span class="tok-o">|</span> <span class="tok-nc">A</span>
+  <span class="tok-o">|</span> <span class="tok-nc">B</span> <span class="tok-k">of</span> <span class="tok-kt">int</span> <span class="tok-o">*</span> <span class="tok-kt">int</span>
+  <span class="tok-o">|</span> <span class="tok-nc">C</span> <span class="tok-k">of</span> <span class="tok-kt">int</span> <span class="tok-o">*</span> <span class="tok-kt">int</span>
+  <span class="tok-o">|</span> <span class="tok-nc">D</span> <span class="tok-o">[@@</span><span class="tok-n">bs</span><span class="tok-o">.</span><span class="tok-n">deriving</span><span class="tok-o">{</span><span class="tok-n">export</span><span class="tok-o">}]</span></code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -5622,15 +5683,15 @@ We are working to provide a ppx extension as below:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml">val a : t
-val b : int -&gt; int -&gt; t
-val c : int -&gt; int -&gt; t
-val d : int
+<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">val</span> <span class="tok-n">a</span> <span class="tok-o">:</span> <span class="tok-n">t</span>
+<span class="tok-k">val</span> <span class="tok-n">b</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-n">t</span>
+<span class="tok-k">val</span> <span class="tok-n">c</span> <span class="tok-o">:</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">int</span> <span class="tok-o">-&gt;</span> <span class="tok-n">t</span>
+<span class="tok-k">val</span> <span class="tok-n">d</span> <span class="tok-o">:</span> <span class="tok-kt">int</span>
 
-val a_of_t : t -&gt; bool
-val d_of_t : t -&gt; bool
-val b_of_t : t -&gt; (int * int ) Js.Null.t
-val c_of_t : t -&gt; (int * int ) Js.Null.t</code></pre>
+<span class="tok-k">val</span> <span class="tok-n">a_of_t</span> <span class="tok-o">:</span> <span class="tok-n">t</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">bool</span>
+<span class="tok-k">val</span> <span class="tok-n">d_of_t</span> <span class="tok-o">:</span> <span class="tok-n">t</span> <span class="tok-o">-&gt;</span> <span class="tok-kt">bool</span>
+<span class="tok-k">val</span> <span class="tok-n">b_of_t</span> <span class="tok-o">:</span> <span class="tok-n">t</span> <span class="tok-o">-&gt;</span> <span class="tok-o">(</span><span class="tok-kt">int</span> <span class="tok-o">*</span> <span class="tok-kt">int</span> <span class="tok-o">)</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-nn">Null</span><span class="tok-p">.</span><span class="tok-n">t</span>
+<span class="tok-k">val</span> <span class="tok-n">c_of_t</span> <span class="tok-o">:</span> <span class="tok-n">t</span> <span class="tok-o">-&gt;</span> <span class="tok-o">(</span><span class="tok-kt">int</span> <span class="tok-o">*</span> <span class="tok-kt">int</span> <span class="tok-o">)</span> <span class="tok-nn">Js</span><span class="tok-p">.</span><span class="tok-nn">Null</span><span class="tok-p">.</span><span class="tok-n">t</span></code></pre>
 </div>
 </div>
 </div>
@@ -5730,7 +5791,7 @@ so the user does not need install those tools.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="sh">make snapshotml # see the diffs in jscomp/bin</code></pre>
+<pre class="pygments highlight"><code data-lang="sh">make snapshotml <span class="tok-c"># see the diffs in jscomp/bin</span></code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -5741,12 +5802,12 @@ so the user does not need install those tools.</p>
 <h3 id="_contributing_to_code_bsc_exe_code"><a class="anchor" href="#_contributing_to_code_bsc_exe_code"></a>Contributing to <code>bsc.exe</code></h3>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="sh">make -C bin bsc.exe # build the compiler in dev mode</code></pre>
+<pre class="pygments highlight"><code data-lang="sh">make -C bin bsc.exe <span class="tok-c"># build the compiler in dev mode</span></code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="sh">make libs # build all libs using the dev compiler</code></pre>
+<pre class="pygments highlight"><code data-lang="sh">make libs <span class="tok-c"># build all libs using the dev compiler</span></code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -5799,13 +5860,13 @@ the compiler you modified.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="pygments highlight"><code data-lang="ocaml">let suites : _ Mt.pair_suites =
-   ["hey", (fun _ -&gt; Eq(true, 3 &gt; 2));
-       "hi", (fun _ -&gt; Neq(2,3));
-       "hello", (fun _ -&gt; Approx(3.0, 3.0));
-       "throw", (fun _ -&gt; ThrowAny(fun _ -&gt; raise 3))
-       ]
-let () = Mt.from_pair_suites __FILE__ suites</code></pre>
+<pre class="pygments highlight"><code data-lang="ocaml"><span class="tok-k">let</span> <span class="tok-n">suites</span> <span class="tok-o">:</span> <span class="tok-o">_</span> <span class="tok-nn">Mt</span><span class="tok-p">.</span><span class="tok-n">pair_suites</span> <span class="tok-o">=</span>
+   <span class="tok-o">[</span><span class="tok-s2">&quot;hey&quot;</span><span class="tok-o">,</span> <span class="tok-o">(</span><span class="tok-k">fun</span> <span class="tok-o">_</span> <span class="tok-o">-&gt;</span> <span class="tok-nc">Eq</span><span class="tok-o">(</span><span class="tok-bp">true</span><span class="tok-o">,</span> <span class="tok-mi">3</span> <span class="tok-o">&gt;</span> <span class="tok-mi">2</span><span class="tok-o">));</span>
+       <span class="tok-s2">&quot;hi&quot;</span><span class="tok-o">,</span> <span class="tok-o">(</span><span class="tok-k">fun</span> <span class="tok-o">_</span> <span class="tok-o">-&gt;</span> <span class="tok-nc">Neq</span><span class="tok-o">(</span><span class="tok-mi">2</span><span class="tok-o">,</span><span class="tok-mi">3</span><span class="tok-o">));</span>
+       <span class="tok-s2">&quot;hello&quot;</span><span class="tok-o">,</span> <span class="tok-o">(</span><span class="tok-k">fun</span> <span class="tok-o">_</span> <span class="tok-o">-&gt;</span> <span class="tok-nc">Approx</span><span class="tok-o">(</span><span class="tok-mi">3</span><span class="tok-o">.</span><span class="tok-mi">0</span><span class="tok-o">,</span> <span class="tok-mi">3</span><span class="tok-o">.</span><span class="tok-mi">0</span><span class="tok-o">));</span>
+       <span class="tok-s2">&quot;throw&quot;</span><span class="tok-o">,</span> <span class="tok-o">(</span><span class="tok-k">fun</span> <span class="tok-o">_</span> <span class="tok-o">-&gt;</span> <span class="tok-nc">ThrowAny</span><span class="tok-o">(</span><span class="tok-k">fun</span> <span class="tok-o">_</span> <span class="tok-o">-&gt;</span> <span class="tok-k">raise</span> <span class="tok-mi">3</span><span class="tok-o">))</span>
+       <span class="tok-o">]</span>
+<span class="tok-k">let</span> <span class="tok-bp">()</span> <span class="tok-o">=</span> <span class="tok-nn">Mt</span><span class="tok-p">.</span><span class="tok-n">from_pair_suites</span> <span class="tok-o">__</span><span class="tok-n">FILE__</span> <span class="tok-n">suites</span></code></pre>
 </div>
 </div>
 <div class="ulist">
@@ -5841,9 +5902,7 @@ let () = Mt.from_pair_suites __FILE__ suites</code></pre>
 <div class="sect2">
 <h3 id="_contributing_to_the_documentation"><a class="anchor" href="#_contributing_to_the_documentation"></a>Contributing to the documentation</h3>
 <div class="paragraph">
-<p>You&#8217;ll need <a href="http://asciidoctor.org/">Asciidoctor</a> installed and on your <code>PATH</code>.
-Go into <code>site/docsource/</code>, modify the section you want, and run <code>build.sh</code>.
-You can check the <code>build.compile</code> file for debug output.</p>
+<p>You&#8217;ll need <a href="http://asciidoctor.org/">Asciidoctor</a> installed. Modify the section you want in <code>site/docsource/</code>, then run <code>site/docsource/build.sh</code>.</p>
 </div>
 </div>
 <div class="sect2">

--- a/docs/Manual.html
+++ b/docs/Manual.html
@@ -5843,7 +5843,7 @@ let () = Mt.from_pair_suites __FILE__ suites</code></pre>
 <div class="paragraph">
 <p>You&#8217;ll need <a href="http://asciidoctor.org/">Asciidoctor</a> installed and on your <code>PATH</code>.
 Go into <code>site/docsource/</code>, modify the section you want, and run <code>build.sh</code>.
-You can check the <code>build.compile</code> file in the project root for debug output.</p>
+You can check the <code>build.compile</code> file for debug output.</p>
 </div>
 </div>
 <div class="sect2">

--- a/site/docsource/Dev-mode-How-to.adoc
+++ b/site/docsource/Dev-mode-How-to.adoc
@@ -120,7 +120,9 @@ To build libs, tests and run all tests:
 
 ### Contributing to the documentation
 
-You'll need http://asciidoctor.org/[Asciidoctor] installed. Modify the section you want in `site/docsource/`, then run `site/docsource/build.sh`.
+You'll need http://asciidoctor.org/[Asciidoctor] installed and on your `PATH`.
+Go into `site/docsource/`, modify the section you want, and run `build.sh`.
+You can check the `build.compile` file for debug output.
 
 ### Contributing to the API reference
 

--- a/site/docsource/Installation.adoc
+++ b/site/docsource/Installation.adoc
@@ -110,6 +110,7 @@ the previous section.
 
 [source,sh]
 -----------
+cd ../jscomp
 make world
 -----------
 


### PR DESCRIPTION
Clarify instructions for building docs.
Add step to `cd jscomp` before calling `make` when building bucklescript from source.