### PR TITLE
Quote output to ninja build

### DIFF
--- a/jscomp/bin/bsb.ml
+++ b/jscomp/bin/bsb.ml
@@ -10210,11 +10210,21 @@ let init_sample_project ~cwd ~theme name =
         exit exit_code
       end
   in 
+  let ensure_no_spaces name =
+    if String.contains name ' '
+    then begin
+      Format.fprintf Format.err_formatter "Package name cannot contain spaces: %s@." name ;
+      exit 2
+    end
+  in
   begin match name with 
     | "." -> 
-      String_hashtbl.add env "name"  (Filename.basename cwd);
+      let folder = Filename.basename cwd in
+      ensure_no_spaces folder;
+      String_hashtbl.add env "name" folder;
       action ()
     | _ -> 
+      ensure_no_spaces name;
       Format.fprintf Format.std_formatter "Making directory %s@." name;  
       if Sys.file_exists name then 
         begin 

--- a/jscomp/bin/bsb.ml
+++ b/jscomp/bin/bsb.ml
@@ -9698,14 +9698,14 @@ let output_ninja
     let () =
       output_string oc ninja_required_version ;
       output_string oc "bs_package_flags = ";
-      output_string oc ("-bs-package-name "  ^ package_name);
+      output_string oc ("-bs-package-name "  ^ (Filename.quote package_name));
       output_string oc "\n";
       let bsc_flags = 
         Ext_string.inter2  Literals.dash_nostdlib @@
         match built_in_dependency with 
         | None -> bsc_flags   
         | Some {package_install_path} -> 
-          Ext_string.inter3 dash_i package_install_path bsc_flags
+          Ext_string.inter3 dash_i (Filename.quote package_install_path) bsc_flags
   
       in 
       Bsb_ninja.output_kvs

--- a/jscomp/bin/bsb.ml
+++ b/jscomp/bin/bsb.ml
@@ -9698,7 +9698,7 @@ let output_ninja
     let () =
       output_string oc ninja_required_version ;
       output_string oc "bs_package_flags = ";
-      output_string oc ("-bs-package-name "  ^ (Filename.quote package_name));
+      output_string oc ("-bs-package-name "  ^ package_name);
       output_string oc "\n";
       let bsc_flags = 
         Ext_string.inter2  Literals.dash_nostdlib @@
@@ -10136,10 +10136,6 @@ let replace s env : string =
   Bsb_regex.global_substitute "\\${bsb:\\([-a-zA-Z0-9]+\\)}" 
     (fun (_s : string) templates -> 
        match templates with 
-       (* special case for name, package names cannot have spaces *)
-       | "name"::_ ->
-         Str.global_replace (Str.regexp " ") "-"
-           (String_hashtbl.find_exn env "name")
        | key::_ -> 
          String_hashtbl.find_exn  env key
        | _ -> assert false 

--- a/jscomp/bin/bsb.ml
+++ b/jscomp/bin/bsb.ml
@@ -10136,6 +10136,10 @@ let replace s env : string =
   Bsb_regex.global_substitute "\\${bsb:\\([-a-zA-Z0-9]+\\)}" 
     (fun (_s : string) templates -> 
        match templates with 
+       (* special case for name, package names cannot have spaces *)
+       | "name"::_ ->
+         Str.global_replace (Str.regexp " ") "-"
+           (String_hashtbl.find_exn env "name")
        | key::_ -> 
          String_hashtbl.find_exn  env key
        | _ -> assert false 

--- a/jscomp/bin/bsb.ml
+++ b/jscomp/bin/bsb.ml
@@ -9869,7 +9869,7 @@ let root = OCamlRes.Res.([
         "\n\
          \n\
          let () = Js.log \"Hello, BuckleScript\"")]) ;
-    File ("ReadME.md",
+    File ("README.md",
       "\n\
        \n\
        # Build\n\

--- a/jscomp/bsb/bsb_gen.ml
+++ b/jscomp/bsb/bsb_gen.ml
@@ -82,7 +82,7 @@ let output_ninja
     let () =
       output_string oc ninja_required_version ;
       output_string oc "bs_package_flags = ";
-      output_string oc ("-bs-package-name "  ^ (Filename.quote package_name));
+      output_string oc ("-bs-package-name "  ^ package_name);
       output_string oc "\n";
       let bsc_flags = 
         Ext_string.inter2  Literals.dash_nostdlib @@

--- a/jscomp/bsb/bsb_gen.ml
+++ b/jscomp/bsb/bsb_gen.ml
@@ -82,14 +82,14 @@ let output_ninja
     let () =
       output_string oc ninja_required_version ;
       output_string oc "bs_package_flags = ";
-      output_string oc ("-bs-package-name "  ^ package_name);
+      output_string oc ("-bs-package-name "  ^ (Filename.quote package_name));
       output_string oc "\n";
       let bsc_flags = 
         Ext_string.inter2  Literals.dash_nostdlib @@
         match built_in_dependency with 
         | None -> bsc_flags   
         | Some {package_install_path} -> 
-          Ext_string.inter3 dash_i package_install_path bsc_flags
+          Ext_string.inter3 dash_i (Filename.quote package_install_path) bsc_flags
   
       in 
       Bsb_ninja.output_kvs

--- a/jscomp/bsb/bsb_init.ml
+++ b/jscomp/bsb/bsb_init.ml
@@ -30,10 +30,6 @@ let replace s env : string =
   Bsb_regex.global_substitute "\\${bsb:\\([-a-zA-Z0-9]+\\)}" 
     (fun (_s : string) templates -> 
        match templates with 
-       (* special case for name, package names cannot have spaces *)
-       | "name"::_ ->
-         Str.global_replace (Str.regexp " ") "-"
-           (String_hashtbl.find_exn env "name")
        | key::_ -> 
          String_hashtbl.find_exn  env key
        | _ -> assert false 

--- a/jscomp/bsb/bsb_init.ml
+++ b/jscomp/bsb/bsb_init.ml
@@ -30,6 +30,10 @@ let replace s env : string =
   Bsb_regex.global_substitute "\\${bsb:\\([-a-zA-Z0-9]+\\)}" 
     (fun (_s : string) templates -> 
        match templates with 
+       (* special case for name, package names cannot have spaces *)
+       | "name"::_ ->
+         Str.global_replace (Str.regexp " ") "-"
+           (String_hashtbl.find_exn env "name")
        | key::_ -> 
          String_hashtbl.find_exn  env key
        | _ -> assert false 

--- a/jscomp/bsb/bsb_init.ml
+++ b/jscomp/bsb/bsb_init.ml
@@ -104,11 +104,21 @@ let init_sample_project ~cwd ~theme name =
         exit exit_code
       end
   in 
+  let ensure_no_spaces name =
+    if String.contains name ' '
+    then begin
+      Format.fprintf Format.err_formatter "Package name cannot contain spaces: %s@." name ;
+      exit 2
+    end
+  in
   begin match name with 
     | "." -> 
-      String_hashtbl.add env "name"  (Filename.basename cwd);
+      let folder = Filename.basename cwd in
+      ensure_no_spaces folder;
+      String_hashtbl.add env "name" folder;
       action ()
     | _ -> 
+      ensure_no_spaces name;
       Format.fprintf Format.std_formatter "Making directory %s@." name;  
       if Sys.file_exists name then 
         begin 

--- a/jscomp/bsb/bsb_templates.ml
+++ b/jscomp/bsb/bsb_templates.ml
@@ -6,7 +6,7 @@ let root = OCamlRes.Res.([
         "\n\
          \n\
          let () = Js.log \"Hello, BuckleScript\"")]) ;
-    File ("ReadME.md",
+    File ("README.md",
       "\n\
        \n\
        # Build\n\


### PR DESCRIPTION
Fixes #1605.

This is not sufficient to get the generated npm package to work. npm packages [cannot have spaces](https://docs.npmjs.com/getting-started/using-a-package.json#requirements) in their name, so a separate PR should address this issue.