### PR TITLE
Add more functions and tests to Js.Option

### DIFF
--- a/jscomp/others/js_option.ml
+++ b/jscomp/others/js_option.ml
@@ -64,7 +64,7 @@ let map f x =
   | None -> None
   | Some x -> Some (f x [@bs])
 
-let orValue a x =
+let default a x =
   match x with
   | None -> a
   | Some x -> x

--- a/jscomp/others/js_option.ml
+++ b/jscomp/others/js_option.ml
@@ -59,5 +59,27 @@ let andThen f x =
   | None -> None 
   | Some x -> f x [@bs]
 
+let map f x =
+  match x with
+  | None -> None
+  | Some x -> Some (f x [@bs])
 
+let orValue a x =
+  match x with
+  | None -> a
+  | Some x -> x
 
+let filter f x =
+  match x with
+  | None -> None
+  | Some x -> 
+    if f x [@bs] then
+      Some x
+    else
+      None
+
+let firstSome a b =
+  match (a, b) with
+  | (Some _, _) -> a
+  | (None, Some _) -> b
+  | (None, None) -> None

--- a/jscomp/others/js_option.mli
+++ b/jscomp/others/js_option.mli
@@ -40,7 +40,7 @@ val andThen : ('a -> 'b option [@bs]) -> 'a option -> 'b option
 
 val map : ('a -> 'b [@bs]) -> 'a option -> 'b option
 
-val orValue : 'a -> 'a option -> 'a
+val default : 'a -> 'a option -> 'a
 
 val filter : ('a -> bool [@bs]) -> 'a option -> 'a option
 

--- a/jscomp/others/js_option.mli
+++ b/jscomp/others/js_option.mli
@@ -37,3 +37,11 @@ val getExn : 'a option -> 'a
 val equal : ('a -> 'b -> bool [@bs]) -> 'a option -> 'b option -> bool
 
 val andThen : ('a -> 'b option [@bs]) -> 'a option -> 'b option
+
+val map : ('a -> 'b [@bs]) -> 'a option -> 'b option
+
+val orValue : 'a -> 'a option -> 'a
+
+val filter : ('a -> bool [@bs]) -> 'a option -> 'a option
+
+val firstSome : 'a option -> 'a option -> 'a option

--- a/jscomp/test/Makefile
+++ b/jscomp/test/Makefile
@@ -157,6 +157,7 @@ OTHERS := literals a test_ari test_export2 test_internalOO test_obj_simple_ffi t
 	mario_game\
 	gpr_1600_test\
 	js_list_test\
+	js_option_test\
 	gpr_1658_test\
 	gpr_1667_test
 

--- a/jscomp/test/js_option_test.js
+++ b/jscomp/test/js_option_test.js
@@ -168,21 +168,21 @@ var option_suites_001 = /* :: */[
                             ],
                             /* :: */[
                               /* tuple */[
-                                "option_orValue_Some",
+                                "option_default_Some",
                                 function () {
                                   return /* Eq */Block.__(0, [
                                             2,
-                                            Js_option.orValue(3, /* Some */[2])
+                                            Js_option.$$default(3, /* Some */[2])
                                           ]);
                                 }
                               ],
                               /* :: */[
                                 /* tuple */[
-                                  "option_orValue_None",
+                                  "option_default_None",
                                   function () {
                                     return /* Eq */Block.__(0, [
                                               3,
-                                              Js_option.orValue(3, /* None */0)
+                                              Js_option.$$default(3, /* None */0)
                                             ]);
                                   }
                                 ],

--- a/jscomp/test/js_option_test.js
+++ b/jscomp/test/js_option_test.js
@@ -1,0 +1,288 @@
+'use strict';
+
+var Mt        = require("./mt.js");
+var Block     = require("../../lib/js/block.js");
+var Js_option = require("../../lib/js/js_option.js");
+
+function simpleEq(a, b) {
+  return +(a === b);
+}
+
+var option_suites_000 = /* tuple */[
+  "option_isSome_Some",
+  function () {
+    return /* Eq */Block.__(0, [
+              /* true */1,
+              /* true */1
+            ]);
+  }
+];
+
+var option_suites_001 = /* :: */[
+  /* tuple */[
+    "option_isSome_None",
+    function () {
+      return /* Eq */Block.__(0, [
+                /* false */0,
+                /* false */0
+              ]);
+    }
+  ],
+  /* :: */[
+    /* tuple */[
+      "option_isNone_Some",
+      function () {
+        return /* Eq */Block.__(0, [
+                  /* false */0,
+                  /* false */0
+                ]);
+      }
+    ],
+    /* :: */[
+      /* tuple */[
+        "option_isNone_None",
+        function () {
+          return /* Eq */Block.__(0, [
+                    /* true */1,
+                    /* true */1
+                  ]);
+        }
+      ],
+      /* :: */[
+        /* tuple */[
+          "option_isSomeValue_Eq",
+          function () {
+            return /* Eq */Block.__(0, [
+                      /* true */1,
+                      Js_option.isSomeValue(simpleEq, 2, /* Some */[2])
+                    ]);
+          }
+        ],
+        /* :: */[
+          /* tuple */[
+            "option_isSomeValue_Diff",
+            function () {
+              return /* Eq */Block.__(0, [
+                        /* false */0,
+                        Js_option.isSomeValue(simpleEq, 1, /* Some */[2])
+                      ]);
+            }
+          ],
+          /* :: */[
+            /* tuple */[
+              "option_isSomeValue_DiffNone",
+              function () {
+                return /* Eq */Block.__(0, [
+                          /* false */0,
+                          Js_option.isSomeValue(simpleEq, 1, /* None */0)
+                        ]);
+              }
+            ],
+            /* :: */[
+              /* tuple */[
+                "option_getExn_Some",
+                function () {
+                  return /* Eq */Block.__(0, [
+                            2,
+                            Js_option.getExn(/* Some */[2])
+                          ]);
+                }
+              ],
+              /* :: */[
+                /* tuple */[
+                  "option_equal_Eq",
+                  function () {
+                    return /* Eq */Block.__(0, [
+                              /* true */1,
+                              Js_option.equal(simpleEq, /* Some */[2], /* Some */[2])
+                            ]);
+                  }
+                ],
+                /* :: */[
+                  /* tuple */[
+                    "option_equal_Diff",
+                    function () {
+                      return /* Eq */Block.__(0, [
+                                /* false */0,
+                                Js_option.equal(simpleEq, /* Some */[1], /* Some */[2])
+                              ]);
+                    }
+                  ],
+                  /* :: */[
+                    /* tuple */[
+                      "option_equal_DiffNone",
+                      function () {
+                        return /* Eq */Block.__(0, [
+                                  /* false */0,
+                                  Js_option.equal(simpleEq, /* Some */[1], /* None */0)
+                                ]);
+                      }
+                    ],
+                    /* :: */[
+                      /* tuple */[
+                        "option_andThen_SomeSome",
+                        function () {
+                          return /* Eq */Block.__(0, [
+                                    /* true */1,
+                                    Js_option.isSomeValue(simpleEq, 3, Js_option.andThen(function (a) {
+                                              return /* Some */[a + 1 | 0];
+                                            }, /* Some */[2]))
+                                  ]);
+                        }
+                      ],
+                      /* :: */[
+                        /* tuple */[
+                          "option_andThen_SomeNone",
+                          function () {
+                            return /* Eq */Block.__(0, [
+                                      /* false */0,
+                                      Js_option.isSomeValue(simpleEq, 3, Js_option.andThen(function () {
+                                                return /* None */0;
+                                              }, /* Some */[2]))
+                                    ]);
+                          }
+                        ],
+                        /* :: */[
+                          /* tuple */[
+                            "option_map_Some",
+                            function () {
+                              return /* Eq */Block.__(0, [
+                                        /* true */1,
+                                        Js_option.isSomeValue(simpleEq, 3, Js_option.map(function (a) {
+                                                  return a + 1 | 0;
+                                                }, /* Some */[2]))
+                                      ]);
+                            }
+                          ],
+                          /* :: */[
+                            /* tuple */[
+                              "option_map_None",
+                              function () {
+                                return /* Eq */Block.__(0, [
+                                          /* None */0,
+                                          Js_option.map(function (a) {
+                                                return a + 1 | 0;
+                                              }, /* None */0)
+                                        ]);
+                              }
+                            ],
+                            /* :: */[
+                              /* tuple */[
+                                "option_orValue_Some",
+                                function () {
+                                  return /* Eq */Block.__(0, [
+                                            2,
+                                            Js_option.orValue(3, /* Some */[2])
+                                          ]);
+                                }
+                              ],
+                              /* :: */[
+                                /* tuple */[
+                                  "option_orValue_None",
+                                  function () {
+                                    return /* Eq */Block.__(0, [
+                                              3,
+                                              Js_option.orValue(3, /* None */0)
+                                            ]);
+                                  }
+                                ],
+                                /* :: */[
+                                  /* tuple */[
+                                    "option_filter_Pass",
+                                    function () {
+                                      return /* Eq */Block.__(0, [
+                                                /* true */1,
+                                                Js_option.isSomeValue(simpleEq, 2, Js_option.filter(function (a) {
+                                                          return +(a % 2 === 0);
+                                                        }, /* Some */[2]))
+                                              ]);
+                                    }
+                                  ],
+                                  /* :: */[
+                                    /* tuple */[
+                                      "option_filter_Reject",
+                                      function () {
+                                        return /* Eq */Block.__(0, [
+                                                  /* None */0,
+                                                  Js_option.filter(function (a) {
+                                                        return +(a % 3 === 0);
+                                                      }, /* Some */[2])
+                                                ]);
+                                      }
+                                    ],
+                                    /* :: */[
+                                      /* tuple */[
+                                        "option_filter_None",
+                                        function () {
+                                          return /* Eq */Block.__(0, [
+                                                    /* None */0,
+                                                    Js_option.filter(function (a) {
+                                                          return +(a % 3 === 0);
+                                                        }, /* None */0)
+                                                  ]);
+                                        }
+                                      ],
+                                      /* :: */[
+                                        /* tuple */[
+                                          "option_firstSome_First",
+                                          function () {
+                                            return /* Eq */Block.__(0, [
+                                                      /* true */1,
+                                                      Js_option.isSomeValue(simpleEq, 3, Js_option.firstSome(/* Some */[3], /* Some */[2]))
+                                                    ]);
+                                          }
+                                        ],
+                                        /* :: */[
+                                          /* tuple */[
+                                            "option_firstSome_First",
+                                            function () {
+                                              return /* Eq */Block.__(0, [
+                                                        /* true */1,
+                                                        Js_option.isSomeValue(simpleEq, 2, Js_option.firstSome(/* None */0, /* Some */[2]))
+                                                      ]);
+                                            }
+                                          ],
+                                          /* :: */[
+                                            /* tuple */[
+                                              "option_firstSome_None",
+                                              function () {
+                                                return /* Eq */Block.__(0, [
+                                                          /* None */0,
+                                                          Js_option.firstSome(/* None */0, /* None */0)
+                                                        ]);
+                                              }
+                                            ],
+                                            /* [] */0
+                                          ]
+                                        ]
+                                      ]
+                                    ]
+                                  ]
+                                ]
+                              ]
+                            ]
+                          ]
+                        ]
+                      ]
+                    ]
+                  ]
+                ]
+              ]
+            ]
+          ]
+        ]
+      ]
+    ]
+  ]
+];
+
+var option_suites = /* :: */[
+  option_suites_000,
+  option_suites_001
+];
+
+Mt.from_pair_suites("js_option_test.ml", option_suites);
+
+exports.simpleEq      = simpleEq;
+exports.option_suites = option_suites;
+/*  Not a pure module */

--- a/jscomp/test/js_option_test.ml
+++ b/jscomp/test/js_option_test.ml
@@ -50,11 +50,11 @@ let option_suites = Mt.[
     "option_map_None", (fun _ -> 
         Eq (None , Js.Option.map (fun [@bs] a -> a + 1) None)
       );
-    "option_orValue_Some", (fun _ -> 
-        Eq (2 , Js.Option.orValue 3 (Some 2))
+    "option_default_Some", (fun _ -> 
+        Eq (2 , Js.Option.default 3 (Some 2))
       );
-    "option_orValue_None", (fun _ -> 
-        Eq (3 , Js.Option.orValue 3 None)
+    "option_default_None", (fun _ -> 
+        Eq (3 , Js.Option.default 3 None)
       );
     "option_filter_Pass", (fun _ -> 
         Eq (true , 

--- a/jscomp/test/js_option_test.ml
+++ b/jscomp/test/js_option_test.ml
@@ -1,0 +1,86 @@
+
+let simpleEq = (fun [@bs] a b -> a = b)
+  
+let option_suites = Mt.[
+    "option_isSome_Some" , (fun _ -> 
+        Eq (true , Js.Option.isSome (Some 1))
+      );
+    "option_isSome_None" , (fun _ -> 
+        Eq (false , Js.Option.isSome None)
+      );
+    "option_isNone_Some" , (fun _ -> 
+        Eq (false , Js.Option.isNone (Some 1))
+      );
+    "option_isNone_None" , (fun _ -> 
+        Eq (true , Js.Option.isNone None)
+      );
+    "option_isSomeValue_Eq", (fun _ -> 
+        Eq (true , Js.Option.isSomeValue simpleEq 2 (Some 2))
+      );
+    "option_isSomeValue_Diff", (fun _ -> 
+        Eq (false , Js.Option.isSomeValue simpleEq 1 (Some 2))
+      );
+    "option_isSomeValue_DiffNone", (fun _ -> 
+        Eq (false , Js.Option.isSomeValue simpleEq 1 None)
+      );
+    "option_getExn_Some" , (fun _ -> 
+        Eq (2 , Js.Option.getExn (Some 2))
+      );
+    "option_equal_Eq", (fun _ -> 
+        Eq (true , Js.Option.equal simpleEq (Some 2) (Some 2))
+      );
+    "option_equal_Diff", (fun _ -> 
+        Eq (false , Js.Option.equal simpleEq (Some 1) (Some 2))
+      );
+    "option_equal_DiffNone", (fun _ -> 
+        Eq (false , Js.Option.equal simpleEq (Some 1) None)
+      );
+    "option_andThen_SomeSome", (fun _ -> 
+        Eq (true , 
+            Js.Option.isSomeValue simpleEq 3 (Js.Option.andThen (fun [@bs] a -> Some (a + 1)) (Some 2)))
+      );
+    "option_andThen_SomeNone", (fun _ -> 
+        Eq (false , 
+            Js.Option.isSomeValue simpleEq 3 (Js.Option.andThen (fun [@bs] _ -> None) (Some 2)))
+      );
+    "option_map_Some", (fun _ -> 
+        Eq (true , 
+            Js.Option.isSomeValue simpleEq 3 (Js.Option.map (fun [@bs] a -> a + 1) (Some 2)))
+      );
+    "option_map_None", (fun _ -> 
+        Eq (None , Js.Option.map (fun [@bs] a -> a + 1) None)
+      );
+    "option_orValue_Some", (fun _ -> 
+        Eq (2 , Js.Option.orValue 3 (Some 2))
+      );
+    "option_orValue_None", (fun _ -> 
+        Eq (3 , Js.Option.orValue 3 None)
+      );
+    "option_filter_Pass", (fun _ -> 
+        Eq (true , 
+            Js.Option.isSomeValue simpleEq 2 (Js.Option.filter (fun [@bs] a -> (a mod 2) = 0) (Some 2)))
+      );
+    "option_filter_Reject", (fun _ -> 
+        Eq (None , Js.Option.filter (fun [@bs] a -> (a mod 3) = 0) (Some 2))
+      );
+    "option_filter_None", (fun _ -> 
+        Eq (None , Js.Option.filter (fun [@bs] a -> (a mod 3) = 0) None)
+      );
+    "option_firstSome_First", (fun _ -> 
+        Eq (true , 
+            Js.Option.isSomeValue simpleEq 3 (Js.Option.firstSome (Some 3) (Some 2)))
+      );
+    "option_firstSome_First", (fun _ -> 
+        Eq (true , 
+            Js.Option.isSomeValue simpleEq 2 (Js.Option.firstSome None (Some 2)))
+      );
+    "option_firstSome_None", (fun _ -> 
+        Eq (None , Js.Option.firstSome None None)
+      );
+    
+  ]
+
+let () = 
+  begin
+    Mt.from_pair_suites __FILE__ option_suites
+  end

--- a/lib/js/js_option.js
+++ b/lib/js/js_option.js
@@ -65,7 +65,7 @@ function map(f, x) {
   }
 }
 
-function orValue(a, x) {
+function $$default(a, x) {
   if (x) {
     return x[0];
   } else {
@@ -104,7 +104,7 @@ exports.getExn      = getExn;
 exports.equal       = equal;
 exports.andThen     = andThen;
 exports.map         = map;
-exports.orValue     = orValue;
+exports.$$default   = $$default;
 exports.filter      = filter;
 exports.firstSome   = firstSome;
 /* No side effect */

--- a/lib/js/js_option.js
+++ b/lib/js/js_option.js
@@ -57,6 +57,45 @@ function andThen(f, x) {
   }
 }
 
+function map(f, x) {
+  if (x) {
+    return /* Some */[f(x[0])];
+  } else {
+    return /* None */0;
+  }
+}
+
+function orValue(a, x) {
+  if (x) {
+    return x[0];
+  } else {
+    return a;
+  }
+}
+
+function filter(f, x) {
+  if (x) {
+    var x$1 = x[0];
+    if (f(x$1)) {
+      return /* Some */[x$1];
+    } else {
+      return /* None */0;
+    }
+  } else {
+    return /* None */0;
+  }
+}
+
+function firstSome(a, b) {
+  if (a) {
+    return a;
+  } else if (b) {
+    return b;
+  } else {
+    return /* None */0;
+  }
+}
+
 exports.some        = some;
 exports.isSome      = isSome;
 exports.isSomeValue = isSomeValue;
@@ -64,4 +103,8 @@ exports.isNone      = isNone;
 exports.getExn      = getExn;
 exports.equal       = equal;
 exports.andThen     = andThen;
+exports.map         = map;
+exports.orValue     = orValue;
+exports.filter      = filter;
+exports.firstSome   = firstSome;
 /* No side effect */


### PR DESCRIPTION
I have added what I consider basic functions that should be in every standard library for options. I also created tests for all functions as we didn't have any for these.

I tried running the doc generating script here, but it changes a lot more files than what I was expecting, so I'm leaving this out for now. Let me know how to proceed in this case.