### PR TITLE
activeOnStart should be false for the vscode watch task

### DIFF
--- a/jscomp/bsb/templates/basic/.vscode/tasks.json
+++ b/jscomp/bsb/templates/basic/.vscode/tasks.json
@@ -15,7 +15,7 @@
         "fileLocation": "absolute",
         "owner": "ocaml",
         "watching": {
-            "activeOnStart": true,
+            "activeOnStart": false,
             "beginsPattern": ">>>> Start compiling",
             "endsPattern": ">>>> Finish compiling"
         },


### PR DESCRIPTION
With this property set to true, the little "build in progress" icon that appears to the left of the "problems" icons in the lower left never stops spinning. What it's supposed to do is only spin while the watch tool is busy (the speed of `bsb` makes it hard to spot, which is a good thing!).

I'm not sure whether vscode is trying to support multiple start/end patterns, but it definitely goes into the wrong state when set to true but the tool still outputs the begin pattern.