### PR TITLE
ReasonReact template

### DIFF
--- a/jscomp/bsb/templates/react/.gitignore
+++ b/jscomp/bsb/templates/react/.gitignore
@@ -1,0 +1,4 @@
+lib
+node_modules
+.merlin
+npm-debug.log

--- a/jscomp/bsb/templates/react/README.md
+++ b/jscomp/bsb/templates/react/README.md
@@ -1,0 +1,13 @@
+This is a repo with examples usages of [ReasonReact](https://github.com/reasonml/reason-react).
+Have something you don't understand? Join us on [Discord](https://discord.gg/reasonml)!
+
+Run this project:
+
+```
+npm install
+npm start
+# in another tab
+npm run build
+```
+
+After you see the webpack compilation succeed (the `npm run build` step), open up the nested html files in `src/*` (**no server needed!**). Then modify whichever file in `src` and refresh the page to see the changes.

--- a/jscomp/bsb/templates/react/bsconfig.json
+++ b/jscomp/bsb/templates/react/bsconfig.json
@@ -1,0 +1,15 @@
+/* This is the BuckleScript configuration file. Note that this is a comment;
+  BuckleScript comes with a JSON parser that supports comments and trailing
+  comma. If this screws with your editor highlighting, please tell us by filing
+  an issue! */
+{
+  "name" : "${bsb:name}",
+  "reason" : {"react-jsx" : 2},
+  "bs-dependencies": ["reason-react"],
+  "sources": [
+    {
+      "dir": "src",
+      "subdirs": ["interop", "simple"],
+    }
+  ],
+}

--- a/jscomp/bsb/templates/react/package.json
+++ b/jscomp/bsb/templates/react/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "${bsb:name}",
+  "private": true,
+  "version": "${bsb:proj-version}",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "bsb -make-world -w",
+    "build": "webpack -w",
+    "clean": "bsb -clean-world"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "react": "^15.4.2",
+    "react-dom": "^15.4.2",
+    "reason-react": ">=0.1.4"
+  },
+  "devDependencies": {
+    "bs-platform": "^${bsb:bs-version}",
+    "webpack": "^1.14.0"
+  }
+}

--- a/jscomp/bsb/templates/react/src/interop/README.md
+++ b/jscomp/bsb/templates/react/src/interop/README.md
@@ -1,0 +1,7 @@
+## Interoperate with Existing ReactJS Components
+
+This subdirectory demonstrate the ReasonReact <-> ReactJS interop APIs.
+
+The entry point, `interopRoot.js`, illustrates ReactJS requiring a ReasonReact component, `PageReason`.
+
+`PageReason` itself illustrates ReasonReact requiring a ReactJS component, `myBanner.js`, through the Reason file `myBannerRe.re`.

--- a/jscomp/bsb/templates/react/src/interop/index.html
+++ b/jscomp/bsb/templates/react/src/interop/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Pure Reason Example</title>
+</head>
+<body>
+  <div id="index"></div>
+  <script src="../../bundledOutputs/interop.js"></script>
+</body>
+</html>

--- a/jscomp/bsb/templates/react/src/interop/interopRoot.js
+++ b/jscomp/bsb/templates/react/src/interop/interopRoot.js
@@ -1,0 +1,17 @@
+var ReactDOM = require('react-dom');
+var React = require('react');
+
+// Import a ReasonReact component! `comp` is the exposed, underlying ReactJS class
+var PageReason = require('../../lib/js/src/interop/pageReason').comp;
+
+var App = React.createClass({
+  render: function() {
+    return React.createElement('div', null,
+      React.createElement(PageReason, {message: 'Hello!'})
+    );
+    // didn't feel like dragging in Babel. Here's the equivalent JSX:
+    // <div><PageReason message="Hello!"></div>
+  }
+});
+
+ReactDOM.render(React.createElement(App), document.getElementById('index'));

--- a/jscomp/bsb/templates/react/src/interop/myBanner.js
+++ b/jscomp/bsb/templates/react/src/interop/myBanner.js
@@ -1,0 +1,16 @@
+var ReactDOM = require('react-dom');
+var React = require('react');
+
+var App = React.createClass({
+  render: function() {
+    if (this.props.show) {
+      return React.createElement('div', null,
+        this.props.message
+      );
+    } else {
+      return null;
+    }
+  }
+});
+
+module.exports = App;

--- a/jscomp/bsb/templates/react/src/interop/myBannerRe.re
+++ b/jscomp/bsb/templates/react/src/interop/myBannerRe.re
@@ -1,0 +1,12 @@
+/* Typing the myBanner.js component's output as a `reactClass`. */
+/* Note that this file's JS output is located at reason-react-example/lib/js/src/interop/myBannerRe.js; we're specifying the relative path to myBanner.js in the string below */
+external myBanner : ReasonReact.reactClass = "../../../../src/interop/myBanner" [@@bs.module];
+
+let make ::show ::message children =>
+  ReasonReact.wrapJsForReason
+    reactClass::myBanner
+    props::{
+      "show": Js.Boolean.to_js_boolean show, /* ^ don't forget to convert an OCaml bool into a JS boolean! */
+      "message": message /* OCaml string maps to JS string, no conversion needed here */
+    }
+    children;

--- a/jscomp/bsb/templates/react/src/interop/pageReason.re
+++ b/jscomp/bsb/templates/react/src/interop/pageReason.re
@@ -1,0 +1,24 @@
+let component = ReasonReact.statelessComponent "PageReason";
+
+let make ::message ::extraGreeting=? _children => {
+  ...component,
+  render: fun () _self => {
+    let greeting =
+      switch extraGreeting {
+      | None => "How are you?"
+      | Some g => g
+      };
+    <div> <MyBannerRe show=true message=(message ^ " " ^ greeting) /> </div>
+  }
+};
+
+let comp =
+  ReasonReact.wrapReasonForJs
+    ::component
+    (
+      fun jsProps =>
+        make
+          message::jsProps##message
+          extraGreeting::?(Js.Null_undefined.to_opt jsProps##extraGreeting)
+          [||]
+    );

--- a/jscomp/bsb/templates/react/src/simple/index.html
+++ b/jscomp/bsb/templates/react/src/simple/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Pure Reason Example</title>
+</head>
+<body>
+  <div id="index"></div>
+  <script src="../../bundledOutputs/simple.js"></script>
+</body>
+</html>

--- a/jscomp/bsb/templates/react/src/simple/page.re
+++ b/jscomp/bsb/templates/react/src/simple/page.re
@@ -1,0 +1,13 @@
+let component = ReasonReact.statefulComponent "Greeting";
+
+let make ::name _children => {
+  let click _event state _self => ReasonReact.Update (state + 1);
+  {
+    ...component,
+    initialState: fun () => 0,
+    render: fun state self => {
+      let greeting = {j|Hello $name, You've clicked the button $state times(s)!|j};
+      <button onClick=(self.update click)> (ReasonReact.stringToElement greeting) </button>
+    }
+  }
+};

--- a/jscomp/bsb/templates/react/src/simple/simpleRoot.re
+++ b/jscomp/bsb/templates/react/src/simple/simpleRoot.re
@@ -1,0 +1,1 @@
+ReactDOMRe.renderToElementWithId <Page name="Lil' Reason" /> "index";

--- a/jscomp/bsb/templates/react/webpack.config.js
+++ b/jscomp/bsb/templates/react/webpack.config.js
@@ -1,0 +1,12 @@
+const path = require('path');
+
+module.exports = {
+  entry: {
+    simple: './lib/js/src/simple/simpleRoot.js',
+    interop: './src/interop/interopRoot.js',
+  },
+  output: {
+    path: path.join(__dirname, "bundledOutputs"),
+    filename: '[name].js',
+  },
+};


### PR DESCRIPTION
This is basically copied over from https://github.com/chenglou/reason-react-example

I didn't regenerate things with ocp-ocamlres.

Note that if you test this as-is, it'll fail because reason-react>=0.1.4 (as specified by package.json) isn't released yet (waiting for the bs release). You'd have to manually change it to `https://github.com/SanderSpies/react-on-reason.git`.

Test: see the readme